### PR TITLE
Use `rx.PyDiGraph` for `ConversionGraph`

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ q_1: ┤ H ├────┤ √X ├────
 1: ───H───X^0.5────────
 ```
 
-Behind the scenes, the qBraid-SDK uses ``networkx`` to create a directional graph that maps all possible conversions between supported program types:
+Behind the scenes, the qBraid-SDK uses ``rustworkx`` to create a directional graph that maps all possible conversions between supported program types:
 
 ```python
 from qbraid.transpiler import ConversionGraph

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ exclude = '''
 [tool.pylint.'MESSAGES CONTROL']
 max-line-length = 100
 disable = "C0103, E0401, R0801, R0902, R0903, R0911, R0912, R0914, W0212, W0511"
+extension-pkg-whitelist = ["rustworkx"]
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "numpy>=1.17,<1.27",
     "openqasm3[parser]>=0.4.0,<0.6.0",
     "ply>=3.6",
-    "qbraid-core>=0.1.10,<0.1.11"
+    "qbraid-core>=0.1.10"
 ]
 requires-python = ">=3.9,<3.13"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "networkx>=2.5,<4.0",
+    "rustworkx>=0.14.2",
     "numpy>=1.17,<1.27",
     "openqasm3[parser]>=0.4.0,<0.6.0",
     "ply>=3.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "numpy>=1.17,<1.27",
     "openqasm3[parser]>=0.4.0,<0.6.0",
     "ply>=3.6",
-    "qbraid-core>=0.1.10"
+    "qbraid-core>=0.1.10,<0.1.11"
 ]
 requires-python = ">=3.9,<3.13"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics"
 ]
 dependencies = [
-    "networkx>=2.5,<4.0",
     "rustworkx>=0.14.2",
     "numpy>=1.17,<1.27",
     "openqasm3[parser]>=0.4.0,<0.6.0",

--- a/qbraid/_about.py
+++ b/qbraid/_about.py
@@ -20,7 +20,6 @@ def about() -> None:
     # pylint: disable=import-outside-toplevel
     import platform
 
-    from networkx import __version__ as networkx_version
     from numpy import __version__ as numpy_version
     from openqasm3 import __version__ as openqasm3_version
     from ply import __version__ as ply_version
@@ -30,7 +29,6 @@ def about() -> None:
 
     # Core dependencies
     core_dependencies = {
-        "networkx": networkx_version,
         "rustworkx": rustworkx_version,
         "openqasm3": openqasm3_version,
         "numpy": numpy_version,

--- a/qbraid/_about.py
+++ b/qbraid/_about.py
@@ -24,12 +24,14 @@ def about() -> None:
     from numpy import __version__ as numpy_version
     from openqasm3 import __version__ as openqasm3_version
     from ply import __version__ as ply_version
+    from rustworkx import __version__ as rustworkx_version
 
     from ._version import __version__ as qbraid_version
 
     # Core dependencies
     core_dependencies = {
         "networkx": networkx_version,
+        "rustworkx": rustworkx_version,
         "openqasm3": openqasm3_version,
         "numpy": numpy_version,
         "ply": ply_version,

--- a/qbraid/_about.py
+++ b/qbraid/_about.py
@@ -24,7 +24,7 @@ def about() -> None:
     from numpy import __version__ as numpy_version
     from openqasm3 import __version__ as openqasm3_version
     from ply import __version__ as ply_version
-    from rustworkx import __version__ as rustworkx_version
+    from rustworkx import __version__ as rustworkx_version  # pylint: disable=no-name-in-module
 
     from ._version import __version__ as qbraid_version
 

--- a/qbraid/_compat.py
+++ b/qbraid/_compat.py
@@ -36,11 +36,6 @@ def filterwarnings():
     )
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     warnings.filterwarnings("ignore", category=RuntimeWarning, module="numpy")
-    warnings.filterwarnings(
-        "ignore",
-        message="networkx backend defined more than once: nx-loopback",
-        category=RuntimeWarning,
-    )
 
 
 def check_warn_version_update():

--- a/qbraid/transforms/pytket/ionq.py
+++ b/qbraid/transforms/pytket/ionq.py
@@ -30,7 +30,7 @@ except (ModuleNotFoundError, ImportError):  # prama: no cover
         # pytket <= 1.18
         from pytket._tket.circuit._library import _TK1_to_RzRx as TK1_to_RzRx  # type: ignore
 
-from pytket.passes import RebaseCustom
+from pytket.passes import DecomposeBoxes, RebaseCustom
 from pytket.predicates import (
     CompilationUnit,
     GateSetPredicate,
@@ -118,6 +118,7 @@ def harmony_transform(circuit: "pytket.circuit.Circuit") -> "pytket.circuit.Circ
 
     """
     cu = CompilationUnit(circuit, preds)
+    DecomposeBoxes().apply(cu)
     ionq_rebase_pass.apply(cu)
     if not cu.check_all_predicates():
         raise CompilationError("Circuit cannot be compiled to IonQ Harmony.")

--- a/qbraid/transpiler/converter.py
+++ b/qbraid/transpiler/converter.py
@@ -118,12 +118,12 @@ def transpile(
     graph_type = "Default" if conversion_graph is None else "Provided"
 
     if not graph.has_node(target):
-        raise NodeNotFoundError(graph_type, target, graph.nodes)
+        raise NodeNotFoundError(graph_type, target, list(graph._node_str_to_id.keys()))
 
     source = get_program_type_alias(program)
 
     if not graph.has_node(source):
-        raise NodeNotFoundError(graph_type, source, graph.nodes)
+        raise NodeNotFoundError(graph_type, source, list(graph._node_str_to_id.keys()))
 
     if not graph.has_path(source, target):
         raise ConversionPathNotFoundError(source, target)

--- a/qbraid/transpiler/graph.py
+++ b/qbraid/transpiler/graph.py
@@ -184,7 +184,8 @@ class ConversionGraph(rx.PyDiGraph):
             target (str): The target node for the path.
 
         Returns:
-            list of Callable: The shortest conversion path as a list of bound methods of Conversion instances.
+            list of Callable: The shortest conversion path
+                              as a list of bound methods of Conversion instances.
 
         Raises:
             ValueError: If no path is found between source and target.

--- a/qbraid/transpiler/graph.py
+++ b/qbraid/transpiler/graph.py
@@ -246,8 +246,7 @@ class ConversionGraph(rx.PyDiGraph):
         """
         if source == target:
             return True  # nx.has_path returns True, but rx.has_path returns False
-        else:
-            return rx.has_path(self, self._node_str_to_id[source], self._node_str_to_id[target])
+        return rx.has_path(self, self._node_str_to_id[source], self._node_str_to_id[target])
 
     def reset(self, conversions: Optional[list[Conversion]] = None) -> None:
         """

--- a/qbraid/transpiler/graph.py
+++ b/qbraid/transpiler/graph.py
@@ -14,7 +14,7 @@ quantum programs available through the qbraid.transpiler using directed graphs.
 
 """
 from importlib import import_module
-from typing import Optional
+from typing import Callable, Optional
 
 import rustworkx as rx
 
@@ -175,7 +175,7 @@ class ConversionGraph(rx.PyDiGraph):
             if not (conv.source == source and conv.target == target)
         ]
 
-    def find_shortest_conversion_path(self, source: str, target: str) -> list[str]:
+    def find_shortest_conversion_path(self, source: str, target: str) -> list[Callable]:
         """
         Find the shortest conversion path between two nodes in a graph.
 
@@ -184,7 +184,7 @@ class ConversionGraph(rx.PyDiGraph):
             target (str): The target node for the path.
 
         Returns:
-            list of str: The shortest conversion path as a list of step strings.
+            list of Callable: The shortest conversion path as a list of bound methods of Conversion instances.
 
         Raises:
             ValueError: If no path is found between source and target.
@@ -204,7 +204,7 @@ class ConversionGraph(rx.PyDiGraph):
 
     def find_top_shortest_conversion_paths(
         self, source: str, target: str, top_n: int = 3
-    ) -> list[list[str]]:
+    ) -> list[list[Callable]]:
         """
         Find the top shortest conversion paths between two nodes in a graph.
 
@@ -214,7 +214,7 @@ class ConversionGraph(rx.PyDiGraph):
             top_n (int): Number of top shortest paths to find.
 
         Returns:
-            list of list of str: The top shortest conversion paths.
+            list of list of Callable: The top shortest conversion paths.
 
         Raises:
             ValueError: If no path is found between source and target.

--- a/qbraid/transpiler/graph.py
+++ b/qbraid/transpiler/graph.py
@@ -31,7 +31,7 @@ class ConversionGraph(rx.PyDiGraph):
 
     # avoid passing arguments to rx.PyDiGraph.__new__() when inheriting
     def __new__(cls, *args, **kwargs):
-        return super().__new__(cls)
+        return super().__new__(cls)  # pylint: disable=no-value-for-parameter
 
     def __init__(
         self, conversions: Optional[list[Conversion]] = None, require_native: bool = False
@@ -98,6 +98,16 @@ class ConversionGraph(rx.PyDiGraph):
         return node in self._node_str_to_id
 
     def has_edge(self, node_a: str, node_b: str) -> bool:
+        """
+        Check if an edge exists between two nodes in the graph.
+
+        Args:
+            node_a (str): The source node.
+            node_b (str): The target node.
+
+        Returns:
+            bool: True if the edge exists, False otherwise.
+        """
         return super().has_edge(self._node_str_to_id[node_a], self._node_str_to_id[node_b])
 
     def conversions(self) -> list[Conversion]:

--- a/qbraid/visualization/plot_conversions.py
+++ b/qbraid/visualization/plot_conversions.py
@@ -27,19 +27,16 @@ plt = LazyLoader("plt", globals(), "matplotlib.pyplot")
 
 def _convert_retworkx_to_networkx(graph: rx.PyDiGraph) -> nx.DiGraph:
     """Convert a retworkx PyDiGraph to a networkx DiGraph."""
-    if isinstance(graph, rx.PyDiGraph):
-        edge_list = [
-            (
-                graph.get_node_data(x[0]),
-                graph.get_node_data(x[1]),
-                {"native": x[2]["native"], "func": x[2]["func"]},
-            )
-            for x in graph.weighted_edge_list()
-        ]
+    edge_list = [
+        (
+            graph.get_node_data(x[0]),
+            graph.get_node_data(x[1]),
+            {"native": x[2]["native"], "func": x[2]["func"]},
+        )
+        for x in graph.weighted_edge_list()
+    ]
 
-        return nx.DiGraph(edge_list)
-    else:
-        raise ValueError("Only PyDiGraph is supported")
+    return nx.DiGraph(edge_list)
 
 
 def plot_conversion_graph(  # pylint: disable=too-many-arguments
@@ -103,11 +100,12 @@ def plot_conversion_graph(  # pylint: disable=too-many-arguments
     ecolors = [
         (
             colors["qbraid_edge"]
-            if graph[edge.source][edge.target]["native"]
+            if graph.get_edge_data(edge.source, edge.target)["native"]
             else colors["extras_edge"] if len(edge._extras) > 0 else colors["external_edge"]
         )
         for edge in conversions_ordered
     ]
+    print(ecolors)
 
     graph = _convert_retworkx_to_networkx(graph)
     pos = nx.spring_layout(graph, seed=seed)  # good seeds: 123, 134

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-networkx>=3.2.1,<3.4.0
 rustworkx>=0.14.2
 numpy>=1.17,<1.27
 openqasm3[parser]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 networkx>=3.2.1,<3.4.0
+rustworkx>=0.14.2
 numpy>=1.17,<1.27
 openqasm3[parser]
 ply>=3.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ rustworkx>=0.14.2
 numpy>=1.17,<1.27
 openqasm3[parser]
 ply>=3.6
-qbraid-core>=0.1.10,<0.1.11
+qbraid-core>=0.1.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ rustworkx>=0.14.2
 numpy>=1.17,<1.27
 openqasm3[parser]
 ply>=3.6
-qbraid-core>=0.1.10
+qbraid-core>=0.1.10,<0.1.11

--- a/tests/top_level/test_about.py
+++ b/tests/top_level/test_about.py
@@ -38,6 +38,7 @@ def test_about():
     # Verify core dependencies are mentioned in the output
     assert "Core Dependencies" in output
     assert "networkx:" in output
+    assert "rustworkx:" in output
     assert "numpy:" in output
     assert "openqasm3:" in output
     assert "ply:" in output

--- a/tests/top_level/test_about.py
+++ b/tests/top_level/test_about.py
@@ -37,7 +37,6 @@ def test_about():
 
     # Verify core dependencies are mentioned in the output
     assert "Core Dependencies" in output
-    assert "networkx:" in output
     assert "rustworkx:" in output
     assert "numpy:" in output
     assert "openqasm3:" in output

--- a/tests/transpiler/test_conversion_grah.py
+++ b/tests/transpiler/test_conversion_grah.py
@@ -14,8 +14,8 @@ used to dictate transpiler conversions.
 
 """
 import braket.circuits
-import networkx as nx
 import pytest
+import rustworkx as rx
 from qbraid_core._import import LazyLoader
 
 from qbraid.programs.registry import QPROGRAM_ALIASES
@@ -32,7 +32,7 @@ def bound_method_str(source, target):
     return f"<bound method Conversion.convert of ('{source}', '{target}')>"
 
 
-def are_graphs_equal(graph1: nx.DiGraph, graph2: nx.DiGraph) -> bool:
+def are_graphs_equal(graph1: rx.PyDiGraph, graph2: rx.PyDiGraph) -> bool:
     """Return True if two graphs are equal, False otherwise."""
     # Check if nodes are the same
     if set(graph1.nodes) != set(graph2.nodes):

--- a/tests/transpiler/test_converter.py
+++ b/tests/transpiler/test_converter.py
@@ -32,7 +32,9 @@ def test_get_path_from_bound_method():
     source, target = "cirq", "qasm2"
     edge = Conversion(source, target, lambda x: x)
     graph = ConversionGraph([edge])
-    bound_method = graph[source][target]["func"]
+    bound_method = graph.get_edge_data(
+        graph._node_str_to_id[source], graph._node_str_to_id[target]
+    )["func"]
     bound_method_list = [bound_method]
     path = _get_path_from_bound_methods(bound_method_list)
     assert path == "cirq -> qasm2"

--- a/tools/set_provider_configs.py
+++ b/tools/set_provider_configs.py
@@ -49,5 +49,4 @@ def ibm_configure(
 
 
 if __name__ == "__main__":
-    if not skip_remote_tests:
-        aws_configure()
+    aws_configure()

--- a/tox.ini
+++ b/tox.ini
@@ -13,10 +13,14 @@ basepython = python3
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements-dev.txt
+pass_env =
+    AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY
 
 [testenv:unit-tests]
 description = Run pytests and generate coverage report.
 commands =
+    python3 tools/set_provider_configs.py
     coverage run -m pytest -x tests/programs \
                               tests/transpiler \
                               tests/transforms \

--- a/tox.ini
+++ b/tox.ini
@@ -48,28 +48,28 @@ commands =
 envdir = .tox/linters
 skip_install = true
 deps = isort
-commands = 
+commands =
     isort . {posargs} qbraid tools tests
 
 [testenv:pylint]
 envdir = .tox/linters
 skip_install = true
 deps = pylint
-commands = 
-    pylint {posargs} qbraid tools tests --disable=C0103,E0401,R0801,R0902,R0903,R0911,R0912,R0914,W0212,W0511
-                    
+commands =
+    pylint {posargs} qbraid tools tests --disable=C0103,E0401,R0801,R0902,R0903,R0911,R0912,R0914,W0212,W0511 --extension-pkg-whitelist=rustworkx
+
 [testenv:black]
 envdir = .tox/linters
 skip_install = true
 deps = black
-commands = 
+commands =
     black qbraid tools tests --exclude /(tests/transpiler/cirq/test_qasm_parser.py)/ {posargs}
 
 [testenv:headers]
 envdir = .tox/linters
 skip_install = true
 deps = qbraid-cli
-commands = 
+commands =
     qbraid admin headers tests tools qbraid --type=gpl {posargs}
 
 [testenv:linters]

--- a/tox.ini
+++ b/tox.ini
@@ -13,15 +13,10 @@ basepython = python3
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements-dev.txt
-pass_env =
-    AWS_ACCESS_KEY_ID
-    AWS_SECRET_ACCESS_KEY
-    QBRAID_RUN_REMOTE_TESTS
 
 [testenv:unit-tests]
 description = Run pytests and generate coverage report.
 commands =
-    python3 tools/set_provider_configs.py
     coverage run -m pytest -x tests/programs \
                               tests/transpiler \
                               tests/transforms \
@@ -33,7 +28,7 @@ commands =
                            -W ignore::urllib3.exceptions.InsecureRequestWarning \
                            -W ignore::RuntimeWarning
     coverage combine
-    coverage report --omit=qbraid/visualization/draw_circuit.py,qbraid/visualization/plot_conversions.py,qbraid/_compat.py,qbraid/transpiler/conversions/qasm2/qasm2_extras.py,qbraid/runtime/ionq/*
+    coverage report --omit=qbraid/runtime/braket/tracker.py,qbraid/visualization/draw_circuit.py,qbraid/visualization/plot_conversions.py,qbraid/_compat.py,qbraid/transpiler/conversions/qasm2/qasm2_extras.py,qbraid/runtime/ionq/*
     coverage html
     coverage xml
 


### PR DESCRIPTION
<!-- Please link or tag any issues that is PR closes -->

# Changes
- Resolve #618

## Details or comments
- `networkx` is removed from requirements
- I added `rustworkx` to a pylint whitelist to disable `no-member` error
- I added `DecomposeBoxes` pass in `harmony_transform()` because `RebaseCustom` pass cannot handle gates like `ECR`, `GPi`, etc. when converting braket circuit to pytket circuit at `test_pytket_ionq.py`. (The reason the error did not occur before seems to be that `rustworkx` returns the top shortest conversion paths in a different order than `networkx`. For the record, if `networkx` is used than the conversion path is `['braket', 'cirq', 'qasm2', 'pytket']`, but if we use `rustworkx` it becomes `['braket', 'qiskit', 'qasm2', 'pytket']`)

(I am contributing to this project as a unitaryHACK participant)

## Before You Merge

Please review the checklist below and mark items with an `x` in the brackets that apply. Remember, it's perfectly fine
to submit a draft pull request if you're still working through some items on the checklist. We're here to help!

### General

- [x] I have read `CONTRIBUTING.md`.
- [x] All new code includes corresponding unit tests and satisfies codecov.
- [x] API Reference docstrings and/or User Guide have been updated to account for new features.
- [x] All integration tests, including remote tests, are passing.
