### PR TITLE
improve formatting of unit tests + housekeeping

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,24 +1,58 @@
 cff-version: 1.2.0
-title: 'qBraid-SDK: An Open-source Toolkit for Quantum Computing'
+title: >-
+  qBraid-SDK: Python toolkit for cross-framework abstraction
+  of quantum programs.
 message: >-
   If you use this software, please cite it using the
   metadata from this file.
 type: software
 authors:
-  - given-names: Ryan
+  - given-names: Ryan James
     family-names: Hill
-    email: ryanhill@qbraid.com
+    affiliation: qBraid Co.
+  - given-names: Ricky
+    family-names: Young
+    affiliation: qBraid Co.
+  - given-names: Erik
+    family-names: Weis
+  - given-names: Tan
+    family-names: Jun Liang
+  - given-names: Graeme
+    family-names: Jacobson
+  - given-names: Harshit
+    family-names: Gupta
+  - given-names: Mohamed Messaoud
+    family-names: Louamri
+  - given-names: Caleb
+    family-names: McIrvin
+  - given-names: Swaraj
+    family-names: Purohit
+  - given-names: Jason
+    family-names: Necaise
+  - given-names: Enrique Anguiano
+    family-names: Vara
+  - given-names: Pronil
+    family-names: Chakraborty
+  - given-names: Jiaju
+    family-names: Liu
+  - given-names: Andrea Wei
+    family-names: Coladangelo
+    affiliation: University of Washington
+  - given-names: Pranav
+    family-names: Kakhandiki
+    affiliation: Cornell University
+  - given-names: Kanav
+    family-names: Setia
     affiliation: qBraid Co.
 repository-code: 'https://github.com/qBraid/qBraid'
 url: 'https://www.qbraid.com'
-abstract: >-
-  A Python toolkit for cross-framework abstraction,
-  transpilation, and execution of quantum programs.
+repository-artifact: 'https://github.com/qBraid/qBraid/releases/tag/v0.4.5'
 keywords:
   - python
   - quantum-computing
   - transpiler
   - openqasm
 license: GPL-3.0
-version: 0.4.3
-date-released: '2023-08-07'
+commit: 8bc6dfae1f7b0bc73365436f1c8c2c50172fb1d4
+version: 0.4.5
+date-released: '2023-08-27'

--- a/qbraid/compiler/braket/ionq.py
+++ b/qbraid/compiler/braket/ionq.py
@@ -29,6 +29,7 @@ from pytket.predicates import (
     NoSymbolsPredicate,
 )
 
+from qbraid.compiler.exceptions import CompilerError
 from qbraid.wrappers import circuit_wrapper
 
 HARMONY_MAX_QUBITS = 11
@@ -115,6 +116,7 @@ def braket_ionq_compile(circuit: Union[Circuit, pytket.circuit.Circuit]) -> Circ
 
     cu = CompilationUnit(tk_circuit, preds)
     ionq_rebase_pass.apply(cu)
-    assert cu.check_all_predicates()
+    if not cu.check_all_predicates():
+        raise CompilerError("Circuit cannot be compiled to IonQ Harmony.")
     compiled, _, _ = pytket.extensions.braket.braket_convert.tk_to_braket(cu.circuit)
     return compiled

--- a/qbraid/compiler/exceptions.py
+++ b/qbraid/compiler/exceptions.py
@@ -9,16 +9,12 @@
 # THERE IS NO WARRANTY for the qBraid-SDK, as per Section 15 of the GPL v3.
 
 """
-==============================================
-Compiler  (:mod:`qbraid.compiler`)
-==============================================
-
-.. currentmodule:: qbraid.compiler
-
-.. autosummary::
-   :toctree: ../stubs/
-
-   CompilerError
+Module defining exceptions for errors raised by the qBraid compiler.
 
 """
-from .exceptions import CompilerError
+
+from qbraid.exceptions import QbraidError
+
+
+class CompilerError(QbraidError):
+    """Base class for errors raised by the qBraid compiler."""

--- a/qbraid/transpiler/cirq_pyquil/quil_output.py
+++ b/qbraid/transpiler/cirq_pyquil/quil_output.py
@@ -2,12 +2,12 @@
 # Copyright (C) 2022 The Cirq Developers
 #
 # This file is part of the qBraid-SDK.
-# 
+#
 # The qBraid-SDK is free software released under the GNU General Public License v3
 # or later. This specific file, adapted from Cirq, is dual-licensed under both the
 # Apache License, Version 2.0, and the GPL v3. You may not use this file except in
 # compliance with the applicable license. You may obtain a copy of the Apache License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
 #
 # This file includes code adapted from Cirq (https://github.com/quantumlib/Cirq)

