### PR TITLE
fix cirq to braket bug

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ sys.path.insert(0, os.path.abspath("../../qbraid"))
 # -- Project information -----------------------------------------------------
 
 project = "qBraid"
-copyright = "2022, qBraid Development Team"
+copyright = "2023, qBraid Development Team"
 author = "qBraid Development Team"
 
 # The full version, including alpha/beta/rc tags

--- a/qbraid/devices/ibm/__init__.py
+++ b/qbraid/devices/ibm/__init__.py
@@ -29,6 +29,7 @@ This module contains the classes used to run quantum circuits on devices availab
 
    ibm_provider
    ibm_least_busy_qpu
+   ibm_to_qbraid_id
    IBMBackendWrapper
    IBMJobWrapper
    IBMResultWrapper
@@ -37,4 +38,4 @@ This module contains the classes used to run quantum circuits on devices availab
 from .result import IBMResultWrapper
 from .device import IBMBackendWrapper
 from .job import IBMJobWrapper
-from .provider import ibm_provider, ibm_least_busy_qpu
+from .provider import ibm_provider, ibm_least_busy_qpu, ibm_to_qbraid_id

--- a/qbraid/devices/ibm/provider.py
+++ b/qbraid/devices/ibm/provider.py
@@ -16,12 +16,20 @@
 Module for top-level interfacing with the IBMQ API
 
 """
+import re
 from typing import Optional
 
 from qiskit_ibm_provider import IBMProvider, least_busy
 from qiskit_ibm_provider.accounts import AccountNotFoundError
 
 from qbraid.api.exceptions import AuthError
+
+
+def ibm_to_qbraid_id(name: str) -> str:
+    """Converts IBM device name to qBraid device ID"""
+    if name.startswith("ibm") or name.startswith("ibmq_"):
+        return re.sub(r"^(ibm)(q)?_(.*)", r"\1_q_\3", name)
+    return "ibm_q_" + name
 
 
 def ibm_provider(token: Optional[str] = None) -> IBMProvider:

--- a/qbraid/devices/ibm/tests/test_ibm_provider.py
+++ b/qbraid/devices/ibm/tests/test_ibm_provider.py
@@ -18,9 +18,24 @@ Unit tests for working with IBM provider
 """
 import os
 
+import pytest
 from qiskit_ibm_provider import IBMProvider
 
-from qbraid.devices.ibm.provider import ibm_least_busy_qpu, ibm_provider
+from qbraid.devices.ibm.provider import ibm_least_busy_qpu, ibm_provider, ibm_to_qbraid_id
+
+backend_id_data = [
+    ("ibm_nairobi", "ibm_q_nairobi"),
+    ("ibmq_belem", "ibm_q_belem"),
+    ("simulator_extended_stabilizer", "ibm_q_simulator_extended_stabilizer"),
+]
+
+
+@pytest.mark.parametrize("data", backend_id_data)
+def test_get_qbraid_id(data):
+    """Test converting backend name to qbraid_id."""
+    original, expected = data
+    result = ibm_to_qbraid_id(original)
+    assert result == expected
 
 
 def test_ibm_provider():

--- a/qbraid/devices/tests/test_devices.py
+++ b/qbraid/devices/tests/test_devices.py
@@ -23,7 +23,7 @@ from braket.aws import AwsDevice
 from braket.circuits import Circuit as BraketCircuit
 from braket.tasks.quantum_task import QuantumTask as AwsQuantumTask
 from qiskit import QuantumCircuit as QiskitCircuit
-from qiskit_ibm_provider import IBMBackend, IBMJob
+from qiskit_ibm_provider import IBMBackend, IBMJob, IBMProvider
 
 from qbraid import QbraidError, device_wrapper, job_wrapper
 from qbraid.api import QbraidSession
@@ -31,7 +31,12 @@ from qbraid.devices import DeviceError
 from qbraid.devices.aws import AwsDeviceWrapper, AwsQuantumTaskWrapper
 from qbraid.devices.enums import is_status_final
 from qbraid.devices.exceptions import JobStateError
-from qbraid.devices.ibm import IBMBackendWrapper, IBMJobWrapper, ibm_least_busy_qpu
+from qbraid.devices.ibm import (
+    IBMBackendWrapper,
+    IBMJobWrapper,
+    ibm_least_busy_qpu,
+    ibm_to_qbraid_id,
+)
 from qbraid.interface import random_circuit
 
 
@@ -46,13 +51,21 @@ def device_wrapper_inputs(vendor: str):
     return input_list
 
 
+def ibm_devices():
+    provider = IBMProvider()
+    backends = provider.backends()
+    qbraid_devices = device_wrapper_inputs("IBM")
+    ibm_devices = [ibm_to_qbraid_id(backend.name) for backend in backends]
+    return [dev for dev in qbraid_devices if dev in ibm_devices]
+
+
 """
 Device wrapper tests: initialization
 Coverage: all vendors, all available devices
 """
 
 inputs_braket_dw = device_wrapper_inputs("AWS")
