### PR TITLE
Add implementation for `contiguous` compression [contd]

### DIFF
--- a/tests/interface/test_qasm3_utils.py
+++ b/tests/interface/test_qasm3_utils.py
@@ -24,7 +24,7 @@ from qiskit.qasm3 import dumps, loads
 from qbraid.interface import circuits_allclose, random_circuit
 from qbraid.interface.qbraid_qasm3.random_circuit import _qasm3_random
 from qbraid.interface.qbraid_qasm3.tools import (
-    convert_to_contiguous_qasm3,
+    _convert_to_contiguous_qasm3,
     convert_to_qasm3,
     qasm3_depth,
     qasm3_num_qubits,
@@ -134,8 +134,8 @@ c[2] = measure q[2];
     _check_output(circuit, out__expected)
 
 
-def test_convert_to_contiguous_qasm_3():
-    """Test conversion of qasm3 to contiguous qasm3"""
+def test_convert_to_expanded_contiguous_qasm_3():
+    """Test conversion of qasm3 to expanded contiguous qasm3"""
     qasm_test = """
     OPENQASM 3.0;
     gate custom q1, q2, q3{
@@ -155,7 +155,60 @@ def test_convert_to_contiguous_qasm_3():
 
     qasm_expected = qasm_test + """i q1[1];\ni q2[1];\ni q4[0];\n"""
 
-    assert convert_to_contiguous_qasm3(qasm_test) == qasm_expected
+    assert _convert_to_contiguous_qasm3(qasm_test, expansion=True) == qasm_expected
+
+
+def test_convert_to_compressed_contiguous_qasm_3():
+    """Test conversion of qasm3 to compressed contiguous qasm3"""
+    qasm_test = """
+    OPENQASM 3.0;
+    gate custom q1, q2, q3{
+        x q1;
+        y q2;
+        z q3;
+    }
+    qreg q1[2];
+    qubit[2] q2;
+    qubit[3] q3;
+    qubit q4;
+    qubit[5]   q5;
+    qreg qr[3];
+    
+    x q1[0];
+    y q2[1];
+    z q3;
+    
+    
+    qubit[3] q6;
+    
+    cx q6[1], q6[2];
+    """
+
+    qasm_expected = """
+    OPENQASM 3.0;
+    gate custom q1, q2, q3{
+        x q1;
+        y q2;
+        z q3;
+    }
+    qreg q1[1];
+    qubit[1] q2;
+    qubit[3] q3;
+    
+    
+    
+    
+    x q1[0];
+    y q2[0];
+    z q3;
+    
+    
+    qubit[2] q6;
+    
+    cx q6[0], q6[1];
+    """
+
+    assert _convert_to_contiguous_qasm3(qasm_test, expansion=False) == qasm_expected
 
 
 QASM_TEST_DATA = [


### PR DESCRIPTION
Issue : #298 
PR : [398](https://github.com/qBraid/qBraid/pull/398) [contd.]

## Changes:
Add new implementation for the `_convert_to_contiguous_qasm3` function 

## Details or comments:
- Adds a compression function `_compress_to_contiguous_qasm3` alongside the `_expand_to_contiguous_qasm3` to create a contiguous qasm3 string
- Refactored the `_convert_to_contiguous_qasm3` to use the new implementations
- Logic for compression was as discussed in the older PR, have added unit test to validate it

## Checklist before merge
Add an `x` between the boxes braket that apply, meaning to complete the check before any merge happen, feel free to ask help if you are unsure about anything.

### General 
- [x] I have read the CONTRIBUTING doc.

- [x] ALL new features must include unit test to the test directory, codecov will check for any missing test code exist.

- [x] Ensure that all the test passes.