--- a/qbraid/transpiler/cirq_pyquil/quil_output.py
+++ b/qbraid/transpiler/cirq_pyquil/quil_output.py
@@ -1,0 +1,560 @@
+# Copyright (C) 2023 qBraid
+# Copyright (C) 2022 The Cirq Developers
+#
+# This file is part of the qBraid-SDK.
+# 
+# The qBraid-SDK is free software released under the GNU General Public License v3
+# or later. This specific file, adapted from Cirq, is dual-licensed under both the
+# Apache License, Version 2.0, and the GPL v3. You may not use this file except in
+# compliance with the applicable license. You may obtain a copy of the Apache License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file includes code adapted from Cirq (https://github.com/quantumlib/Cirq)
+# with modifications by qBraid. The original copyright notice is included above.
+# THERE IS NO WARRANTY for the qBraid-SDK, as per Section 15 of the GPL v3.
+
+# isort: skip_file
+# pylint: skip-file
+# flake8: noqa
+# fmt: off
+
+"""
+Module defining qBraid Cirq QuilOutput.
+
+"""
+
+import string
+from typing import Callable, Dict, Set, Tuple, Union, Any, Optional, List, cast
+import numpy as np
+import cirq
+import cirq_rigetti
+from cirq import protocols, value, ops
+
+
+def to_quil_complex_format(num) -> str:
+    """A function for outputting a number to a complex string in QUIL format."""
+    cnum = complex(str(num))
+    return f"{cnum.real}+{cnum.imag}i"
+
+
+class QuilFormatter(string.Formatter):
+    """A unique formatter to correctly output values to QUIL."""
+
+    def __init__(
+        self, qubit_id_map: Dict['cirq.Qid', str], measurement_id_map: Dict[str, str]
+    ) -> None:
+        """Inits QuilFormatter.
+
+        Args:
+            qubit_id_map: A dictionary {qubit, quil_output_string} for
+            the proper QUIL output for each qubit.
+            measurement_id_map: A dictionary {measurement_key,
+            quil_output_string} for the proper QUIL output for each
+            measurement key.
+        """
+        self.qubit_id_map = {} if qubit_id_map is None else qubit_id_map
+        self.measurement_id_map = {} if measurement_id_map is None else measurement_id_map
+
+    def format_field(self, value: Any, spec: str) -> str:
+        if isinstance(value, cirq.ops.Qid):
+            value = self.qubit_id_map[value]
+        if isinstance(value, str) and spec == 'meas':
+            value = self.measurement_id_map[value]
+            spec = ''
+        return super().format_field(value, spec)
+
+
+@value.value_equality(approximate=True)
+class QuilOneQubitGate(ops.Gate):
+    """A QUIL gate representing any single qubit unitary with a DEFGATE and
+    2x2 matrix in QUIL.
+    """
+
+    def __init__(self, matrix: np.ndarray) -> None:
+        """Inits QuilOneQubitGate.
+
+        Args:
+            matrix: The 2x2 unitary matrix for this gate.
+        """
+        self.matrix = matrix
+
+    def _num_qubits_(self) -> int:
+        return 1
+
+    def __repr__(self) -> str:
+        return f'cirq.circuits.quil_output.QuilOneQubitGate(matrix=\n{self.matrix}\n)'
+
+    def _value_equality_values_(self):
+        return self.matrix
+
+
+@value.value_equality(approximate=True)
+class QuilTwoQubitGate(ops.Gate):
+    """A two qubit gate represented in QUIL with a DEFGATE and it's 4x4
+    unitary matrix.
+    """
+
+    def __init__(self, matrix: np.ndarray) -> None:
+        """Inits QuilTwoQubitGate.
+
+        Args:
+            matrix: The 4x4 unitary matrix for this gate.
+        """
+        self.matrix = matrix
+
+    def _num_qubits_(self) -> int:
+        return 2
+
+    def _value_equality_values_(self):
+        return self.matrix
+
+    def __repr__(self) -> str:
+        return f'cirq.circuits.quil_output.QuilTwoQubitGate(matrix=\n{self.matrix}\n)'
+
+
+def _ccnotpow_gate(op: cirq.Operation, formatter: QuilFormatter) -> Optional[str]:
+    gate = cast(cirq.CCNotPowGate, op.gate)
+    if gate._exponent != 1:
+        return None
+    return formatter.format('CCNOT {0} {1} {2}\n', op.qubits[0], op.qubits[1], op.qubits[2])
+
+
+def _cczpow_gate(op: cirq.Operation, formatter: QuilFormatter) -> Optional[str]:
+    gate = cast(cirq.CCZPowGate, op.gate)
+    if gate._exponent != 1:
+        return None
+    lines = [
+        formatter.format('H {0}\n', op.qubits[2]),
+        formatter.format('CCNOT {0} {1} {2}\n', op.qubits[0], op.qubits[1], op.qubits[2]),
+        formatter.format('H {0}\n', op.qubits[2]),
+    ]
+    return ''.join(lines)
+
+
+def _cnotpow_gate(op: cirq.Operation, formatter: QuilFormatter) -> Optional[str]:
+    gate = cast(cirq.CNotPowGate, op.gate)
+    if gate._exponent == 1:
+        return formatter.format('CNOT {0} {1}\n', op.qubits[0], op.qubits[1])
+    return None
+
+
+def _cswap_gate(op: cirq.Operation, formatter: QuilFormatter) -> str:
+    return formatter.format('CSWAP {0} {1} {2}\n', op.qubits[0], op.qubits[1], op.qubits[2])
+
+
+def _czpow_gate(op: cirq.Operation, formatter: QuilFormatter) -> str:
+    gate = cast(cirq.CZPowGate, op.gate)
+    if gate._exponent == 1:
+        return formatter.format('CZ {0} {1}\n', op.qubits[0], op.qubits[1])
+    return formatter.format(
+        'CPHASE({0}) {1} {2}\n', gate._exponent * np.pi, op.qubits[0], op.qubits[1]
+    )
+
+
+def _hpow_gate(op: cirq.Operation, formatter: QuilFormatter) -> str:
+    gate = cast(cirq.HPowGate, op.gate)
+    if gate._exponent == 1:
+        return formatter.format('H {0}\n', op.qubits[0])
+    return formatter.format(
+        'RY({0}) {3}\nRX({1}) {3}\nRY({2}) {3}\n',
+        0.25 * np.pi,
+        gate._exponent * np.pi,
+        -0.25 * np.pi,
+        op.qubits[0],
+    )
+
+
+def _identity_gate(op: cirq.Operation, formatter: QuilFormatter) -> str:
+    return ''.join(formatter.format('I {0}\n', qubit) for qubit in op.qubits)
+
+
+def _iswappow_gate(op: cirq.Operation, formatter: QuilFormatter) -> str:
+    gate = cast(cirq.ISwapPowGate, op.gate)
+    if gate._exponent == 1:
+        return formatter.format('ISWAP {0} {1}\n', op.qubits[0], op.qubits[1])
+    return formatter.format('XY({0}) {1} {2}\n', gate._exponent * np.pi, op.qubits[0], op.qubits[1])
+
+
+def _measurement_gate(op: cirq.Operation, formatter: QuilFormatter) -> str:
+    gate = cast(cirq.MeasurementGate, op.gate)
+    invert_mask = gate.invert_mask
+    if len(invert_mask) < len(op.qubits):
+        invert_mask = invert_mask + (False,) * (len(op.qubits) - len(invert_mask))
+    lines = []
+    for i, (qubit, inv) in enumerate(zip(op.qubits, invert_mask)):
+        if inv:
+            lines.append(formatter.format('X {0} # Inverting for following measurement\n', qubit))
+        lines.append(formatter.format('MEASURE {0} {1:meas}[{2}]\n', qubit, gate.key, i))
+    return ''.join(lines)
+
+
+def _quilonequbit_gate(op: cirq.Operation, formatter: QuilFormatter) -> str:
+    gate = cast(QuilOneQubitGate, op.gate)
+    return (
+        f'DEFGATE USERGATE:\n    '
+        f'{to_quil_complex_format(gate.matrix[0, 0])}, '
+        f'{to_quil_complex_format(gate.matrix[0, 1])}\n    '
+        f'{to_quil_complex_format(gate.matrix[1, 0])}, '
+        f'{to_quil_complex_format(gate.matrix[1, 1])}\n'
+        f'{formatter.format("USERGATE {0}", op.qubits[0])}\n'
+    )
+
+
+def _quiltwoqubit_gate(op: cirq.Operation, formatter: QuilFormatter) -> str:
+    gate = cast(QuilOneQubitGate, op.gate)
+    return (
+        f'DEFGATE USERGATE:\n    '
+        f'{to_quil_complex_format(gate.matrix[0, 0])}, '
+        f'{to_quil_complex_format(gate.matrix[0, 1])}, '
+        f'{to_quil_complex_format(gate.matrix[0, 2])}, '
+        f'{to_quil_complex_format(gate.matrix[0, 3])}\n    '
+        f'{to_quil_complex_format(gate.matrix[1, 0])}, '
+        f'{to_quil_complex_format(gate.matrix[1, 1])}, '
+        f'{to_quil_complex_format(gate.matrix[1, 2])}, '
+        f'{to_quil_complex_format(gate.matrix[1, 3])}\n    '
+        f'{to_quil_complex_format(gate.matrix[2, 0])}, '
+        f'{to_quil_complex_format(gate.matrix[2, 1])}, '
+        f'{to_quil_complex_format(gate.matrix[2, 2])}, '
+        f'{to_quil_complex_format(gate.matrix[2, 3])}\n    '
+        f'{to_quil_complex_format(gate.matrix[3, 0])}, '
+        f'{to_quil_complex_format(gate.matrix[3, 1])}, '
+        f'{to_quil_complex_format(gate.matrix[3, 2])}, '
+        f'{to_quil_complex_format(gate.matrix[3, 3])}\n'
+        f'{formatter.format("USERGATE {0} {1}", op.qubits[0], op.qubits[1])}\n'
+    )
+
+
+def _swappow_gate(op: cirq.Operation, formatter: QuilFormatter) -> str:
+    gate = cast(cirq.SwapPowGate, op.gate)
+    if gate._exponent % 2 == 1:
+        return formatter.format('SWAP {0} {1}\n', op.qubits[0], op.qubits[1])
+    return formatter.format(
+        'PSWAP({0}) {1} {2}\n', gate._exponent * np.pi, op.qubits[0], op.qubits[1]
+    )
+
+
+def _twoqubitdiagonal_gate(op: cirq.Operation, formatter: QuilFormatter) -> Optional[str]:
+    gate = cast(cirq.TwoQubitDiagonalGate, op.gate)
+    diag_angles_radians = np.asarray(gate._diag_angles_radians)
+    if np.count_nonzero(diag_angles_radians) == 1:
+        if diag_angles_radians[0] != 0:
+            return formatter.format(
+                'CPHASE00({0}) {1} {2}\n', diag_angles_radians[0], op.qubits[0], op.qubits[1]
+            )
+        elif diag_angles_radians[1] != 0:
+            return formatter.format(
+                'CPHASE01({0}) {1} {2}\n', diag_angles_radians[1], op.qubits[0], op.qubits[1]
+            )
+        elif diag_angles_radians[2] != 0:
+            return formatter.format(
+                'CPHASE10({0}) {1} {2}\n', diag_angles_radians[2], op.qubits[0], op.qubits[1]
+            )
+        elif diag_angles_radians[3] != 0:
+            return formatter.format(
+                'CPHASE({0}) {1} {2}\n', diag_angles_radians[3], op.qubits[0], op.qubits[1]
+            )
+    return None
+
+
+def _wait_gate(op: cirq.Operation, formatter: QuilFormatter) -> str:
+    return 'WAIT\n'
+
+
+def _xpow_gate(op: cirq.Operation, formatter: QuilFormatter) -> str:
+    gate = cast(cirq.XPowGate, op.gate)
+    if gate._exponent == 1 and gate._global_shift != -0.5:
+        return formatter.format('X {0}\n', op.qubits[0])
+    return formatter.format('RX({0}) {1}\n', gate._exponent * np.pi, op.qubits[0])
+
+
+def _xxpow_gate(op: cirq.Operation, formatter: QuilFormatter) -> str:
+    gate = cast(cirq.XPowGate, op.gate)
+    if gate._exponent == 1:
+        return formatter.format('X {0}\nX {1}\n', op.qubits[0], op.qubits[1])
+    return formatter.format(
+        'RX({0}) {1}\nRX({2}) {3}\n',
+        gate._exponent * np.pi,
+        op.qubits[0],
+        gate._exponent * np.pi,
+        op.qubits[1],
+    )
+
+
+def _ypow_gate(op: cirq.Operation, formatter: QuilFormatter) -> str:
+    gate = cast(cirq.YPowGate, op.gate)
+    if gate._exponent == 1 and gate.global_shift != -0.5:
+        return formatter.format('Y {0}\n', op.qubits[0])
+    return formatter.format('RY({0}) {1}\n', gate._exponent * np.pi, op.qubits[0])
+
+
+def _yypow_gate(op: cirq.Operation, formatter: QuilFormatter) -> str:
+    gate = cast(cirq.YYPowGate, op.gate)
+    if gate._exponent == 1:
+        return formatter.format('Y {0}\nY {1}\n', op.qubits[0], op.qubits[1])
+
+    return formatter.format(
+        'RY({0}) {1}\nRY({2}) {3}\n',
+        gate._exponent * np.pi,
+        op.qubits[0],
+        gate._exponent * np.pi,
+        op.qubits[1],
+    )
+
+
+def _zpow_gate(op: cirq.Operation, formatter: QuilFormatter) -> str:
+    gate = cast(cirq.ZPowGate, op.gate)
+    if gate._exponent == 1 and gate.global_shift != -0.5:
+        return formatter.format('Z {0}\n', op.qubits[0])
+    return formatter.format('RZ({0}) {1}\n', gate._exponent * np.pi, op.qubits[0])
+
+
+def _zzpow_gate(op: cirq.Operation, formatter: QuilFormatter) -> str:
+    gate = cast(cirq.ZZPowGate, op.gate)
+    if gate._exponent == 1:
+        return formatter.format('Z {0}\nZ {1}\n', op.qubits[0], op.qubits[1])
+
+    return formatter.format(
+        'RZ({0}) {1}\nRZ({2}) {3}\n',
+        gate._exponent * np.pi,
+        op.qubits[0],
+        gate._exponent * np.pi,
+        op.qubits[1],
+    )
+
+
+SUPPORTED_GATES = {
+    ops.CCNotPowGate: _ccnotpow_gate,
+    ops.CCZPowGate: _cczpow_gate,
+    ops.CNotPowGate: _cnotpow_gate,
+    ops.CSwapGate: _cswap_gate,
+    ops.CZPowGate: _czpow_gate,
+    ops.HPowGate: _hpow_gate,
+    ops.IdentityGate: _identity_gate,
+    ops.ISwapPowGate: _iswappow_gate,
+    ops.MeasurementGate: _measurement_gate,
+    QuilOneQubitGate: _quilonequbit_gate,
+    QuilTwoQubitGate: _quiltwoqubit_gate,
+    ops.SwapPowGate: _swappow_gate,
+    ops.TwoQubitDiagonalGate: _twoqubitdiagonal_gate,
+    ops.WaitGate: _wait_gate,
+    ops.XPowGate: _xpow_gate,
+    ops.XXPowGate: _xxpow_gate,
+    ops.YPowGate: _ypow_gate,
+    ops.YYPowGate: _yypow_gate,
+    ops.ZPowGate: _zpow_gate,
+    ops.ZZPowGate: _zzpow_gate,
+}
+
+
+class QuilOutput:
+    """An object for passing operations and qubits then outputting them to
+    QUIL format. The string representation returns the QUIL output for the
+    circuit.
+    """
+
+    def __init__(self, operations: 'cirq.OP_TREE', qubits: Tuple['cirq.Qid', ...]) -> None:
+        """Inits QuilOutput.
+
+        Args:
+            operations: A list or tuple of `cirq.OP_TREE` arguments.
+            qubits: The qubits used in the operations.
+        """
+        self.qubits = qubits
+        self.operations = tuple(cirq.ops.flatten_to_ops(operations))
+        self.measurements = tuple(
+            op for op in self.operations if isinstance(op.gate, ops.MeasurementGate)
+        )
+        self.qubit_id_map = self._generate_qubit_ids()
+        self.measurement_id_map = self._generate_measurement_ids()
+        self.formatter = cirq_rigetti.quil_output.QuilFormatter(
+            qubit_id_map=self.qubit_id_map, measurement_id_map=self.measurement_id_map
+        )
+
+    def _generate_qubit_ids(self) -> Dict['cirq.Qid', str]:
+        return {qubit: str(i) for i, qubit in enumerate(self.qubits)}
+
+    def _generate_measurement_ids(self) -> Dict[str, str]:
+        index = 0
+        measurement_id_map: Dict[str, str] = {}
+        for op in self.operations:
+            if isinstance(op.gate, ops.MeasurementGate):
+                key = protocols.measurement_key_name(op)
+                if key in measurement_id_map:
+                    continue
+                measurement_id_map[key] = f'm{index}'
+                index += 1
+        return measurement_id_map
+
+    def save_to_file(self, path: Union[str, bytes, int]) -> None:
+        """Write QUIL output to a file specified by path."""
+        with open(path, 'w') as f:
+            f.write(str(self))
+
+    def __str__(self) -> str:
+        output = []
+        self._write_quil(lambda s: output.append(s))
+        return self.rename_defgates(''.join(output))
+
+    def _op_to_maybe_quil(self, op: cirq.Operation) -> Optional[str]:
+        for gate_type in SUPPORTED_GATES.keys():
+            if isinstance(op.gate, gate_type):
+                quil: Callable[[cirq.Operation, QuilFormatter], Optional[str]] = SUPPORTED_GATES[
+                    gate_type
+                ]
+                return quil(op, self.formatter)
+        return None
+
+    def _op_to_quil(self, op: cirq.Operation) -> str:
+        quil_str = self._op_to_maybe_quil(op)
+        if not quil_str:
+            raise ValueError("Can't convert Operation to string")
+        return quil_str
+
+    def _write_quil(self, output_func: Callable[[str], None]) -> None:
+        output_func('# Created using qBraid.\n\n')
+        if len(self.measurements) > 0:
+            measurements_declared: Set[str] = set()
+            for m in self.measurements:
+                key = protocols.measurement_key_name(m)
+                if key in measurements_declared:
+                    continue
+                measurements_declared.add(key)
+                output_func(f'DECLARE {self.measurement_id_map[key]} BIT[{len(m.qubits)}]\n')
+            output_func('\n')
+
+        def keep(op: 'cirq.Operation') -> bool:
+            if isinstance(op.gate, tuple(SUPPORTED_GATES.keys())):
+                if not self._op_to_maybe_quil(op):
+                    return False
+                return True
+            return False
+
+        def fallback(op):
+            if len(op.qubits) not in [1, 2]:
+                return NotImplemented
+
+            mat = protocols.unitary(op, None)
+            if mat is None:
+                return NotImplemented
+
+            # Following code is a safety measure
+            # Could not find a gate that doesn't decompose into a gate
+            # with a _quil_ implementation
+            if len(op.qubits) == 1:  # pragma: no cover
+                return QuilOneQubitGate(mat).on(*op.qubits)
+            return QuilTwoQubitGate(mat).on(*op.qubits)  # pragma: no cover
+
+        def on_stuck(bad_op):
+            return ValueError(f'Cannot output operation as QUIL: {bad_op!r}')
+
+        for main_op in self.operations:
+            decomposed = protocols.decompose(
+                main_op, keep=keep, fallback_decomposer=fallback, on_stuck_raise=on_stuck
+            )
+
+            for decomposed_op in decomposed:
+                output_func(self._op_to_quil(decomposed_op))
+
+    def rename_defgates(self, output: str) -> str:
+        """A function for renaming the DEFGATEs within the QUIL output. This
+        utilizes a second pass to find each DEFGATE and rename it based on
+        a counter.
+        """
+        result = output
+        defString = "DEFGATE"
+        nameString = "USERGATE"
+        defIdx = 0
+        nameIdx = 0
+        gateNum = 0
+        i = 0
+        while i < len(output):
+            if result[i] == defString[defIdx]:
+                defIdx += 1
+            else:
+                defIdx = 0
+            if result[i] == nameString[nameIdx]:
+                nameIdx += 1
+            else:
+                nameIdx = 0
+            if defIdx == len(defString):
+                gateNum += 1
+                defIdx = 0
+            if nameIdx == len(nameString):
+                result = result[: i + 1] + str(gateNum) + result[i + 1 :]
+                nameIdx = 0
+                i += 1
+            i += 1
+        return result
+
+
+class RigettiQCSQuilOutput(QuilOutput):
+    """A sub-class of `cirq.circuits.quil_output.QuilOutput` that additionally accepts a
+    `qubit_id_map` for explicitly mapping logical qubits to physical qubits.
+
+    Attributes:
+        qubit_id_map: A dictionary mapping `cirq.Qid` to strings that
+            address physical qubits in the outputted QUIL.
+        measurement_id_map: A dictionary mapping a Cirq measurement key to
+            the corresponding QUIL memory region.
+        formatter: A QUIL formatter that formats QUIL strings account for both
+            the `qubit_id_map` and `measurement_id_map`.
+    """
+
+    def __init__(
+        self,
+        *,
+        operations: cirq.OP_TREE,
+        qubits: Tuple[cirq.Qid, ...],
+        decompose_operation: Optional[Callable[[cirq.Operation], List[cirq.Operation]]] = None,
+        qubit_id_map: Optional[Dict[cirq.Qid, str]] = None,
+    ):
+        """Initializes an instance of `RigettiQCSQuilOutput`.
+
+        Args:
+            operations: A list or tuple of `cirq.OP_TREE` arguments.
+            qubits: The qubits used in the operations.
+            decompose_operation: Optional; A callable that decomposes a circuit operation
+                into a list of equivalent operations. If None provided, this class
+                decomposes operations by invoking `QuilOutput._write_quil`.
+            qubit_id_map: Optional; A dictionary mapping `cirq.Qid` to strings that
+                address physical qubits in the outputted QUIL.
+        """
+        super().__init__(operations, qubits)
+        self.qubit_id_map = qubit_id_map or self._generate_qubit_ids()
+        self.measurement_id_map = self._generate_measurement_ids()
+
+        self.formatter = QuilFormatter(
+            qubit_id_map=self.qubit_id_map, measurement_id_map=self.measurement_id_map
+        )
+        self._decompose_operation = decompose_operation
+
+    def _write_quil(self, output_func: Callable[[str], None]) -> None:
+        """Calls `output_func` for successive lines of QUIL output.
+
+        Args:
+            output_func: A function that accepts a string of QUIL. This will likely
+                write the QUIL to a file.
+
+        Returns:
+            None.
+        """
+        if self._decompose_operation is None:
+            return super()._write_quil(output_func)
+
+        output_func("# Created using qBraid.\n\n")
+
+        if len(self.measurements) > 0:
+            measurements_declared: Set[str] = set()
+            for m in self.measurements:
+                key = cirq.measurement_key_name(m)
+                if key in measurements_declared:
+                    continue
+                measurements_declared.add(key)
+                output_func(f"DECLARE {self.measurement_id_map[key]} BIT[{len(m.qubits)}]\n")
+            output_func("\n")
+
+        for main_op in self.operations:
+            decomposed = self._decompose_operation(main_op)
+            for decomposed_op in decomposed:
+                output_func(self._op_to_quil(decomposed_op))

