### PR TITLE
patch cirq named qubit bug

### DIFF
--- a/tests/programs/test_cirq_program.py
+++ b/tests/programs/test_cirq_program.py
@@ -62,7 +62,7 @@ def test_convert_to_line_qubits():
     """Test converting a circuit of all NamedQubits to LineQubits"""
     circuit = Circuit(
         [
-            Moment(H(NamedQubit("q0"))),
+            Moment(H(NamedQubit("q"))),
         ]
     )
 

--- a/tests/programs/test_cirq_program.py
+++ b/tests/programs/test_cirq_program.py
@@ -12,7 +12,7 @@
 Unit tests for qbraid.programs.cirq.CirqCircuit
 
 """
-from cirq import Circuit, GridQubit, LineQubit, X, Y, Z
+from cirq import Circuit, GridQubit, H, LineQubit, Moment, NamedQubit, X, Y, Z
 
 from qbraid.programs.cirq import CirqCircuit
 
@@ -56,3 +56,17 @@ def test_mixed_qubit_types():
 
     expected_qubits = [LineQubit(0), LineQubit(1)]
     assert set(program.qubits) == set(expected_qubits)
+
+
+def test_convert_to_line_qubits():
+    """Test converting a circuit of all NamedQubits to LineQubits"""
+    circuit = Circuit(
+        [
+            Moment(H(NamedQubit("q0"))),
+        ]
+    )
+
+    program = CirqCircuit(circuit)
+    program._convert_to_line_qubits()
+    for qubit in program.qubits:
+        assert isinstance(qubit, LineQubit)


### PR DESCRIPTION
cirq NamedQubits without any index were failing to be parsed to int e.g. NamedQubit("q") was failing. So fixed for convert to line qubits with extra conditional and added patch in for the get int from qubit function which is naive but should work for most cases.
