### PR TITLE
fix gpi qasm gate pi decimal bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Types of changes:
 
 ### Fixed
 - Fixed native runtime bug: failure to raise exception if `qbraid-qir` not installed for "qbraid_qir_simulator" device. Now warns at provider level and raises in run method if transform fails ([#801](https://github.com/qBraid/qBraid/pull/801))
+- Fixed bug in `qbraid.passes.qasm.convert_qasm_pi_to_decimal()` where `gpi` and `gpi2` gate defs were being subbed with pi decimal value. Fix is not perfect but will work for most cases. ([#810](https://github.com/qBraid/qBraid/pull/810))
 
 ### Dependencies
 - Added `pyqasm` as optional dependency extra for IonQ ([#807](https://github.com/qBraid/qBraid/pull/807))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Types of changes:
 
 ### Dependencies
 
-## [0.8.4] - 2024-10-28
+## [0.8.4] - 2024-10-29
 
 ### Added
 - Added support for [IonQ native gates](https://docs.ionq.com/guides/getting-started-with-native-gates) (gpi/gpi2/ms/zz) for `qasmX_to_ionq()` conversions ([#807](https://github.com/qBraid/qBraid/pull/807))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ Types of changes:
 
 ### Fixed
 - Fixed native runtime bug: failure to raise exception if `qbraid-qir` not installed for "qbraid_qir_simulator" device. Now warns at provider level and raises in run method if transform fails ([#801](https://github.com/qBraid/qBraid/pull/801))
-- Fixed bug in `qbraid.passes.qasm.convert_qasm_pi_to_decimal()` where `gpi` and `gpi2` gate defs were being subbed with pi decimal value. Fix is not perfect but will work for most cases. ([#810](https://github.com/qBraid/qBraid/pull/810))
+- Fixed bug in `qbraid.passes.qasm.convert_qasm_pi_to_decimal()` where `gpi` and `gpi2` gate defs were being subbed with pi decimal value. Fix is not perfect but will work for most cases. ([#812](https://github.com/qBraid/qBraid/pull/812))
 
 ### Dependencies
 - Added `pyqasm` as optional dependency extra for IonQ ([#807](https://github.com/qBraid/qBraid/pull/807))

--- a/tests/passes/test_qasm3_compat.py
+++ b/tests/passes/test_qasm3_compat.py
@@ -265,3 +265,59 @@ def test_convert_qasm_pi_to_decimal_omits_gpi_gate():
     cry(3.141592653589793) q[0], q[1];
     """
     assert convert_qasm_pi_to_decimal(qasm) == expected
+
+
+@pytest.mark.skip(reason="Not yet implemented")
+def test_convert_qasm_pi_to_decimal_qasm3_fns_gates_vars():
+    """Test converting pi symbol to decimal in a qasm3 string
+    with custom functions, gates, and variables."""
+    qasm = """
+    OPENQASM 3;
+    include "stdgates.inc";
+
+    gate pipe q {
+        gpi(0) q;
+        gpi2(pi/8) q;
+    }
+
+    const int[32] primeN = 3;
+    const float[32] c = primeN*pi/4;
+    qubit[3] q;
+
+    def spiral(qubit[primeN] q_func) {
+    for int i in [0:primeN-1] { pipe q_func[i]; }
+    }
+
+    spiral(q);
+
+    ry(c) q[0];
+
+    bit[3] result;
+    result = measure q;
+    """
+
+    expected = """
+    OPENQASM 3;
+    include "stdgates.inc";
+
+    gate pipe q {
+        gpi(0) q;
+        gpi2(0.39269908169872414) q;
+    }
+
+    const int[32] primeN = 3;
+    const float[32] c = primeN*0.7853981633974483;
+    qubit[3] q;
+
+    def spiral(qubit[primeN] q_func) {
+    for int i in [0:primeN-1] { pipe q_func[i]; }
+    }
+
+    spiral(q);
+
+    ry(c) q[0];
+
+    bit[3] result;
+    result = measure q;
+    """
+    assert convert_qasm_pi_to_decimal(qasm) == expected

--- a/tests/passes/test_qasm3_compat.py
+++ b/tests/passes/test_qasm3_compat.py
@@ -19,6 +19,7 @@ import pytest
 from qbraid.passes.qasm.compat import (
     _evaluate_expression,
     add_stdgates_include,
+    convert_qasm_pi_to_decimal,
     has_redundant_parentheses,
     insert_gate_def,
     normalize_qasm_gate_params,
@@ -242,3 +243,25 @@ def test_evaluate_expression_error():
     match = re.search(r"\(([0-9+\-*/. ]+)\)", qasm_str)
 
     assert _evaluate_expression(match) == "(1*)"
+
+
+def test_convert_qasm_pi_to_decimal_omits_gpi_gate():
+    """Test converting pi symbol to decimal in qasm string with gpi and gpi2 gates."""
+    qasm = """
+    OPENQASM 2.0;
+    include "qelib1.inc";
+    qreg q[2];
+    gpi(0) q[0];
+    gpi2(0) q[1];
+    cry(pi) q[0], q[1];
+    """
+
+    expected = """
+    OPENQASM 2.0;
+    include "qelib1.inc";
+    qreg q[2];
+    gpi(0) q[0];
+    gpi2(0) q[1];
+    cry(3.141592653589793) q[0], q[1];
+    """
+    assert convert_qasm_pi_to_decimal(qasm) == expected


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

- Fixed bug in `qbraid.passes.qasm.convert_qasm_pi_to_decimal()` where `gpi` and `gpi2` gate defs were being subbed with pi decimal value. Fix is not perfect but will work for most cases.