--- a/qbraid/transpiler/conversions.py
+++ b/qbraid/transpiler/conversions.py
@@ -133,10 +133,8 @@ def _convert_from_cirq(circuit: "cirq.Circuit", frontend: str) -> "qbraid.QPROGR
             if circuits_allclose(circuit, program):
                 return program
 
-            cirq_decomp = from_qasm(circuit.to_qasm())
+            cirq_decomp = from_qasm(to_qasm(circuit))
             return to_pyquil(cirq_decomp)
-
-            return to_pyquil(circuit)
 
         if frontend == "braket":
             from qbraid.transpiler.cirq_braket import to_braket

--- a/qbraid/transpiler/conversions.py
+++ b/qbraid/transpiler/conversions.py
@@ -20,6 +20,7 @@ from cirq import Circuit
 from cirq.contrib.qasm_import import circuit_from_qasm
 
 from qbraid.exceptions import PackageValueError, ProgramTypeError, QasmError
+from qbraid.interface.calculate_unitary import circuits_allclose
 from qbraid.qasm_checks import get_qasm_version
 from qbraid.transpiler.cirq_qasm import from_qasm, to_qasm
 from qbraid.transpiler.exceptions import CircuitConversionError
@@ -127,6 +128,13 @@ def _convert_from_cirq(circuit: "cirq.Circuit", frontend: str) -> "qbraid.QPROGR
 
         if frontend == "pyquil":
             from qbraid.transpiler.cirq_pyquil import to_pyquil
