### PR TITLE
Improve support for gates in `qasm2_to_ionq` conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,30 @@ result = job.result()
 print(f"device_id: {result.device_id}, job_id: {result.job_id}, success: {result.success}")
 print(result.data.measurements)  # List of AhsShotResult instances
 ```
+- Improved the `qbraid.transpiler.conversions.qasm2.qasm2_to_ionq` method by adding support for registers in quantum gate arguments. See example below - ([#771](https://github.com/qBraid/qBraid/pull/771))
+
+```python
+from qbraid.transpiler.conversions.qasm2 import qasm2_to_ionq
+
+qasm_str = """
+OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[3];
+x q[0];
+y q;
+"""
+
+print(qasm2_to_ionq(qasm_str))
+```
+
+outputs - 
+
+```python
+{'qubits': 3, 'circuit': [{'gate': 'x', 'target': 0}, 
+                          {'gate': 'y', 'target': 0}, 
+                          {'gate': 'y', 'target': 1}, 
+                          {'gate': 'y', 'target': 2}]}
+```
 
 ### Deprecated
 - `result.measurement_counts()` method(s) from result objects retured by `qbraid.runtime.QuantumJob.result()`. Intead, for gate model jobs, measurement counts dictionary now accessible via `result.data.get_counts()`. ([#756](https://github.com/qBraid/qBraid/pull/756))

--- a/qbraid/transpiler/conversions/qasm2/qasm2_to_ionq.py
+++ b/qbraid/transpiler/conversions/qasm2/qasm2_to_ionq.py
@@ -26,13 +26,46 @@ from qbraid.transpiler.annotations import weight
 if TYPE_CHECKING:
     from qbraid.programs.typer import IonQDictType, Qasm2StringType
 
+IONQ_ONE_QUBIT_GATE_MAP = {
+    "x": "x",
+    "not": "not",
+    "y": "y",
+    "z": "z",
+    "h": "h",
+    "s": "s",
+    "si": "si",
+    "t": "t",
+    "ti": "ti",
+    "v": "v",
+    "vi": "vi",
+    "sdg": "si",
+    "tdg": "ti",
+    "sx": "v",
+    "sxdg": "vi",
+    "rx": "rx",
+    "ry": "ry",
+    "rz": "rz",
+}
+
+IONQ_TWO_QUBIT_GATE_MAP = {
+    "cnot": "cnot",
+    "cx": "cnot",
+    "CX": "cnot",
+    "swap": "swap",
+}
+
+IONQ_THREE_QUBIT_GATE_MAP = {
+    "ccx": "cnot",
+    "toffoli": "cnot",
+}
+
 
 @weight(1)
 def qasm2_to_ionq(qasm: Qasm2StringType) -> IonQDictType:
     """Returns an IonQ JSON format representation the input OpenQASM 2 string.
 
     Args:
-        qasm (str): OpenQASM 2 string to convert to a pytket circuit.
+        qasm (str): OpenQASM 2 string to convert to IonQDict type
 
     Returns:
         dict: IonQ JSON format equivalent to input OpenQASM 2 string.
@@ -40,6 +73,7 @@ def qasm2_to_ionq(qasm: Qasm2StringType) -> IonQDictType:
 
     qprogram = OpenQasm2Program(qasm)
     num_qubits = qprogram.num_qubits
+    program_qubits = qprogram.qubits
 
     program = qprogram.parsed()
 
@@ -51,60 +85,57 @@ def qasm2_to_ionq(qasm: Qasm2StringType) -> IonQDictType:
             qubits = statement.qubits
             qubit_values = []
 
-            for qubit in qubits:
-                _ = qubit.name.name
-                indices = qubit.indices
-                for index in indices:
-                    qubit_values.extend(literal.value for literal in index)
+            if len(qubits) == 1 and isinstance(qubits[0], openqasm3.ast.Identifier):
+                # full register reference here
+                reg_name = qubits[0].name
+                for qreg_name, qubit_id in program_qubits:
+                    if qreg_name == reg_name:
+                        qubit_values.append(qubit_id)
+            else:
+                for qubit in qubits:
+                    indices = qubit.indices
+                    for index in indices:
+                        qubit_values.extend(literal.value for literal in index)
 
-            # support gates defined in `stdgates.inc` from OpenQASM 3
-            if len(qubit_values) == 1:
-                # IonQ supported gates:
-                if name in ["x", "not", "y", "z", "h", "s", "si", "t", "ti", "v", "vi"]:
-                    gate_data = {"gate": name, "target": qubit_values[0]}
-                elif name in ["rx", "ry", "rz"]:
+            # support gates defined for IonQ JSON format
+            if name in IONQ_ONE_QUBIT_GATE_MAP:
+                ionq_name = IONQ_ONE_QUBIT_GATE_MAP[name]
+                if ionq_name in ["rx", "ry", "rz"]:
                     # convert "rz(3 * pi / 4) q[0];" to "3 * pi / 4"
                     angle_str = re.findall(r"\((.+)\)", openqasm3.dumps(statement))[0]
-                    gate_data = {
-                        "gate": name,
-                        "target": qubit_values[0],
-                        "rotation": float(convert_qasm_pi_to_decimal(angle_str)),
-                    }
-                # OpenQASM 3 aliases:
-                elif name == "sdg":
-                    gate_data = {"gate": "si", "target": qubit_values[0]}
-                elif name == "tdg":
-                    gate_data = {"gate": "ti", "target": qubit_values[0]}
-                elif name == "sx":
-                    gate_data = {"gate": "v", "target": qubit_values[0]}
-                elif name == "sxdg":
-                    gate_data = {"gate": "vi", "target": qubit_values[0]}
+                    for qubit in qubit_values:
+                        gates.append(
+                            {
+                                "gate": ionq_name,
+                                "target": qubit,
+                                "rotation": float(convert_qasm_pi_to_decimal(angle_str)),
+                            }
+                        )
                 else:
-                    raise NotImplementedError(f"'{name}' gate not yet supported")
-            elif len(qubit_values) == 2:
-                if name in ["cnot", "cx", "CX"]:
-                    gate_data = {
-                        "gate": "cnot",
-                        "control": qubit_values[0],
-                        "target": qubit_values[1],
-                    }
-                elif name == "swap":
-                    gate_data = {
-                        "gate": "swap",
-                        "targets": qubit_values,
-                    }
+                    for qubit in qubit_values:
+                        gates.append({"gate": ionq_name, "target": qubit})
+
+            elif name in IONQ_TWO_QUBIT_GATE_MAP:
+                ionq_name = IONQ_TWO_QUBIT_GATE_MAP[name]
+                if ionq_name == "swap":
+                    gates.append({"gate": ionq_name, "targets": qubit_values})
                 else:
-                    raise NotImplementedError(f"'{name}' gate not yet supported")
-            elif len(qubit_values) == 3:
-                if name in ["ccx", "toffoli"]:
-                    gate_data = {
-                        "gate": "cnot",
+                    gates.append(
+                        {
+                            "gate": ionq_name,
+                            "control": qubit_values[0],
+                            "target": qubit_values[1],
+                        }
+                    )
+            elif name in IONQ_THREE_QUBIT_GATE_MAP:
+                gates.append(
+                    {
+                        "gate": IONQ_THREE_QUBIT_GATE_MAP[name],
                         "controls": qubit_values[:2],
                         "target": qubit_values[2],
                     }
+                )
             else:
                 raise NotImplementedError(f"'{name}' gate not yet supported")
-
-            gates.append(gate_data)
 
     return {"qubits": num_qubits, "circuit": gates}

--- a/qbraid/transpiler/conversions/qasm2/qasm2_to_ionq.py
+++ b/qbraid/transpiler/conversions/qasm2/qasm2_to_ionq.py
@@ -65,7 +65,7 @@ def qasm2_to_ionq(qasm: Qasm2StringType) -> IonQDictType:
     """Returns an IonQ JSON format representation the input OpenQASM 2 string.
 
     Args:
-        qasm (str): OpenQASM 2 string to convert to IonQDict type
+        qasm (str): OpenQASM 2 string to convert to IonQDict type.
 
     Returns:
         dict: IonQ JSON format equivalent to input OpenQASM 2 string.

--- a/tests/programs/test_program_circuits_qasm2.py
+++ b/tests/programs/test_program_circuits_qasm2.py
@@ -38,8 +38,8 @@ from ..fixtures.qasm2.circuits import (
 def test_qasm_qubits():
     """Test getting QASM qubits"""
 
-    assert OpenQasm2Program(qasm2_bell()).qubits == ["q[0]", "q[1]"]
-    assert OpenQasm2Program(qasm2_shared15()).qubits == ["q[0]", "q[1]", "q[2]", "q[3]"]
+    assert OpenQasm2Program(qasm2_bell()).qubits == [("q", 0), ("q", 1)]
+    assert OpenQasm2Program(qasm2_shared15()).qubits == [("q", 0), ("q", 1), ("q", 2), ("q", 3)]
 
 
 def test_qasm_num_qubits():

--- a/tests/transpiler/qasm/test_qasm2_to_ionq.py
+++ b/tests/transpiler/qasm/test_qasm2_to_ionq.py
@@ -24,11 +24,12 @@ def test_ionq_device_extract_gate_data():
     x q[0];
     not q[1];
     y q[0];
-    z q[0];
+    z q[0], q[1];
     rx(pi / 4) q[0];
     ry(pi / 2) q[0];
     rz(3 * pi / 4) q[0];
     h q[0];
+    h q;
     cx q[0], q[1];
     CX q[1], q[2];
     cnot q[2], q[0];
@@ -52,10 +53,13 @@ def test_ionq_device_extract_gate_data():
         {"gate": "not", "target": 1},
         {"gate": "y", "target": 0},
         {"gate": "z", "target": 0},
+        {"gate": "z", "target": 1},
         {"gate": "rx", "target": 0, "rotation": 0.7853981633974483},
         {"gate": "ry", "target": 0, "rotation": 1.5707963267948966},
         {"gate": "rz", "target": 0, "rotation": 2.356194490192345},
         {"gate": "h", "target": 0},
+        {"gate": "h", "target": 0},
+        {"gate": "h", "target": 1},
         {"gate": "cnot", "control": 0, "target": 1},
         {"gate": "cnot", "control": 1, "target": 2},
         {"gate": "cnot", "control": 2, "target": 0},


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->
Fixes #769 
## Summary of changes
- Update the `qasm2_to_ionq` conversion to include full registers being applied as quantum gate arguments 
- Moreover, the number of qubits used in gate application is not reflective of the number of qubits on which a gate acts on. Eg. `h q[0], q[1];` means `h` is being applied on 2 qubits but is itself a 1-qubit gate. Updated the logic to identify this based on gate name instead of actual qubit arguments.
- Some other updates for representing the bits of qasm programs for easier handling 