### PR TITLE
bump requirements

### DIFF
--- a/qbraid/interface/tests/test_programs.py
+++ b/qbraid/interface/tests/test_programs.py
@@ -152,7 +152,7 @@ def test_pyquil_raises():
 
 
 def test_pytket_draw():
-    assert len(circuit_drawer(pytket_bell, output="html")) == 1922
+    assert len(circuit_drawer(pytket_bell, output="html")) == 2381
 
 
 def test_pytket_raises():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-amazon-braket-sdk~=1.39.0
-cirq~=1.1.0
-numpy>=1.17,<1.24
-pyquil~=3.4.1
-pytket<1.13.2
+amazon-braket-sdk~=1.42.0
+cirq~=1.2.0.dev20230524233104
+numpy>=1.17
+pyquil>=3.5.4,<3.6.0
+pytket~=1.15.0
 qiskit<0.43.0
 qiskit-ibm-provider<0.5.3
-requests~=2.30.0
+requests~=2.31.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,14 +24,14 @@ packages = find:
 python_requires = >=3.9
 
 install_requires =
-    amazon-braket-sdk~=1.39.0
-    cirq~=1.1.0
-    numpy>=1.17,<1.24
-    pyquil~=3.4.1
-    pytket<1.13.2
+    amazon-braket-sdk~=1.42.0
+    cirq~=1.2.0.dev20230524233104
+    numpy>=1.17
+    pyquil>=3.5.4,<3.6.0
+    pytket~=1.15.0
     qiskit<0.43.0
     qiskit-ibm-provider<0.5.3
-    requests~=2.30.0
+    requests~=2.31.0
     ipython
 
 [options.extras_require]


### PR DESCRIPTION
Requirements bumps allowing latest pytket thanks to loosening of networkx requirements in pyquil and cirq:

https://github.com/rigetti/pyquil/pull/1584
https://github.com/quantumlib/Cirq/pull/6105