+
+            program = to_pyquil(circuit)
+            if circuits_allclose(circuit, program):
+                return program
+
+            cirq_decomp = from_qasm(circuit.to_qasm())
+            return to_pyquil(cirq_decomp)
 
             return to_pyquil(circuit)
 

--- a/tests/_data/programs.py
+++ b/tests/_data/programs.py
@@ -12,14 +12,13 @@
 Module containing quantum programs used for testing
 
 """
+
 from typing import Any, Callable, Dict, Tuple
 
 import numpy as np
 
 from qbraid._qprogram import QPROGRAM
 from qbraid.interface.calculate_unitary import to_unitary
-
-QROGRAM_TEST_TYPE = Tuple[Dict[str, Callable[[Any], QPROGRAM]], np.ndarray]
 
 from .braket.circuits import braket_bell, braket_shared15
 from .cirq.circuits import cirq_bell, cirq_shared15
@@ -28,6 +27,8 @@ from .pytket.circuits import pytket_bell, pytket_shared15
 from .qasm2.circuits import qasm2_bell, qasm2_cirq_shared15
 from .qasm3.circuits import qasm3_bell, qasm3_shared15
 from .qiskit.circuits import qiskit_bell, qiskit_shared15
+
+QROGRAM_TEST_TYPE = Tuple[Dict[str, Callable[[Any], QPROGRAM]], np.ndarray]
 
 
 def bell_data() -> QROGRAM_TEST_TYPE:

--- a/tests/benchmarking/qiskit_to_braket.py
+++ b/tests/benchmarking/qiskit_to_braket.py
@@ -20,14 +20,15 @@ import qbraid
 from .._data.qiskit.gates import get_qiskit_gates
 
 
-def execute_test(conversion_function, qiskit_circuit):
+def execute_test(conversion_function, input_circuit):
+    """Execute conversion, test equality, and return 1 if it fails, 0 otherwise"""
     try:
-        braket_circuit = conversion_function(qiskit_circuit)
+        output_circuit = conversion_function(input_circuit)
         if not qbraid.interface.circuits_allclose(
-            qiskit_circuit, braket_circuit, strict_gphase=False
+            input_circuit, output_circuit, strict_gphase=False
         ):
             return 1
-    except Exception:
+    except Exception:  # pylint: disable=broad-exception-caught
         return 1
     return 0
 
@@ -55,6 +56,6 @@ qbraid_percentage, qiskit_percentage = round((qbraid_passed / total_tests) * 100
     (qiskit_passed / total_tests) * 100, 2
 )
 
-print(f"Qiskit to Braket standard gate conversion tests\n")
+print("Qiskit to Braket standard gate conversion tests\n")
 print(f"qbraid: {qbraid_passed}/{total_tests} ~= {qbraid_percentage}%")  # 58/58
 print(f"qiskit-braket-provider: {qiskit_passed}/{total_tests} ~= {qiskit_percentage}%")  # 31/58

--- a/tests/compiler/test_braket_compiler.py
+++ b/tests/compiler/test_braket_compiler.py
@@ -9,7 +9,7 @@
 # THERE IS NO WARRANTY for the qBraid-SDK, as per Section 15 of the GPL v3.
 
 """
-Unit tests for converting braket circuit to use only ionq supprted gates
+Unit tests for Amazon Braket circuit compilation
 
 """
 import braket
@@ -24,6 +24,7 @@ braket_gates = get_braket_gates()
 
 @pytest.mark.parametrize("gate_name", braket_gates)
 def test_braket_ionq_compilation(gate_name):
+    """Test converting Amazon Braket circuit to use only IonQ supprted gates"""
     gate = braket_gates[gate_name]
     if gate.qubit_count == 1:
         source_circuit = braket.circuits.Circuit([braket.circuits.Instruction(gate, 0)])
@@ -32,6 +33,5 @@ def test_braket_ionq_compilation(gate_name):
             [braket.circuits.Instruction(gate, range(gate.qubit_count))]
         )
 
-        braket_ionq_compile(
-            source_circuit
-        )  # the function already has an assertion which checks that the predicates are satistfied
+        braket_circuit = braket_ionq_compile(source_circuit)
+        assert isinstance(braket_circuit, braket.circuits.Circuit)

--- a/tests/interface/test_cirq_tools.py
+++ b/tests/interface/test_cirq_tools.py
@@ -22,6 +22,8 @@ from qbraid.interface.qbraid_cirq.tools import _equal
 
 @pytest.mark.parametrize("require_qubit_equality", [True, False])
 def test_circuit_equality_identical_qubits(require_qubit_equality):
+    """Test evaluating circuit equality with added qubit equality requirement for
+    circuit constructed using the same qubits."""
     qreg = cirq.NamedQubit.range(5, prefix="q_")
     circA = cirq.Circuit(cirq.ops.H.on_each(*qreg))
     circB = cirq.Circuit(cirq.ops.H.on_each(*qreg))
@@ -33,6 +35,8 @@ def test_circuit_equality_identical_qubits(require_qubit_equality):
 def test_circuit_equality_nonidentical_but_equal_qubits(
     require_qubit_equality,
 ):
+    """Test evaluating circuit equality with added qubit equality requirement for
+    circuit constructed with independent qubit declarations."""
     n = 5
     qregA = cirq.NamedQubit.range(n, prefix="q_")
     qregB = cirq.NamedQubit.range(n, prefix="q_")
@@ -43,6 +47,8 @@ def test_circuit_equality_nonidentical_but_equal_qubits(
 
 
 def test_circuit_equality_linequbit_gridqubit_equal_indices():
+    """Test evaluating circuit equality for circuits constructed
+    using LineQubit and GridQubit with identical qubit indexing."""
     n = 10
     qregA = cirq.LineQubit.range(n)
     qregB = [cirq.GridQubit(x, 0) for x in range(n)]
@@ -53,6 +59,8 @@ def test_circuit_equality_linequbit_gridqubit_equal_indices():
 
 
 def test_circuit_equality_linequbit_gridqubit_unequal_indices():
+    """Test evaluating circuit equality for circuits constructed
+    using LineQubit and GridQubit with differing qubit indexing."""
     n = 10
     qregA = cirq.LineQubit.range(n)
     qregB = [cirq.GridQubit(x + 3, 0) for x in range(n)]
@@ -63,6 +71,8 @@ def test_circuit_equality_linequbit_gridqubit_unequal_indices():
 
 
 def test_circuit_equality_linequbit_namedqubit_equal_indices():
+    """Test evaluating circuit equality for circuits constructed
+    using LineQubit and NamedQubit with identical qubit indexing."""
     n = 8
     qregA = cirq.LineQubit.range(n)
     qregB = cirq.NamedQubit.range(n, prefix="q_")
@@ -73,6 +83,8 @@ def test_circuit_equality_linequbit_namedqubit_equal_indices():
 
 
 def test_circuit_equality_linequbit_namedqubit_unequal_indices():
+    """Test evaluating circuit equality for circuits constructed
+    using LineQubit and NamedQubit with differing qubit indexing."""
     n = 11
     qregA = cirq.LineQubit.range(n)
     qregB = [cirq.NamedQubit(str(x + 10)) for x in range(n)]
@@ -83,6 +95,8 @@ def test_circuit_equality_linequbit_namedqubit_unequal_indices():
 
 
 def test_circuit_equality_gridqubit_namedqubit_equal_indices():
+    """Test evaluating circuit equality for circuits constructed
+    using GridQubit and NamedQubit with identical qubit indexing."""
     n = 8
     qregA = [cirq.GridQubit(0, x) for x in range(n)]
     qregB = cirq.NamedQubit.range(n, prefix="q_")
@@ -93,6 +107,8 @@ def test_circuit_equality_gridqubit_namedqubit_equal_indices():
 
 
 def test_circuit_equality_gridqubit_namedqubit_unequal_indices():
+    """Test evaluating circuit equality for circuits constructed
+    using GridQubit and NamedQubit with differing qubit indexing."""
     n = 5
     qregA = [cirq.GridQubit(x + 2, 0) for x in range(n)]
     qregB = [cirq.NamedQubit(str(x + 10)) for x in range(n)]
@@ -103,6 +119,8 @@ def test_circuit_equality_gridqubit_namedqubit_unequal_indices():
 
 
 def test_circuit_equality_unequal_measurement_keys_terminal_measurements():
+    """Test evaluating circuit equality for circuits with terminal
+    measurement constructed using differing measurement keys."""
     base_circuit = cirq.testing.random_circuit(
         qubits=5, n_moments=10, op_density=0.99, random_state=1
     )
@@ -122,6 +140,8 @@ def test_circuit_equality_unequal_measurement_keys_terminal_measurements():
 def test_circuit_equality_equal_measurement_keys_terminal_measurements(
     require_measurement_equality,
 ):
+    """Test evaluating circuit equality for circuits with terminal
+    measurement constructed using identical measurement keys."""
     base_circuit = cirq.testing.random_circuit(
         qubits=5, n_moments=10, op_density=0.99, random_state=1
     )
@@ -141,6 +161,8 @@ def test_circuit_equality_equal_measurement_keys_terminal_measurements(
 
 
 def test_circuit_equality_unequal_measurement_keys_nonterminal_measurements():
+    """Test evaluating circuit equality for circuits with non-terminal
+    measurement constructed using differing measurement keys."""
     base_circuit = cirq.testing.random_circuit(
         qubits=5, n_moments=10, op_density=0.99, random_state=1
     )
@@ -165,6 +187,8 @@ def test_circuit_equality_unequal_measurement_keys_nonterminal_measurements():
 def test_circuit_equality_equal_measurement_keys_nonterminal_measurements(
     require_measurement_equality,
 ):
+    """Test evaluating circuit equality for circuits with non-terminal
+    measurement constructed using identical measurement keys."""
     base_circuit = cirq.testing.random_circuit(
         qubits=5, n_moments=10, op_density=0.99, random_state=1
     )

--- a/tests/interface/test_convert_to_contiguous.py
+++ b/tests/interface/test_convert_to_contiguous.py
@@ -9,7 +9,7 @@
 # THERE IS NO WARRANTY for the qBraid-SDK, as per Section 15 of the GPL v3.
 
 """
