### PR TITLE
integrate qasm3

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Construct a quantum program of any supported program type,
 ```python
 >>> from qbraid import QPROGRAM_LIBS
 >>> QPROGRAM_LIBS
-['braket', 'cirq', 'qiskit', 'pyquil', 'pytket', 'qasm2']
+['braket', 'cirq', 'qiskit', 'pyquil', 'pytket', 'qasm2', 'qasm3']
 ```
 
 and use the `circuit_wrapper()` to convert to any other supported program type:

--- a/docs/sdk/circuits.rst
+++ b/docs/sdk/circuits.rst
@@ -13,7 +13,7 @@ Program Types
 
 Supported frontend program types include `Qiskit <QiskitQuantumCircuit>`_,
 `Amazon Braket <BraketCircuit>`_, `Cirq <CirqCircuit>`_, `PyQuil <PyQuilProgram>`_,
-`PyTKET <PyTKETCircuit>`_, and `OpenQASM 2 <OpenQASMString>`_:
+`PyTKET <PyTKETCircuit>`_, and `OpenQASM <OpenQASMString>`_:
 
 .. code-block:: python
     
@@ -27,6 +27,7 @@ Supported frontend program types include `Qiskit <QiskitQuantumCircuit>`_,
     pyquil.quil.Program
     pytket._tket.circuit.Circuit
     qasm2
+    qasm3
 
 
 .. _QiskitQuantumCircuit: https://qiskit.org/documentation/stubs/qiskit.circuit.QuantumCircuit.html

--- a/docs/sdk/overview.rst
+++ b/docs/sdk/overview.rst
@@ -63,7 +63,7 @@ Construct a quantum program of any supported program type:
    >>> from qbraid import QPROGRAM_LIBS
    >>> from qbraid.interface import random_circuit
    >>> QPROGRAM_LIBS
-   ['braket', 'cirq', 'qiskit', 'pyquil', 'pytket', 'qasm2']
+   ['braket', 'cirq', 'qiskit', 'pyquil', 'pytket', 'qasm2', 'qasm3']
    >>> circuit = random_circuit("qiskit", num_qubits=1, measure=True)
 
 Search for quantum backend(s) on which to execute your program:

