### PR TITLE
braket qasm3 mapped gates fix

### DIFF
--- a/qbraid/transpiler/braket/conversions_qasm.py
+++ b/qbraid/transpiler/braket/conversions_qasm.py
@@ -53,8 +53,25 @@ def qasm3_to_braket(qasm3_str: QASMType) -> Circuit:
         CircuitConversionError: If qasm to braket conversion fails
 
     """
+    replacements = {
+        "cx ": "cnot ",
+        "sdg ": "si ",
+        "tdg ": "ti ",
+        "sx ": "v ",
+        "sxdg ": "vi ",
+        "p(": "phaseshift(",
+        "cp(": "cphaseshift(",
+    }
+
+    def replace_commands(qasm, replacements):
+        for old, new in replacements.items():
+            qasm = qasm.replace(old, new)
+        return qasm
+
     qasm3_str = qasm3_str.replace('include "stdgates.inc";', "")
+    qasm3_str = replace_commands(qasm3_str, replacements)
     qasm3_str = _convert_pi_to_decimal(qasm3_str)
+
     try:
         program = OpenQasmProgram(source=qasm3_str)
         return Circuit.from_ir(source=program.source, inputs=program.inputs)

--- a/tests/transpiler/cirq_braket/test_braket_qasm3.py
+++ b/tests/transpiler/cirq_braket/test_braket_qasm3.py
@@ -12,14 +12,19 @@
 Unit tests for converting Braket circuits to/from OpenQASM
 
 """
+import numpy as np
 import pytest
+import qiskit
 from braket.circuits import Circuit
 
+from qbraid.programs import circuits_allclose
+from qbraid.transpiler.braket import qasm3_to_braket
 from qbraid.transpiler.braket.conversions_qasm import (
     _convert_pi_to_decimal,
     braket_to_qasm3,
     qasm3_to_braket,
 )
+from qbraid.transpiler.qiskit import qiskit_to_qasm3
 
 pi_decimal_data = [
     (
@@ -87,3 +92,21 @@ b[1] = measure q[1];
 """
     circuit_expected = Circuit().rx(0, 0.15).rx(1, 0.3)
     assert circuit_expected == qasm3_to_braket(qasm_str)
+
+
+def test_qiskit_to_qasm3_to_braket():
+    """Test converting Qiskit circuit to Braket via OpenQASM 3.0 for mapped gate defs"""
+    qc = qiskit.QuantumCircuit(4)
+    qc.cx(0, 1)
+    qc.s(0)
+    qc.sdg(1)
+    qc.t(2)
+    qc.tdg(3)
+    qc.sx(0)
+    qc.sxdg(1)
+    qc.p(np.pi / 8, 3)
+    qc.cp(np.pi / 4, 2, 3)
+
+    qasm3_str = qiskit_to_qasm3(qc)
+    circuit = qasm3_to_braket(qasm3_str)
+    assert circuits_allclose(qc, circuit)


### PR DESCRIPTION
qiskit and braket define various standard gates in slightly different ways in OpenQASM 3, see below. These mismatches were previously accounted for for braket $\rightarrow$ qiskit conversions, but not for qiskit $\rightarrow$ braket conversions. This PR now considers these gate def maps both directions.

**OpenQASM 3 standard gate definitions**

| Qiskit           | Amazon Braket  |
| ------------| ---------------- |
| cx | cnot | 
| sdg | si | 
| tdg | ti | 
| sx | v | 
| sxdg | vi | 
| p | phaseshift | 
| cp | cphaseshift |