-Unit tests for the qbraid convert_to_contiguous interfacing
+Unit tests for converting circuits to use contiguous qubit indexing
 
 """
 import numpy as np
@@ -85,6 +85,7 @@ def test_braket_control_modifier():
 
 
 def test_remove_blank_wires_pytket():
+    """Test wires with no operations from pytket circuit"""
     circuit = TKCircuit(3)
     circuit.H(0)
     circuit.CX(0, 1)
@@ -93,5 +94,6 @@ def test_remove_blank_wires_pytket():
 
 
 def test_unitary_raises():
+    """Test that convert_to_contiguous raises an error when passed a non-circuit object"""
     with pytest.raises(ProgramTypeError):
         convert_to_contiguous(None)

--- a/tests/interface/test_programs.py
+++ b/tests/interface/test_programs.py
@@ -23,22 +23,22 @@ from qbraid.interface.random_circuit import random_circuit
 
 from .._data.programs import bell_data, shared15_data
 
-map, _ = bell_data()
-braket_bell = map["braket"]()
-cirq_bell = map["cirq"]()
-pyquil_bell = map["pyquil"]()
-qiskit_bell = map["qiskit"]()
-pytket_bell = map["pytket"]()
-qasm2_bell = map["qasm2"]()
-qasm3_bell = map["qasm3"]()
+bell_map, _ = bell_data()
+braket_bell = bell_map["braket"]()
+cirq_bell = bell_map["cirq"]()
+pyquil_bell = bell_map["pyquil"]()
+qiskit_bell = bell_map["qiskit"]()
+pytket_bell = bell_map["pytket"]()
+qasm2_bell = bell_map["qasm2"]()
+qasm3_bell = bell_map["qasm3"]()
 
-map, _ = shared15_data()
-braket_shared15 = map["braket"]()
-cirq_shared15 = map["cirq"]()
-qiskit_shared15 = map["qiskit"]()
-pytket_shared15 = map["pytket"]()
-qasm2_shared15 = map["qasm2"]()
-qasm3_shared15 = map["qasm3"]()
+shared15_map, _ = shared15_data()
+braket_shared15 = shared15_map["braket"]()
+cirq_shared15 = shared15_map["cirq"]()
+qiskit_shared15 = shared15_map["qiskit"]()
+pytket_shared15 = shared15_map["pytket"]()
+qasm2_shared15 = shared15_map["qasm2"]()
+qasm3_shared15 = shared15_map["qasm3"]()
 
 
 def test_bell():
@@ -71,7 +71,7 @@ def test_random(package):
     """Test generating random circuits"""
     try:
         random_circuit(package)
-    except Exception:
+    except Exception:  # pylint: disable=broad-exception-caught
         assert False
     assert True
 
@@ -83,27 +83,29 @@ def test_draw_raises():
 
 
 def test_draw_program_raises():
+    """Test that non-supported package raises error"""
     with pytest.raises(ProgramTypeError):
         circuit_drawer(None)
 
 
 def test_qiskit_draw():
+    """Test draw function standard output for qiskit bell circuit."""
     expected = """          ┌───┐
 q_0: ─────┤ X ├
      ┌───┐└─┬─┘
 q_1: ┤ H ├──■──
      └───┘     """
     result = circuit_drawer(reverse_qubit_ordering(qiskit_bell), output="text")
-    assert result.__str__() == expected
+    assert str(result) == expected
 
 
 @pytest.mark.parametrize("package", ["braket", "cirq", "qiskit", "pytket", "pyquil", "qasm2"])
 def test_braket_bell_draw(capfd, package):
-    """Test that draw function standard output is of the expected length."""
+    """Test using Amazon Braket to draw using ascii output is of the expected length."""
+    # pylint: disable=eval-used
     circuit_wrapper(eval(f"{package}_bell")).draw(package="braket", output="ascii")
 
     out, err = capfd.readouterr()
-    print(out, err)
     assert len(err) == 0
     assert len(out) == 67
 
@@ -112,56 +114,59 @@ def test_braket_bell_draw(capfd, package):
 
 
 def test_braket_raises():
-    """Test that non-supported output raises error"""
+    """Test that drawing braket circuit with non-supported output raises error"""
     with pytest.raises(VisualizationError):
         circuit_drawer(braket_bell, output="bad_input")
 
 
 @pytest.mark.parametrize("package", ["braket", "cirq", "qiskit", "pytket", "pyquil", "qasm2"])
 def test_cirq_bell_text_draw(capfd, package):
-    """Test that draw function standard output is of the expected length."""
+    """Test using Cirq to draw circuit using text output is of the expected length."""
+    # pylint: disable=eval-used
     circuit_wrapper(eval(f"{package}_bell")).draw(package="cirq", output="text")
 
     out, err = capfd.readouterr()
-    print(out, err)
     assert len(err) == 0
-    if package == "pytket" or package == "qasm2":  # todo: there is "q_n" represent number of qubit
+    if package in ["pytket", "qasm2"]:  # todo: there is "q_n" represent number of qubit
         assert len(out) == 48
     else:
         assert len(out) == 42
 
 
 def test_cirq_bell_svg_draw():
-    """Test svg_source"""
-
+    """Test drawing Cirq circuit using SVG source output"""
     assert len(circuit_drawer(cirq_bell, output="svg_source")) == 1211
 
 
 def test_cirq_raises():
+    """Test that drawing Cirq circuit with non-supported output raises error"""
     with pytest.raises(VisualizationError):
         circuit_drawer(cirq_bell, output="bad_input")
 
 
 @pytest.mark.parametrize("package", ["braket", "cirq", "qiskit", "pytket", "pyquil", "qasm2"])
 def test_pyquil_bell_draw(capfd, package):
-    """Test that draw function standard output is of the expected length."""
+    """Test using pyquil to draw circuit using text output is of the expected length."""
+    # pylint: disable=eval-used
     circuit_wrapper(eval(f"{package}_bell")).draw(package="pyquil", output="text")
 
     out, err = capfd.readouterr()
-    print(out, err)
     assert len(err) == 0
     assert len(out) == 14
 
 
 def test_pyquil_raises():
+    """Test that drawing pyQuil program with non-supported output raises error"""
     with pytest.raises(VisualizationError):
         circuit_drawer(pyquil_bell, output="bad_input")
 
 
 def test_pytket_draw():
+    """Test draw function html output for pytket bell circuit."""
     assert len(circuit_drawer(pytket_bell, output="html")) == 2381
 
 
 def test_pytket_raises():
+    """Test that drawing pytket circuit with non-supported output raises error"""
     with pytest.raises(VisualizationError):
         circuit_drawer(pytket_bell, output="bad_input")

--- a/tests/interface/test_qiskit_tools.py
+++ b/tests/interface/test_qiskit_tools.py
@@ -19,20 +19,17 @@ from qbraid.interface.qbraid_qiskit.tools import reverse_qubit_ordering
 
 
 def test_reverse_qubit_ordering():
-    # Create a sample circuit
+    """Test reversing ordering of qubits in qiskit circuit"""
     circ = QuantumCircuit(3)
     circ.h(0)
     circ.cx(0, 2)
 
-    # Get the reversed circuit
     reversed_circ = reverse_qubit_ordering(circ)
 
-    # Expected reversed circuit
     expected_circ = QuantumCircuit(3)
     expected_circ.h(2)
     expected_circ.cx(2, 0)
 
-    # Check if the two circuits are equivalent
     assert (
         reversed_circ == expected_circ
     ), "The reversed circuit does not match the expected output."

--- a/tests/transpiler/cirq_pyquil/test_quil_output.py
+++ b/tests/transpiler/cirq_pyquil/test_quil_output.py
@@ -1,0 +1,500 @@
+# Copyright (C) 2023 qBraid
+# Copyright (C) 2022 The Cirq Developers
+#
+# This file is part of the qBraid-SDK.
+# 
+# The qBraid-SDK is free software released under the GNU General Public License v3
+# or later. This specific file, adapted from Cirq, is dual-licensed under both the
+# Apache License, Version 2.0, and the GPL v3. You may not use this file except in
+# compliance with the applicable license. You may obtain a copy of the Apache License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file includes code adapted from Cirq (https://github.com/quantumlib/Cirq)
+# with modifications by qBraid. The original copyright notice is included above.
+# THERE IS NO WARRANTY for the qBraid-SDK, as per Section 15 of the GPL v3.
+
+# isort: skip_file
+# pylint: skip-file
+# flake8: noqa
+# fmt: off
+
+"""
+Module for testing qBraid QuilOutput.
+
+"""
+
+import os
+import numpy as np
+import pytest
+
+import cirq
+from cirq.ops.pauli_interaction_gate import PauliInteractionGate
+
+from qbraid.transpiler.cirq_pyquil.quil_output import QuilOutput, QuilOneQubitGate, QuilTwoQubitGate
+
+
+def _make_qubits(n):
+    return [cirq.NamedQubit(f'q{i}') for i in range(n)]
+
+
+def test_single_gate_no_parameter():
+    (q0,) = _make_qubits(1)
+    output = QuilOutput((cirq.X(q0),), (q0,))
+    assert (
+        str(output)
+        == """# Created using qBraid.
+
+X 0\n"""
+    )
+
+
+def test_single_gate_with_parameter():
+    (q0,) = _make_qubits(1)
+    output = QuilOutput((cirq.X(q0) ** 0.5,), (q0,))
+    assert (
+        str(output)
+        == f"""# Created using qBraid.
+
+RX({np.pi / 2}) 0\n"""
+    )
+
+
+def test_single_gate_named_qubit():
+    q = cirq.NamedQubit('qTest')
+    output = QuilOutput((cirq.X(q),), (q,))
+
+    assert (
+        str(output)
+        == """# Created using qBraid.
+
+X 0\n"""
+    )
+
+
+def test_h_gate_with_parameter():
+    (q0,) = _make_qubits(1)
+    output = QuilOutput((cirq.H(q0) ** 0.25,), (q0,))
+    assert (
+        str(output)
+        == f"""# Created using qBraid.
+
+RY({np.pi / 4}) 0
+RX({np.pi / 4}) 0
+RY({-np.pi / 4}) 0\n"""
+    )
+
+
+def test_save_to_file(tmpdir):
+    file_path = os.path.join(tmpdir, 'test.quil')
+    (q0,) = _make_qubits(1)
+    output = QuilOutput((cirq.X(q0)), (q0,))
+    output.save_to_file(file_path)
+    with open(file_path, 'r') as f:
+        file_content = f.read()
+    assert (
+        file_content
+        == """# Created using qBraid.
+
+X 0\n"""
+    )
+
+
+def test_quil_one_qubit_gate_repr():
+    gate = QuilOneQubitGate(np.array([[1, 0], [0, 1]]))
+    assert repr(gate) == (
+        """cirq.circuits.quil_output.QuilOneQubitGate(matrix=
+[[1 0]
+ [0 1]]
+)"""
+    )
+
+
+def test_quil_two_qubit_gate_repr():
+    gate = QuilTwoQubitGate(
+        np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
+    )
+    assert repr(gate) == (
+        """cirq.circuits.quil_output.QuilTwoQubitGate(matrix=
+[[1 0 0 0]
+ [0 1 0 0]
+ [0 0 1 0]
+ [0 0 0 1]]
+)"""
+    )
+
+
+def test_quil_one_qubit_gate_eq():
+    gate = QuilOneQubitGate(np.array([[1, 0], [0, 1]]))
+    gate2 = QuilOneQubitGate(np.array([[1, 0], [0, 1]]))
+    assert cirq.approx_eq(gate, gate2, atol=1e-16)
+    gate3 = QuilOneQubitGate(np.array([[1, 0], [0, 1]]))
+    gate4 = QuilOneQubitGate(np.array([[1, 0], [0, 2]]))
+    assert not cirq.approx_eq(gate4, gate3, atol=1e-16)
+
+
+def test_quil_two_qubit_gate_eq():
+    gate = QuilTwoQubitGate(
+        np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
+    )
+    gate2 = QuilTwoQubitGate(
+        np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
+    )
+    assert cirq.approx_eq(gate, gate2, atol=1e-8)
+    gate3 = QuilTwoQubitGate(
+        np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
+    )
+    gate4 = QuilTwoQubitGate(
+        np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 2, 0], [0, 0, 0, 1]])
+    )
+    assert not cirq.approx_eq(gate4, gate3, atol=1e-8)
+
+
+def test_quil_one_qubit_gate_output():
+    (q0,) = _make_qubits(1)
+    gate = QuilOneQubitGate(np.array([[1, 0], [0, 1]]))
+    output = QuilOutput((gate.on(q0),), (q0,))
+    assert (
+        str(output)
+        == """# Created using qBraid.
+
+DEFGATE USERGATE1:
+    1.0+0.0i, 0.0+0.0i
+    0.0+0.0i, 1.0+0.0i
+USERGATE1 0
+"""
+    )
+
+
+def test_two_quil_one_qubit_gate_output():
+    (q0,) = _make_qubits(1)
+    gate = QuilOneQubitGate(np.array([[1, 0], [0, 1]]))
+    gate1 = QuilOneQubitGate(np.array([[2, 0], [0, 3]]))
+    output = QuilOutput((gate.on(q0), gate1.on(q0)), (q0,))
+    assert (
+        str(output)
+        == """# Created using qBraid.
+
+DEFGATE USERGATE1:
+    1.0+0.0i, 0.0+0.0i
+    0.0+0.0i, 1.0+0.0i
+USERGATE1 0
+DEFGATE USERGATE2:
+    2.0+0.0i, 0.0+0.0i
+    0.0+0.0i, 3.0+0.0i
+USERGATE2 0
+"""
+    )
+
+
+def test_quil_two_qubit_gate_output():
+    (q0, q1) = _make_qubits(2)
+    gate = QuilTwoQubitGate(
+        np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
+    )
+    output = QuilOutput((gate.on(q0, q1),), (q0, q1))
+    assert (
+        str(output)
+        == """# Created using qBraid.
+
+DEFGATE USERGATE1:
+    1.0+0.0i, 0.0+0.0i, 0.0+0.0i, 0.0+0.0i
+    0.0+0.0i, 1.0+0.0i, 0.0+0.0i, 0.0+0.0i
+    0.0+0.0i, 0.0+0.0i, 1.0+0.0i, 0.0+0.0i
+    0.0+0.0i, 0.0+0.0i, 0.0+0.0i, 1.0+0.0i
+USERGATE1 0 1
+"""
+    )
+
+
+def test_unsupported_operation():
+    (q0,) = _make_qubits(1)
+
+    class UnsupportedOperation(cirq.Operation):
+        qubits = (q0,)
+        with_qubits = NotImplemented
+
+    output = QuilOutput((UnsupportedOperation(),), (q0,))
+    with pytest.raises(ValueError):
+        _ = str(output)
+
+
+def test_i_swap_with_power():
+    q0, q1 = _make_qubits(2)
+
+    output = QuilOutput((cirq.ISWAP(q0, q1) ** 0.25,), (q0, q1))
+    assert (
+        str(output)
+        == f"""# Created using qBraid.
+
+XY({np.pi / 4}) 0 1
+"""
+    )
+
+
+def test_all_operations():
+    qubits = tuple(_make_qubits(5))
+    operations = _all_operations(*qubits, include_measurements=False)
+    output = QuilOutput(operations, qubits)
+
+    assert (
+        str(output)
+        == f"""# Created using qBraid.
+
+DECLARE m0 BIT[1]
+DECLARE m1 BIT[1]
+DECLARE m2 BIT[1]
+DECLARE m3 BIT[3]
+
+Z 0
+RZ({5 * np.pi / 8}) 0
+Y 0
+RY({3 * np.pi / 8}) 0
+X 0
+RX({7 * np.pi / 8}) 0
+H 1
+CZ 0 1
+CPHASE({np.pi / 4}) 0 1
+CNOT 0 1
+RY({-np.pi / 2}) 1
+CPHASE({np.pi / 2}) 0 1
+RY({np.pi / 2}) 1
+SWAP 0 1
+SWAP 1 0
+PSWAP({3 * np.pi / 4}) 0 1
+H 2
+CCNOT 0 1 2
+H 2
+CCNOT 0 1 2
+RZ({np.pi / 8}) 0
+RZ({np.pi / 8}) 1
+RZ({np.pi / 8}) 2
+CNOT 0 1
+CNOT 1 2
+RZ({-np.pi / 8}) 1
+RZ({np.pi / 8}) 2
+CNOT 0 1
+CNOT 1 2
+RZ({-np.pi / 8}) 2
+CNOT 0 1
+CNOT 1 2
+RZ({-np.pi / 8}) 2
+CNOT 0 1
+CNOT 1 2
+H 2
+RZ({np.pi / 8}) 0
+RZ({np.pi / 8}) 1
+RZ({np.pi / 8}) 2
+CNOT 0 1
+CNOT 1 2
+RZ({-np.pi / 8}) 1
+RZ({np.pi / 8}) 2
+CNOT 0 1
+CNOT 1 2
+RZ({-np.pi / 8}) 2
+CNOT 0 1
+CNOT 1 2
+RZ({-np.pi / 8}) 2
+CNOT 0 1
+CNOT 1 2
+H 2
+CSWAP 0 1 2
+X 0
+X 1
+RX({3 * np.pi / 4}) 0
+RX({3 * np.pi / 4}) 1
+Y 0
+Y 1
+RY({3 * np.pi / 4}) 0
+RY({3 * np.pi / 4}) 1
+Z 0
+Z 1
+RZ({3 * np.pi / 4}) 0
+RZ({3 * np.pi / 4}) 1
+I 0
+I 0
+I 1
+I 2
+ISWAP 2 0
+RZ({-0.111 * np.pi}) 1
+RX({np.pi / 4}) 1
+RZ({0.111 * np.pi}) 1
+RZ({-0.333 * np.pi}) 1
+RX({np.pi / 2}) 1
+RZ({0.333 * np.pi}) 1
+RZ({-0.777 * np.pi}) 1
+RX({-np.pi / 2}) 1
+RZ({0.777 * np.pi}) 1
+WAIT
+MEASURE 0 m0[0]
+MEASURE 2 m1[0]
+MEASURE 3 m2[0]
+MEASURE 2 m1[0]
+MEASURE 1 m3[0]
+X 2 # Inverting for following measurement
+MEASURE 2 m3[1]
+MEASURE 3 m3[2]
+"""
+    )
+
+
+def _all_operations(q0, q1, q2, q3, q4, include_measurements=True):
+    return (
+        cirq.Z(q0),
+        cirq.Z(q0) ** 0.625,
+        cirq.Y(q0),
+        cirq.Y(q0) ** 0.375,
+        cirq.X(q0),
+        cirq.X(q0) ** 0.875,
+        cirq.H(q1),
+        cirq.CZ(q0, q1),
+        cirq.CZ(q0, q1) ** 0.25,  # Requires 2-qubit decomposition
+        cirq.CNOT(q0, q1),
+        cirq.CNOT(q0, q1) ** 0.5,  # Requires 2-qubit decomposition
+        cirq.SWAP(q0, q1),
+        cirq.SWAP(q1, q0) ** -1,
+        cirq.SWAP(q0, q1) ** 0.75,  # Requires 2-qubit decomposition
+        cirq.CCZ(q0, q1, q2),
+        cirq.CCX(q0, q1, q2),
+        cirq.CCZ(q0, q1, q2) ** 0.5,
+        cirq.CCX(q0, q1, q2) ** 0.5,
+        cirq.CSWAP(q0, q1, q2),
+        cirq.XX(q0, q1),
+        cirq.XX(q0, q1) ** 0.75,
+        cirq.YY(q0, q1),
+        cirq.YY(q0, q1) ** 0.75,
+        cirq.ZZ(q0, q1),
+        cirq.ZZ(q0, q1) ** 0.75,
+        cirq.IdentityGate(1).on(q0),
+        cirq.IdentityGate(3).on(q0, q1, q2),
+        cirq.ISWAP(q2, q0),  # Requires 2-qubit decomposition
+        cirq.PhasedXPowGate(phase_exponent=0.111, exponent=0.25).on(q1),
+        cirq.PhasedXPowGate(phase_exponent=0.333, exponent=0.5).on(q1),
+        cirq.PhasedXPowGate(phase_exponent=0.777, exponent=-0.5).on(q1),
+        cirq.wait(q0, nanos=0),
+        cirq.measure(q0, key='xX'),
+        cirq.measure(q2, key='x_a'),
+        cirq.measure(q3, key='X'),
+        cirq.measure(q2, key='x_a'),
+        cirq.measure(q1, q2, q3, key='multi', invert_mask=(False, True)),
+    )
+
+
+def test_fails_on_big_unknowns():
+    class UnrecognizedGate(cirq.testing.ThreeQubitGate):
+        pass
+
+    q0, q1, q2 = _make_qubits(3)
+    res = QuilOutput(UnrecognizedGate().on(q0, q1, q2), (q0, q1, q2))
+    with pytest.raises(ValueError, match='Cannot output operation as QUIL'):
+        _ = str(res)
+
+
+def test_pauli_interaction_gate():
+    (q0, q1) = _make_qubits(2)
+    output = QuilOutput(PauliInteractionGate.CZ.on(q0, q1), (q0, q1))
+    assert (
+        str(output)
+        == """# Created using qBraid.
+
+CZ 0 1
+"""
+    )
+
+
+def test_equivalent_unitaries():
+    """This test covers the factor of pi change. However, it will be skipped
+    if pyquil is unavailable for import.
+
+    References:
+        https://docs.pytest.org/en/latest/skipping.html#skipping-on-a-missing-import-dependency
+    """
+    pyquil = pytest.importorskip("pyquil")
+    pyquil_simulation_tools = pytest.importorskip("pyquil.simulation.tools")
+    q0, q1 = _make_qubits(2)
+    operations = [
+        cirq.XPowGate(exponent=0.5, global_shift=-0.5)(q0),
+        cirq.YPowGate(exponent=0.5, global_shift=-0.5)(q0),
+        cirq.ZPowGate(exponent=0.5, global_shift=-0.5)(q0),
+        cirq.CZPowGate(exponent=0.5)(q0, q1),
+        cirq.ISwapPowGate(exponent=0.5)(q0, q1),
+    ]
+    output = QuilOutput(operations, (q0, q1))
+    program = pyquil.Program(str(output))
+    pyquil_unitary = pyquil_simulation_tools.program_unitary(program, n_qubits=2)
+    # Qubit ordering differs between pyQuil and Cirq.
+    cirq_unitary = cirq.Circuit(cirq.SWAP(q0, q1), operations, cirq.SWAP(q0, q1)).unitary()
+    assert np.allclose(pyquil_unitary, cirq_unitary)
+
+
+QUIL_CPHASES_PROGRAM = """
+CPHASE00(pi/2) 0 1
+CPHASE01(pi/2) 0 1
+CPHASE10(pi/2) 0 1
+CPHASE(pi/2) 0 1
+"""
+
+QUIL_DIAGONAL_DECOMPOSE_PROGRAM = """
+RZ(0) 0
+RZ(0) 1
+CPHASE(0) 0 1
+X 0
+X 1
+CPHASE(0) 0 1
+X 0
+X 1
+"""
+
+
+def test_two_qubit_diagonal_gate_quil_output():
+    pyquil = pytest.importorskip("pyquil")
+    pyquil_simulation_tools = pytest.importorskip("pyquil.simulation.tools")
+    q0, q1 = _make_qubits(2)
+    operations = [
+        cirq.TwoQubitDiagonalGate([np.pi / 2, 0, 0, 0])(q0, q1),
+        cirq.TwoQubitDiagonalGate([0, np.pi / 2, 0, 0])(q0, q1),
+        cirq.TwoQubitDiagonalGate([0, 0, np.pi / 2, 0])(q0, q1),
+        cirq.TwoQubitDiagonalGate([0, 0, 0, np.pi / 2])(q0, q1),
+    ]
+    output = QuilOutput(operations, (q0, q1))
+    program = pyquil.Program(str(output))
+    assert f"\n{program.out()}" == QUIL_CPHASES_PROGRAM
+
+    pyquil_unitary = pyquil_simulation_tools.program_unitary(program, n_qubits=2)
+    # Qubit ordering differs between pyQuil and Cirq.
+    cirq_unitary = cirq.Circuit(cirq.SWAP(q0, q1), operations, cirq.SWAP(q0, q1)).unitary()
+    assert np.allclose(pyquil_unitary, cirq_unitary)
+    # Also test non-CPHASE case, which decomposes into X/RZ/CPhase
+    operations = [cirq.TwoQubitDiagonalGate([0, 0, 0, 0])(q0, q1)]
+    output = QuilOutput(operations, (q0, q1))
+    program = pyquil.Program(str(output))
+    assert f"\n{program.out()}" == QUIL_DIAGONAL_DECOMPOSE_PROGRAM
+
+
+def test_parseable_defgate_output():
+    pyquil = pytest.importorskip("pyquil")
+    q0, q1 = _make_qubits(2)
+    operations = [
+        QuilOneQubitGate(np.array([[1, 0], [0, 1]])).on(q0),
+        QuilTwoQubitGate(
+            np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
+        ).on(q0, q1),
+    ]
+    output = QuilOutput(operations, (q0, q1))
+    # Just checks that we can create a pyQuil Program without crashing.
+    pyquil.Program(str(output))
+
+
+def test_unconveritble_op():
+    (q0,) = _make_qubits(1)
+
+    class MyGate(cirq.Gate):
+        def num_qubits(self) -> int:
+            return 1
+
+    op = MyGate()(q0)
+
+    # Documenting that this
+    # operation would crash if you call _op_to_quil_directly
+    with pytest.raises(ValueError, match="Can't convert"):
+        _ = QuilOutput(op, (q0,))._op_to_quil(op)

--- a/tests/transpiler/cirq_pyquil/test_quil_output.py
+++ b/tests/transpiler/cirq_pyquil/test_quil_output.py
@@ -2,12 +2,12 @@
 # Copyright (C) 2022 The Cirq Developers
 #
 # This file is part of the qBraid-SDK.
-# 
+#
 # The qBraid-SDK is free software released under the GNU General Public License v3
 # or later. This specific file, adapted from Cirq, is dual-licensed under both the
 # Apache License, Version 2.0, and the GPL v3. You may not use this file except in
 # compliance with the applicable license. You may obtain a copy of the Apache License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
 #
 # This file includes code adapted from Cirq (https://github.com/quantumlib/Cirq)

--- a/tests/transpiler/code/test_qasm_to_braket.py
+++ b/tests/transpiler/code/test_qasm_to_braket.py
@@ -35,6 +35,7 @@ print(passed)
 
 
 def test_qasm_to_braket_code_from_str(capfd):
+    """Test converting OpenQASM 2 code to Amazon Braket code from a string"""
     cirq_circuit = cirq_shared15()
     qasm_str = cirq_circuit.to_qasm()
     current_dir = os.path.dirname(os.path.abspath(__file__))
@@ -44,9 +45,8 @@ def test_qasm_to_braket_code_from_str(capfd):
     qasm_to_braket_code(qasm_str=qasm_str, output_file=output_file)
 
     # write test code to output file
-    braket_out = open(output_file, "a")
-    braket_out.writelines(test_code)
-    braket_out.close()
+    with open(output_file, "a", encoding="utf-8") as f:
+        f.writelines(test_code)
 
     os.system(f"{sys.executable} {output_file}")
     out, err = capfd.readouterr()
@@ -56,6 +56,7 @@ def test_qasm_to_braket_code_from_str(capfd):
 
 
 def test_qasm_to_braket_code_from_file(capfd):
+    """Test converting OpenQASM 2 code to Amazon Braket code from a file"""
     current_dir = os.path.dirname(os.path.abspath(__file__))
     input_file = os.path.join(current_dir, "shared15.qasm")
     output_file = os.path.join(current_dir, "_braket_out_1.py")
@@ -64,9 +65,8 @@ def test_qasm_to_braket_code_from_file(capfd):
     qasm_to_braket_code(qasm_file=input_file, output_file=output_file)
 
     # write test code to output file
-    braket_out = open(output_file, "a")
-    braket_out.writelines(test_code)
-    braket_out.close()
+    with open(output_file, "a", encoding="utf-8") as f:
+        f.writelines(test_code)
 
     os.system(f"{sys.executable} {output_file}")
     out, err = capfd.readouterr()
@@ -76,6 +76,7 @@ def test_qasm_to_braket_code_from_file(capfd):
 
 
 def test_qasm_to_braket_code_print_circuit(capfd):
+    """Test converting OpenQASM 2 code to Amazon Braket code and printing circuit"""
     cirq_circuit_1 = cirq_shared15()
     qasm_str_1 = cirq_circuit_1.to_qasm()
     current_dir = os.path.dirname(os.path.abspath(__file__))
@@ -92,5 +93,6 @@ def test_qasm_to_braket_code_print_circuit(capfd):
 
 
 def test_qasm_to_braket_code_raises_error():
+    """Test that qasm_to_braket_code raises error when no input is provided"""
     with pytest.raises(ValueError):
         qasm_to_braket_code()

--- a/tests/transpiler/coverage/test_coverage_from_braket.py
+++ b/tests/transpiler/coverage/test_coverage_from_braket.py
@@ -19,7 +19,7 @@ import qbraid
 
 from ..._data.braket.gates import get_braket_gates
 
-TARGETS = [("cirq", 1.0), ("pyquil", 1.0), ("pytket", 1.0), ("qiskit", 1.0)]
+TARGETS = [("cirq", 1.0), ("pyquil", 0.91), ("pytket", 1.0), ("qiskit", 1.0)]
 braket_gates = get_braket_gates(seed=0)
 
 

--- a/tests/transpiler/coverage/test_coverage_from_braket.py
+++ b/tests/transpiler/coverage/test_coverage_from_braket.py
@@ -9,7 +9,7 @@
 # THERE IS NO WARRANTY for the qBraid-SDK, as per Section 15 of the GPL v3.
 
 """