--- a/qbraid/_qprogram.py
+++ b/qbraid/_qprogram.py
@@ -50,4 +50,4 @@ _PROGRAM_TYPES = [str(x).strip("<class").strip(">").strip(" ").strip("'") for x 
 QPROGRAM_TYPES = _PROGRAMS + [QASMType]
 
 _PROGRAM_LIBS = [x.split(".")[0] for x in _PROGRAM_TYPES]
-QPROGRAM_LIBS = _PROGRAM_LIBS + ["qasm2"]
+QPROGRAM_LIBS = _PROGRAM_LIBS + ["qasm2", "qasm3"]

--- a/qbraid/interface/__init__.py
+++ b/qbraid/interface/__init__.py
@@ -25,6 +25,7 @@ Interface (:mod:`qbraid.interface`)
    circuits_allclose
    random_circuit
    circuit_drawer
+   is_valid_qasm
    ContiguousConversionError
    UnitaryCalculationError
 
@@ -39,3 +40,4 @@ from .calculate_unitary import (
 from .convert_to_contiguous import ContiguousConversionError, convert_to_contiguous
 from .draw import circuit_drawer
 from .programs import random_circuit
+from .qbraid_qiskit.tools import is_valid_qasm

--- a/qbraid/interface/calculate_unitary.py
+++ b/qbraid/interface/calculate_unitary.py
@@ -45,7 +45,12 @@ def to_unitary(program: "qbraid.QPROGRAM", ensure_contiguous: Optional[bool] = F
     to_unitary_function: Callable[[Any], np.ndarray]
 
     if isinstance(program, str):
-        package = "qasm2"
+        if "OPENQASM 2.0" in program:
+            package = "qasm2"
+        elif "OPENQASM 3.0" in program:
+            package = "qasm3"
+        else:
+            raise ProgramTypeError("Input of type string must represent a valid OpenQASM program.")
     else:
         try:
             package = program.__module__
@@ -75,10 +80,14 @@ def to_unitary(program: "qbraid.QPROGRAM", ensure_contiguous: Optional[bool] = F
         from qbraid.interface.qbraid_pytket.tools import _unitary_from_pytket
 
         to_unitary_function = _unitary_from_pytket
-    elif "qasm2" in package:
+    elif package == "qasm2":
         from qbraid.interface.qbraid_qasm.tools import _unitary_from_qasm
 
         to_unitary_function = _unitary_from_qasm
+    elif package == "qasm3":
+        from qbraid.interface.qbraid_qiskit.tools import _unitary_from_qasm3
+
+        to_unitary_function = _unitary_from_qasm3
     else:
         raise ProgramTypeError(program)
 

--- a/qbraid/interface/convert_to_contiguous.py
+++ b/qbraid/interface/convert_to_contiguous.py
@@ -45,7 +45,12 @@ def convert_to_contiguous(program: "qbraid.QPROGRAM", **kwargs) -> "qbraid.QPROG
     conversion_function: Callable[[Any], QPROGRAM]
 
     if isinstance(program, str):
-        package = "qasm2"
+        if "OPENQASM 2.0" in program:
+            package = "qasm2"
+        elif "OPENQASM 3.0" in program:
+            package = "qasm3"
+        else:
+            raise ProgramTypeError("Input of type string must represent a valid OpenQASM program.")
     else:
         try:
             package = program.__module__
@@ -73,10 +78,14 @@ def convert_to_contiguous(program: "qbraid.QPROGRAM", **kwargs) -> "qbraid.QPROG
         from qbraid.interface.qbraid_pytket.tools import _convert_to_contiguous_pytket
 
         conversion_function = _convert_to_contiguous_pytket
-    elif "qasm2" in package:
+    elif package == "qasm2":
         from qbraid.interface.qbraid_qasm.tools import _convert_to_contiguous_qasm
 
         conversion_function = _convert_to_contiguous_qasm
+    elif package == "qasm3":
+        from qbraid.interface.qbraid_qiskit.tools import _convert_to_contiguous_qasm3
+
+        conversion_function = _convert_to_contiguous_qasm3
     else:
         raise ProgramTypeError(program)
 

--- a/qbraid/interface/qbraid_qiskit/tools.py
+++ b/qbraid/interface/qbraid_qiskit/tools.py
@@ -15,9 +15,14 @@ Module containing Qiskit tools
 from collections import OrderedDict
 
 import numpy as np
+from openqasm3.parser import QASM3ParsingError, parse
 from qiskit import QuantumCircuit
 from qiskit.converters import circuit_to_dag, dag_to_circuit
+from qiskit.qasm import QasmError
+from qiskit.qasm3 import dumps, loads
 from qiskit.quantum_info import Operator
+
+QASMType = str
 
 
 def _unitary_from_qiskit(circuit: QuantumCircuit) -> np.ndarray:
@@ -25,8 +30,14 @@ def _unitary_from_qiskit(circuit: QuantumCircuit) -> np.ndarray:
     return Operator(circuit).data
 
 
+def _unitary_from_qasm3(qasmstr: QASMType) -> np.ndarray:
+    """Return the unitary of the QASM 3 string"""
+    circuit = loads(qasmstr)
+    return _unitary_from_qiskit(circuit)
+
+
 def _convert_to_contiguous_qiskit(circuit: QuantumCircuit) -> QuantumCircuit:
-    """delete qubit with no gate"""
+    """Delete qubit(s) with no gate, if any exist."""
     dag = circuit_to_dag(circuit)
 
     idle_wires = list(dag.idle_wires())
@@ -37,3 +48,28 @@ def _convert_to_contiguous_qiskit(circuit: QuantumCircuit) -> QuantumCircuit:
     dag.qregs = OrderedDict()
 
     return dag_to_circuit(dag)
+
+
+def _convert_to_contiguous_qasm3(qasmstr: QASMType) -> QASMType:
+    """Delete qubit(s) with no gate, if any exist."""
+    circuit = loads(qasmstr)
+    circuit_contig = _convert_to_contiguous_qiskit(circuit)
+    return dumps(circuit_contig)
+
+
+def is_valid_qasm(qasm_str: str) -> bool:
+    """Returns whether the input string represents a
+    valid OpenQASM program.
+
+    TODO: Verify that all exceptions that are caught"""
+    parsers = {"OPENQASM 2.0": QuantumCircuit.from_qasm_str, "OPENQASM 3.0": parse}
+
+    for version, parser in parsers.items():
+        if version in qasm_str:
+            try:
+                parser(qasm_str)
+                return True
+            except (QasmError, QASM3ParsingError):
+                return False
+
+    return False

--- a/qbraid/transpiler/cirq_qiskit/conversions.py
+++ b/qbraid/transpiler/cirq_qiskit/conversions.py
@@ -39,7 +39,7 @@ def to_qiskit(circuit: cirq.Circuit) -> qiskit.QuantumCircuit:
         compat_circuit = _map_zpow_and_unroll(contig_circuit)
         return qiskit.QuantumCircuit.from_qasm_str(to_qasm(compat_circuit))
     except ValueError as err:
-        raise CircuitConversionError("Cirq qasm converter doesn't yet support qasm3.") from err
+        raise CircuitConversionError from err
 
 
 def from_qiskit(circuit: qiskit.QuantumCircuit) -> cirq.Circuit:
@@ -56,4 +56,4 @@ def from_qiskit(circuit: qiskit.QuantumCircuit) -> cirq.Circuit:
         cirq_circuit = from_qasm(qasm_str)
         return _convert_to_line_qubits(cirq_circuit, rev_qubits=True)
     except Exception as err:
-        raise CircuitConversionError("Cirq qasm converter doesn't yet support qasm3.") from err
+        raise CircuitConversionError from err

--- a/qbraid/transpiler/tests/test_transpiler.py
+++ b/qbraid/transpiler/tests/test_transpiler.py
@@ -98,6 +98,12 @@ def test_to_cirq_bad_types(item):
 
 @pytest.mark.parametrize("item", ["DECLARE ro BIT[1]", "circuit"])
 def test_to_cirq_bad_string(item):
+    with pytest.raises(ProgramTypeError):
+        convert_to_cirq(item)
+
+
+@pytest.mark.parametrize("item", ["OPENQASM 2.0; bad operation", "OPENQASM 3.0; bad operation"])
+def test_to_cirq_bad_openqasm_program(item):
     with pytest.raises(CircuitConversionError):
         convert_to_cirq(item)
 
@@ -106,6 +112,8 @@ def test_to_cirq_bad_string(item):
 def test_from_cirq(to_type):
     converted_circuit = convert_from_cirq(cirq_circuit, to_type)
     circuit, input_type = convert_to_cirq(converted_circuit)
+    if to_type == "qasm3":
+        circuit = convert_to_contiguous(circuit, rev_qubits=True)
     assert _equal(circuit, cirq_circuit)
     assert input_type == to_type
 


### PR DESCRIPTION
## Changes:

add qasm3 support integrations into all cross-framework functions

e.g. convert to contiguous, calculate unitary, conversions, etc.

