### PR TITLE
fix oqc provider json decoding error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,4 @@ Types of changes:
 
 ### Fixed
 - qiskit runtime job is terminal state check bug ([#735](https://github.com/qBraid/qBraid/pull/735))
+- OQC provider get_devices and device status method bugs. Fixed by adding json decoding step ([#738](https://github.com/qBraid/qBraid/pull/738))

--- a/qbraid/runtime/ionq/provider.py
+++ b/qbraid/runtime/ionq/provider.py
@@ -89,7 +89,6 @@ class IonQProvider(QuantumProvider):
         """Build a profile for an IonQ device."""
         device_id = data.get("backend")
         simulator = device_id == "simulator"
-        print(device_id, simulator)
 
         return TargetProfile(
             device_id=device_id,

--- a/qbraid/runtime/oqc/device.py
+++ b/qbraid/runtime/oqc/device.py
@@ -15,6 +15,7 @@ Device class for OQC devices.
 from __future__ import annotations
 
 import datetime
+import json
 from typing import TYPE_CHECKING, Union
 
 from qcaas_client.client import QPUTask
@@ -80,16 +81,18 @@ class OQCDevice(QuantumDevice):
         self._client = client
 
     @property
-    def client(self) -> "qcaas_client.client.OQCClient":
+    def client(self) -> qcaas_client.client.OQCClient:
         """Returns the client for the device."""
         return self._client
 
     def status(self) -> DeviceStatus:
         """Returns the status of the device."""
-        devices = self._client.get_qpus()
+        devices: list[dict] = self._client.get_qpus()
         for device in devices:
             if device["id"] == self.id:
-                if device["feature_set"]["always_on"]:
+                feature_set = device.get("feature_set", "{}")
+                feature_set_data = json.loads(feature_set)
+                if feature_set_data["always_on"]:
                     return DeviceStatus.ONLINE
                 now = datetime.datetime.now()
                 start_time = self._client.get_next_window()

--- a/tests/runtime/test_oqc_runtime.py
+++ b/tests/runtime/test_oqc_runtime.py
@@ -15,6 +15,7 @@ Unit tests for OQCProvider class
 
 """
 import datetime
+import json
 import logging
 from unittest.mock import Mock, patch
 
@@ -54,7 +55,7 @@ def lucy_simulator_data():
     """Return data for Lucy Simulator."""
     return {
         "active": True,
-        "feature_set": {"always_on": True, "qubit_count": 8, "simulator": True},
+        "feature_set": json.dumps({"always_on": True, "qubit_count": 8, "simulator": True}),
         "generation": 2,
         "id": "qpu:uk:2:d865b5a184",
         "name": "Lucy Simulator",
@@ -191,7 +192,9 @@ def test_oqc_provider_device(lucy_simulator_data):
         with pytest.raises(ResourceNotFoundError):
             provider.get_device("fake_id")
         assert isinstance(test_device.client, OQCClient)
-        lucy_simulator_data["feature_set"]["always_on"] = False
+        lucy_simulator_data["feature_set"] = json.dumps(
+            {"always_on": False, "qubit_count": 8, "simulator": True}
+        )
         now = datetime.datetime.now()
         year, month, day = now.year, now.month, now.day
         window = f"{year + 1}-{month}-{day} 00:50:00"
@@ -215,6 +218,18 @@ def test_oqc_provider_device(lucy_simulator_data):
         mock_client.return_value.get_next_window.return_value = window
         always_on_false_available_device = provider.get_device(DEVICE_ID)
         assert always_on_false_available_device.status() == DeviceStatus.ONLINE
+
+
+def test_oqc_provider_get_device_raises(lucy_simulator_data):
+    """Test OQC provider get device method raises exception for invalid json data."""
+    with patch("qbraid.runtime.oqc.provider.OQCClient") as mock_client:
+        mock_client.return_value = Mock(spec=OQCClient)
+        invalid_lucy_simulator_data = lucy_simulator_data.copy()
+        invalid_lucy_simulator_data["feature_set"] = ""
+        mock_client.return_value.get_qpus.return_value = [invalid_lucy_simulator_data]
+        provider = OQCProvider(token="fake_token")
+        with pytest.raises(ValueError):
+            provider.get_device(DEVICE_ID)
 
 
 def test_build_runtime_profile(lucy_simulator_data):


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

- In data returned from OQC client, 'feature_set' was assumed to be json format, but in reality was encoded as string. This caused caused errors both with provider get_devices and device status methods which are both now fixed.