-Benchmarking tests for braket conversions
+Benchmarking tests for Amazon Braket conversions
 
 """
 import braket
@@ -24,6 +24,9 @@ braket_gates = get_braket_gates(seed=0)
 
 
 def convert_from_braket_to_x(target, gate_name):
+    """Construct an Amazon Braket circuit with the given gate, transpile it to
+    target program type, and check equivalence.
+    """
     gate = braket_gates[gate_name]
 
     if gate.qubit_count == 1:
@@ -39,13 +42,16 @@ def convert_from_braket_to_x(target, gate_name):
 
 @pytest.mark.parametrize(("target", "baseline"), TARGETS)
 def test_braket_coverage(target, baseline):
+    """Test converting Amazon Braket circuits to supported target program type over
+    all Amazon Braket gates and check against baseline expecte accuracy.
+    """
     ACCURACY_BASELINE = baseline
     ALLOWANCE = 0.01
     failures = {}
     for gate_name in braket_gates:
         try:
             convert_from_braket_to_x(target, gate_name)
-        except Exception as e:
+        except Exception as e:  # pylint: disable=broad-exception-caught
             failures[f"{target}-{gate_name}"] = e
 
     total_tests = len(braket_gates)
@@ -53,6 +59,8 @@ def test_braket_coverage(target, baseline):
     nb_passes = total_tests - nb_fails
     accuracy = float(nb_passes) / float(total_tests)
 
-    assert (
-        nb_passes >= ACCURACY_BASELINE - ALLOWANCE
-    ), f"The coverage threshold was not met. {nb_fails}/{total_tests} tests failed ({nb_fails / (total_tests):.2%}) and {nb_passes}/{total_tests} passed (expected >= {ACCURACY_BASELINE}).\nFailures: {failures.keys()}\n\n"
+    assert accuracy >= ACCURACY_BASELINE - ALLOWANCE, (
+        f"The coverage threshold was not met. {nb_fails}/{total_tests} tests failed "
+        f"({nb_fails / (total_tests):.2%}) and {nb_passes}/{total_tests} passed "
+        f"(expected >= {ACCURACY_BASELINE}).\nFailures: {failures.keys()}\n\n"
+    )

--- a/tests/transpiler/coverage/test_coverage_from_qiskit.py
+++ b/tests/transpiler/coverage/test_coverage_from_qiskit.py
@@ -9,7 +9,7 @@
 # THERE IS NO WARRANTY for the qBraid-SDK, as per Section 15 of the GPL v3.
 
 """