-inputs_qiskit_dw = device_wrapper_inputs("IBM")
+inputs_qiskit_dw = ibm_devices()
 
 
 def test_job_wrapper_type():

--- a/qbraid/interface/qbraid_cirq/tools.py
+++ b/qbraid/interface/qbraid_cirq/tools.py
@@ -19,7 +19,7 @@ Module containing Cirq tools
 from typing import List, Sequence, Union
 
 import numpy as np
-from cirq import Circuit, GridQubit, I, LineQubit, NamedQubit, Qid
+from cirq import Circuit, GridQubit, I, LineQubit, NamedQubit, Qid, ops
 
 QUBIT = Union[LineQubit, GridQubit, NamedQubit, Qid]
 
@@ -143,3 +143,10 @@ def _convert_to_contiguous_cirq(circuit: Circuit, rev_qubits=False, expansion=Fa
     if expansion:
         return _contiguous_expansion(circuit)
     return _contiguous_compression(circuit, rev_qubits=rev_qubits)
+
+
+def is_measurement_gate(op):
+    """Returns whether Cirq gate/operation is MeasurementGate."""
+    return isinstance(op, ops.MeasurementGate) or isinstance(
+        getattr(op, "gate", None), ops.MeasurementGate
+    )

--- a/qbraid/transpiler/cirq_braket/tests/test_from_braket.py
+++ b/qbraid/transpiler/cirq_braket/tests/test_from_braket.py
@@ -194,7 +194,7 @@ def test_kraus_gates():
     assert np.allclose(Gate._kraus_ops, [K0, K1])
 
 
-def test_GeneralizedAmplitudeDampingChannel_gate():
+def test_generalized_amplitude_damping_channel_gate():
     """Testing converting Kraus noise gates"""
     probs = np.random.uniform(low=0, high=0.5, size=(2))
     instruction = Instruction(
@@ -209,7 +209,7 @@ def test_GeneralizedAmplitudeDampingChannel_gate():
     assert Gate.p == probs[1]
 
 
-def test_DepolarizingChannel_gate():
+def test_depolarizing_channel_gate():
     probs = np.random.uniform(low=0, high=0.5, size=(1))
     instruction = Instruction(
         braket_noise_gate.TwoQubitDepolarizing(probability=probs[0]), target=[0, 1]

--- a/qbraid/transpiler/cirq_braket/tests/test_to_braket.py
+++ b/qbraid/transpiler/cirq_braket/tests/test_to_braket.py
@@ -21,7 +21,7 @@ import pytest
 from braket.circuits import noises as braket_noise_gate
 from cirq import Circuit, LineQubit, ops, testing
 
-from qbraid.interface import circuits_allclose, to_unitary
+from qbraid.interface import circuits_allclose
 from qbraid.transpiler.cirq_braket.convert_to_braket import to_braket
 
 

--- a/qbraid/transpiler/cirq_braket/tests/test_to_braket_measure.py
+++ b/qbraid/transpiler/cirq_braket/tests/test_to_braket_measure.py
@@ -1,0 +1,52 @@
+# Copyright 2023 qBraid
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for converting Cirq circuits with MeasurementGate(s) to Braket circuits
+
+"""
+import cirq
+
+from qbraid.interface import circuits_allclose
+from qbraid.transpiler.cirq_braket.convert_to_braket import to_braket
+
+
+def alpha_pump(sys, env):
+    yield cirq.CNOT(sys[0], env[0])
+    yield cirq.H(sys[1])
+    yield cirq.X(env[1])
+
+
+def beta_pump(sys, env):
+    yield cirq.CNOT(sys[1], sys[0])
+    yield cirq.X(env[0])
+
+
+def batch_circuit():
+    sys_qubits = [cirq.LineQubit(i) for i in range(0, 6)]
+    env_qubits = [cirq.LineQubit(i) for i in range(6, 11)]
+
+    circuit = cirq.Circuit()
+    circuit += alpha_pump(sys_qubits[0:2], env_qubits[0:2])
+    circuit += alpha_pump(sys_qubits[2:4], env_qubits[2:4])
+    circuit += beta_pump(sys_qubits[4:6], env_qubits[4:5])
+    circuit.append(cirq.measure(*circuit.all_qubits()))
+    return circuit
+
+
+def test_ommit_measurement_gate():
+    """Test that cirq.MeasurementGate is skipped during Braket conversion"""
+    cirq_circuit = batch_circuit()
+    braket_circuit = to_braket(cirq_circuit)
+    assert circuits_allclose(cirq_circuit, braket_circuit)


### PR DESCRIPTION
Fix Amazon Braket bug caused when converting Cirq --> Amazon Braket due to cirq MeasurementGate type not being properly handled.

