### PR TITLE
conversion graph weighting fix

### DIFF
--- a/qbraid/transpiler/edge.py
+++ b/qbraid/transpiler/edge.py
@@ -16,6 +16,8 @@ import importlib
 import inspect
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
+import numpy as np
+
 from qbraid.programs import QPROGRAM_REGISTRY, get_program_type_alias
 
 if TYPE_CHECKING:
@@ -51,7 +53,7 @@ class Conversion:
         self._weight = weight if weight is not None else default_weight
         if not 0 <= self._weight <= 1:
             raise ValueError("Weight must be a float between 0 and 1, inclusive.")
-        self._weight = 1 / max(self._weight, 1e-10)
+        self._weight = float("inf") if self._weight == 0 else np.log(1 / self._weight)
 
     @property
     def source(self) -> str:

--- a/tests/transpiler/test_conversion_edge.py
+++ b/tests/transpiler/test_conversion_edge.py
@@ -145,7 +145,9 @@ def test_invalid_weight(mock_conversion_func, invalid_weight):
         Conversion("source_pkg", "target_pkg", mock_conversion_func, weight=invalid_weight)
 
 
-@pytest.mark.parametrize("valid_weight,expected_value", [(0.8, np.log(1.25)), (None, np.log(2)), (0, float("inf"))])
+@pytest.mark.parametrize(
+    "valid_weight,expected_value", [(0.8, np.log(1.25)), (None, np.log(2)), (0, float("inf"))]
+)
 def test_valid_weight(mock_conversion_func, valid_weight, expected_value):
     """Test the default weight from the conversion function if not specified."""
     conversion = Conversion("source_pkg", "target_pkg", mock_conversion_func, weight=valid_weight)

--- a/tests/transpiler/test_conversion_edge.py
+++ b/tests/transpiler/test_conversion_edge.py
@@ -17,6 +17,7 @@ Unit tests for defining custom conversions
 from unittest.mock import Mock
 
 import cirq
+import numpy as np
 import pytest
 
 from qbraid.interface.random import random_circuit
@@ -144,7 +145,7 @@ def test_invalid_weight(mock_conversion_func, invalid_weight):
         Conversion("source_pkg", "target_pkg", mock_conversion_func, weight=invalid_weight)
 
 
-@pytest.mark.parametrize("valid_weight,expected_value", [(0.8, 1.25), (None, 2), (0, 1e10)])
+@pytest.mark.parametrize("valid_weight,expected_value", [(0.8, np.log(1.25)), (None, np.log(2)), (0, float("inf"))])
 def test_valid_weight(mock_conversion_func, valid_weight, expected_value):
     """Test the default weight from the conversion function if not specified."""
     conversion = Conversion("source_pkg", "target_pkg", mock_conversion_func, weight=valid_weight)
@@ -158,7 +159,7 @@ def test_weight_without_specified_and_no_default():
         pass  # No weight attribute
 
     conversion = Conversion("source_pkg", "target_pkg", simple_conversion_func)
-    assert conversion.weight == 1
+    assert conversion.weight == 0
 
 
 class TestConversionEquality:


### PR DESCRIPTION
made a small mistake; 

current deployment uses weights $w = \dfrac{1}{a}$ where $a \in [0, 1.0]$ is the accuracy of the conversion. this is incorrect:

consider two paths from $A \to C$: $A \to B_1 \to C$ and $A\to B_2 \to C$. let the first path have accuracies of $\dfrac 14$ and $\dfrac 16$ whereas the two conversions in the second half both have accuracy $\dfrac 15$.  that is, the weights are 4, 6 and 5, 5 respectively.  the current implementation will consider these paths the same weight, as they both sum to 10. however, $\dfrac{1}{24} > \dfrac{1}{25}$, so we would want to prefer the first path over the second.

the fix just takes the logarithms of the current weight. this works because:
1. djikstra's is an algorithm that finds the minimum ***sum*** of edge weights
2. $\log$ is an increasing function