-Benchmarking tests for qiskit conversions
+Benchmarking tests for Qiskit conversions
 
 """
 import pytest
@@ -24,6 +24,9 @@ qiskit_gates = get_qiskit_gates(seed=0)
 
 
 def convert_from_qiskit_to_x(target, gate_name):
+    """Construct a Qiskit circuit with the given gate, transpile it to
+    target program type, and check equivalence.
+    """
     gate = qiskit_gates[gate_name]
     source_circuit = qiskit.QuantumCircuit(gate.num_qubits)
     source_circuit.compose(gate, inplace=True)
@@ -33,13 +36,16 @@ def convert_from_qiskit_to_x(target, gate_name):
 
 @pytest.mark.parametrize(("target", "baseline"), TARGETS)
 def test_qiskit_coverage(target, baseline):
+    """Test converting Qiskit circuits to supported target program type over
+    all Qiskit standard gates and check against baseline expecte accuracy.
+    """
     ACCURACY_BASELINE = baseline
     ALLOWANCE = 0.01
     failures = {}
     for gate_name in qiskit_gates:
         try:
             convert_from_qiskit_to_x(target, gate_name)
-        except Exception as e:
+        except Exception as e:  # pylint: disable=broad-exception-caught
             failures[f"{target}-{gate_name}"] = e
 
     total_tests = len(qiskit_gates)
@@ -47,6 +53,8 @@ def test_qiskit_coverage(target, baseline):
     nb_passes = total_tests - nb_fails
     accuracy = float(nb_passes) / float(total_tests)
 
-    assert (
-        accuracy >= ACCURACY_BASELINE - ALLOWANCE
-    ), f"The coverage threshold was not met. {nb_fails}/{total_tests} tests failed ({nb_fails / (total_tests):.2%}) and {nb_passes}/{total_tests} passed (expected >= {ACCURACY_BASELINE}).\nFailures: {failures.keys()}\n\n"
+    assert accuracy >= ACCURACY_BASELINE - ALLOWANCE, (
+        f"The coverage threshold was not met. {nb_fails}/{total_tests} tests failed "
+        f"({nb_fails / (total_tests):.2%}) and {nb_passes}/{total_tests} passed "
+        f"(expected >= {ACCURACY_BASELINE}).\nFailures: {failures.keys()}\n\n"
+    )

--- a/tests/transpiler/test_conversions.py
+++ b/tests/transpiler/test_conversions.py
@@ -23,6 +23,7 @@ from qbraid.transpiler.conversions import convert_from_cirq
 
 @pytest.mark.parametrize("frontend", QPROGRAM_LIBS)
 def test_convert_circuit_operation_from_cirq(frontend):
+    """Test converting Cirq FrozenCircuit operation to OpenQASM"""
     q = cirq.NamedQubit("q")
     cirq_circuit = cirq.Circuit(
         cirq.Y(q), cirq.CircuitOperation(cirq.FrozenCircuit(cirq.X(q)), repetitions=5), cirq.Z(q)

--- a/tools/verify_headers.py
+++ b/tools/verify_headers.py
@@ -38,9 +38,11 @@ skip_files = [
     "qbraid/transpiler/cirq_braket/convert_from_braket.py",
     "qbraid/transpiler/cirq_braket/convert_to_braket.py",
     "qbraid/transpiler/cirq_qasm/qasm_parser.py",
+    "qbraid/transpiler/cirq_pyquil/quil_output.py",
     "tests/transpiler/cirq_braket/test_from_braket.py",
     "tests/transpiler/cirq_braket/test_to_braket.py",
     "tests/transpiler/cirq_qasm/test_qasm_parser.py",
+    "tests/transpiler/cirq_quil/test_quil_output.py",
 ]
 
 failed_headers = []

--- a/tools/verify_headers.py
+++ b/tools/verify_headers.py
@@ -42,7 +42,7 @@ skip_files = [
     "tests/transpiler/cirq_braket/test_from_braket.py",
     "tests/transpiler/cirq_braket/test_to_braket.py",
     "tests/transpiler/cirq_qasm/test_qasm_parser.py",
-    "tests/transpiler/cirq_quil/test_quil_output.py",
+    "tests/transpiler/cirq_pyquil/test_quil_output.py",
 ]
 
 failed_headers = []

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,7 @@ envdir = .tox/linters
 skip_install = true
 deps = pylint
 commands = 
-    pylint {posargs} qbraid tools --disable=C0103,E0401,R0801,R0902,R0903,R0911,R0912,R0914,W0212,W0511
+    pylint {posargs} qbraid tools tests --disable=C0103,E0401,R0801,R0902,R0903,R0911,R0912,R0914,W0212,W0511
                     
 [testenv:black]
 envdir = .tox/linters


### PR DESCRIPTION
- Addressed all errors/warnings raised from applying `pylint` checks over `tests` module
- Converted some qasm3 tests to use `pytest.mark.parametrize`
- Replaced assertion in braket ionq compiler function to raise new `CompilerError`
