### PR TITLE
Annealing program types updates for nec vector annealer jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,31 @@ Types of changes:
 ## [Unreleased]
 
 ### Added
+- Registered "qubo" coefficients program type under `qbraid.programs.typer.QuboCoefficientsDict` ([#820](https://github.com/qBraid/qBraid/pull/820))
 
 ### Improved / Modified
 - Separated runtime device `transform` and `to_ir` logic into separate steps ([#819](https://github.com/qBraid/qBraid/pull/819))
 - Updated runtime validation step to handle program batches and not re-warn for device-related checks ([#819](https://github.com/qBraid/qBraid/pull/819))
 - Updated runtime device transpile method and target profile to allow for lists of `ProgramSpec` ([#819](https://github.com/qBraid/qBraid/pull/819))
+- Updated native runtime logic for NEC vector annealer to support "qubo" program spec type. Offset argument / attribute removed from `qbraid.programs.annealing.Problem`. `QbraidDevice.run` flow now derives "offset" paramater from `params` argument (of type `QuboSolveParams`, now required). This allows a more straightfoward procedure (with more visiblity) when submitting programs from  `pyqubo.Module`. See code example below. ([#820](https://github.com/qBraid/qBraid/pull/820))
+
+```python
+from qbraid import QbraidProvider
+from qbraid.runtime.schemas import QuboSolveParams
+
+s1, s2, s3, s4 = [pyqubo.Spin(f"s{i}") for i in range(1, 5)]
+H = (4 * s1 + 2 * s2 + 7 * s3 + s4) ** 2
+model = H.compile()
+qubo, offset = model.to_qubo()
+
+params = QuboSolveParams(offset=offset)
+
+provider = QbraidProvider()
+
+device = provider.get_device("nec_vector_annealer")
+
+job = device.run(qubo, params=params)
+```
 
 ### Deprecated
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ lint = ["black", "isort", "pylint", "qbraid-cli>=0.8.7"]
 docs = ["sphinx>=7.2,<8.2", "sphinx-autodoc-typehints>=1.24,<2.6", "sphinx-rtd-theme>=1.3,<3.1", "docutils<0.22", "sphinx-copybutton"]
 
 [project.entry-points."qbraid.programs"]
+qubo = "qbraid.programs.annealing.qubo:QuboProgram"
 cpp_pyqubo = "qbraid.programs.annealing.cpp_pyqubo:PyQuboModel"
 braket_ahs = "qbraid.programs.ahs.braket_ahs:BraketAHS"
 braket = "qbraid.programs.gate_model.braket:BraketCircuit"

--- a/qbraid/programs/_import.py
+++ b/qbraid/programs/_import.py
@@ -21,7 +21,7 @@ from importlib import import_module
 from types import ModuleType
 from typing import Any, Type
 
-from .typer import IonQDict
+from .typer import BOUND_QBRAID_META_TYPES, QBRAID_META_TYPES
 
 
 def _assign_default_type_alias(imported: dict[str, Any], program_type: Type[Any]) -> str:
@@ -120,9 +120,16 @@ dynamic_type_registry: dict[str, Type[Any]] = _dynamic_importer(
     ]
 )
 dynamic_non_native: dict[str, Type[Any]] = _dynamic_importer(["bloqade.builder.assign"])
-static_type_registry: dict[str, Type[Any]] = {"qasm2": str, "qasm3": str, "ionq": IonQDict}
+static_type_registry: dict[str, Type[Any]] = {
+    metatype.__alias__: metatype.__bound__ for metatype in BOUND_QBRAID_META_TYPES
+}
+qbraid_meta_type_registry: dict[str, Type[Any]] = {
+    metatype.__alias__: metatype for metatype in QBRAID_META_TYPES
+}
 
-NATIVE_REGISTRY: dict[str, Type[Any]] = dynamic_type_registry | static_type_registry
+NATIVE_REGISTRY: dict[str, Type[Any]] = (
+    dynamic_type_registry | static_type_registry | qbraid_meta_type_registry
+)
 _QPROGRAM_REGISTRY: dict[str, Type[Any]] = deepcopy(NATIVE_REGISTRY) | dynamic_non_native
 _QPROGRAM_TYPES: set[Type[Any]] = set(_QPROGRAM_REGISTRY.values())
 _QPROGRAM_ALIASES: set[str] = set(_QPROGRAM_REGISTRY.keys())

--- a/qbraid/programs/ahs/_model.py
+++ b/qbraid/programs/ahs/_model.py
@@ -12,6 +12,8 @@
 Module defining AnalogHamiltonianProgram Class
 
 """
+from __future__ import annotations
+
 import json
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
@@ -45,9 +47,9 @@ class AnalogHamiltonianProgram(QuantumProgram, ABC):
         """Number of qubits needed by a quantum device to execute this program."""
         return self.num_atoms
 
-    def transform(self, device: "qbraid.runtime.QuantumDevice") -> None:
+    def transform(self, device: qbraid.runtime.QuantumDevice) -> None:
         """Transform program to according to device target profile."""
-        raise NotImplementedError
+        return None
 
     @abstractmethod
     def to_dict(self) -> dict:

--- a/qbraid/programs/ahs/braket_ahs.py
+++ b/qbraid/programs/ahs/braket_ahs.py
@@ -43,7 +43,7 @@ class BraketAHS(AnalogHamiltonianProgram):
     def to_dict(self) -> dict:
         return BraketAHSEncoder().encode_ahs(self.program)
 
-    def transform(self, device: "qbraid.runtime.aws.BraketDevice") -> None:
+    def transform(self, device: qbraid.runtime.aws.BraketDevice) -> None:
         """Transform program to according to device target profile."""
         if not device.simulator:
             program: AnalogHamiltonianSimulation = self.program

--- a/qbraid/programs/annealing/__init__.py
+++ b/qbraid/programs/annealing/__init__.py
@@ -33,6 +33,7 @@ Submodules
    :toctree: ../stubs/
 
     cpp_pyqubo
+    qubo
 
 """
 import importlib

--- a/qbraid/programs/annealing/cpp_pyqubo.py
+++ b/qbraid/programs/annealing/cpp_pyqubo.py
@@ -31,12 +31,12 @@ class PyQuboModel(AnnealingProgram):
                 message=f"Expected 'pyqubo.Model' object, got '{type(program)}'."
             )
 
-    def to_problem(self) -> QuboProblem:
+    def to_problem(self, **kwargs) -> QuboProblem:
         """Converts the cpp_pyqubo.Model to a Problem instance."""
-        qubo, offset = self.program.to_qubo()
+        qubo, _ = self.program.to_qubo(**kwargs)
         coefficients = {}
 
         for key, value in qubo.items():
             coefficients[key] = value
 
-        return QuboProblem(coefficients, offset)
+        return QuboProblem(coefficients)

--- a/qbraid/programs/annealing/qubo.py
+++ b/qbraid/programs/annealing/qubo.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2024 qBraid
+#
+# This file is part of the qBraid-SDK
+#
+# The qBraid-SDK is free software released under the GNU General Public License v3
+# or later. You can redistribute and/or modify it under the terms of the GPL v3.
+# See the LICENSE file in the project root or <https://www.gnu.org/licenses/gpl-3.0.html>.
+#
+# THERE IS NO WARRANTY for the qBraid-SDK, as per Section 15 of the GPL v3.
+
+"""
+Module defining QuboProgram Class
+
+"""
+from __future__ import annotations
+
+from qbraid.programs.exceptions import ProgramTypeError
+from qbraid.programs.typer import QuboCoefficientsDict
+
+from ._model import AnnealingProgram, QuboProblem
+
+
+class QuboProgram(AnnealingProgram):
+    """AnnealingProblem subclass that accepts a qbraid.typer.QuboCoefficientsDict."""
+
+    def __init__(self, program: QuboCoefficientsDict):
+        super().__init__(program)
+        if not isinstance(program, QuboCoefficientsDict):
+            raise ProgramTypeError(
+                message=f"Expected '{QuboCoefficientsDict}' object, got '{type(program)}'."
+            )
+
+    def to_problem(self) -> QuboProblem:
+        """Converts the QuboCoefficientsDict a Problem instance."""
+        return QuboProblem(self.program)

--- a/qbraid/programs/typer.py
+++ b/qbraid/programs/typer.py
@@ -232,3 +232,39 @@ class Qasm3StringType(QasmStringType):
     """Specifically typed string for OpenQASM 3 formatted text."""
 
     version = 3
+
+
+class QuboCoefficientsDictInstanceMeta(QbraidMetaType):
+    """Metaclass for Qubo coefficients JSON type checking based on dict content."""
+
+    @property
+    def __alias__(cls) -> str:
+        return "qubo"
+
+    @property
+    def __bound__(cls) -> Type[dict]:
+        return dict
+
+    def __instancecheck__(cls, instance: Any) -> bool:
+        """Custom instance checks based on dict format."""
+        if not instance or not isinstance(instance, dict):
+            return False
+
+        for key, value in instance.items():
+            if not (
+                isinstance(key, tuple) and len(key) == 2 and all(isinstance(k, str) for k in key)
+            ):
+                return False
+
+            if not isinstance(value, (float, int)):
+                return False
+
+        return True
+
+
+class QuboCoefficientsDict(metaclass=QuboCoefficientsDictInstanceMeta):
+    """Marker class for dict that are valid Qubo coefficients format."""
+
+
+QBRAID_META_TYPES = {IonQDict, QuboCoefficientsDict}
+BOUND_QBRAID_META_TYPES = {Qasm2String, Qasm3String}

--- a/qbraid/runtime/device.py
+++ b/qbraid/runtime/device.py
@@ -303,6 +303,9 @@ class QuantumDevice(ABC):
             target_alias = target_spec.alias
             target_type = target_spec.program_type
 
+            if run_input_spec.alias == target_alias:
+                return run_input
+
             try:
                 transpiled_run_input = transpile(
                     run_input, target_alias, **conversion_scheme_fields

--- a/qbraid/runtime/native/provider.py
+++ b/qbraid/runtime/native/provider.py
@@ -144,6 +144,7 @@ class QbraidProvider(QuantumProvider):
 
     @staticmethod
     def _get_program_spec(run_package: Optional[str], device_id: str) -> Optional[ProgramSpec]:
+        """Return the program spec for the given run package and device."""
         if not run_package:
             return None
 

--- a/qbraid/runtime/native/provider.py
+++ b/qbraid/runtime/native/provider.py
@@ -24,7 +24,7 @@ from qbraid._caching import cached_method
 from qbraid.passes.qasm.analyze import has_measurements
 from qbraid.passes.qasm.format import format_qasm
 from qbraid.programs import QPROGRAM_REGISTRY, ExperimentType, ProgramSpec, load_program
-from qbraid.programs.typer import Qasm2StringType, Qasm3StringType
+from qbraid.programs.typer import Qasm2StringType, Qasm3StringType, QuboCoefficientsDict
 from qbraid.runtime._display import display_jobs_from_data
 from qbraid.runtime.exceptions import ResourceNotFoundError
 from qbraid.runtime.ionq.provider import IonQProvider
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     import pyqubo
 
     from qbraid.programs.annealing.cpp_pyqubo import PyQuboModel
+    from qbraid.programs.annealing.qubo import QuboProgram
 
 
 def _pyqir_to_json(program: pyqir.Module) -> dict[str, bytes]:
@@ -53,8 +54,8 @@ def _qasm_to_json(
     return {"openQasm": format_qasm(program)}
 
 
-def _pyqubo_to_json(program: pyqubo.Model) -> dict[str, dict[str, Any]]:
-    program: PyQuboModel = load_program(program)
+def _qubo_to_json(program: Union[pyqubo.Model, QuboCoefficientsDict]) -> dict[str, dict[str, Any]]:
+    program: Union[PyQuboModel, QuboProgram] = load_program(program)
     return {"problem": program.to_json()}
 
 
@@ -87,7 +88,8 @@ def get_program_spec_lambdas(
         "pyqir": (_pyqir_to_json, None),
         "qasm2": (_qasm_to_json, None),
         "qasm3": (_qasm_to_json, None),
-        "cpp_pyqubo": (_pyqubo_to_json, None),
+        "cpp_pyqubo": (_qubo_to_json, None),
+        "qubo": (_qubo_to_json, None),
     }
 
     to_ir, validate = lambdas.get(program_type_alias, (None, None))

--- a/tests/programs/test_program_abc.py
+++ b/tests/programs/test_program_abc.py
@@ -16,6 +16,8 @@ Unit tests for equivalence of interfacing quantum programs
 """
 from __future__ import annotations
 
+from unittest.mock import Mock
+
 import numpy as np
 import pytest
 from braket.circuits import Circuit as BKCircuit
@@ -24,6 +26,7 @@ from cirq import Circuit, LineQubit, X, Y, Z
 from qbraid.interface.circuit_equality import circuits_allclose
 from qbraid.interface.random.random import random_circuit, random_unitary_matrix
 from qbraid.programs import get_program_type_alias, load_program
+from qbraid.programs.ahs import AnalogHamiltonianProgram
 from qbraid.programs.exceptions import ProgramTypeError
 from qbraid.programs.gate_model import GateModelProgram
 
@@ -197,3 +200,19 @@ def test_program_type_error():
     qbraid_circuit = load_program(braket_circuit)
     with pytest.raises(ProgramTypeError):
         qbraid_circuit.program = "string"
+
+
+def test_ahs_program_transform():
+    """Test that AHS transform method does not modify the program."""
+
+    class MyAHS(AnalogHamiltonianProgram):
+        """Fake AnalogHamiltonianProgram for testing."""
+
+        def to_dict(self):
+            """Mock to_dict method."""
+            return self.program
+
+    ahs_json = {"hamiltonian": {"terms": []}, "register": {"sites": [], "filling": []}}
+    program = MyAHS(ahs_json)
+    program.transform(device=Mock())
+    assert program.program == ahs_json

--- a/tests/programs/test_program_ahs_braket.py
+++ b/tests/programs/test_program_ahs_braket.py
@@ -15,7 +15,6 @@ Unit tests for loading, encoding, and decoding AHS programs using Amazon Braket.
 
 """
 import json
-from unittest.mock import Mock
 
 import numpy as np
 import pytest
@@ -278,10 +277,3 @@ def test_braket_ahs_wrapper_bad_type():
     """Test that creating a BraketAHS wrapper with a bad type raises a ProgramTypeError."""
     with pytest.raises(ProgramTypeError):
         BraketAHS(())
-
-
-def test_braket_ahs_program_transform(ahs_program):
-    """Test that the BraketAHS transform method does not modify the program."""
-    program = BraketAHS(ahs_program)
-    program.transform(device=Mock())
-    assert program.program == ahs_program

--- a/tests/programs/test_program_ahs_braket.py
+++ b/tests/programs/test_program_ahs_braket.py
@@ -15,6 +15,7 @@ Unit tests for loading, encoding, and decoding AHS programs using Amazon Braket.
 
 """
 import json
+from unittest.mock import Mock
 
 import numpy as np
 import pytest
@@ -274,6 +275,13 @@ def test_braket_ahs_wrapper_equality(ahs_program, ahs_program_local_detuning, de
 
 
 def test_braket_ahs_wrapper_bad_type():
-    """Test that creating a BraketAHS wrapper with a bad type raises a TypeError."""
+    """Test that creating a BraketAHS wrapper with a bad type raises a ProgramTypeError."""
     with pytest.raises(ProgramTypeError):
         BraketAHS(())
+
+
+def test_braket_ahs_program_transform(ahs_program):
+    """Test that the BraketAHS transform method does not modify the program."""
+    program = BraketAHS(ahs_program)
+    program.transform(device=Mock())
+    assert program.program == ahs_program

--- a/tests/programs/test_program_annealing.py
+++ b/tests/programs/test_program_annealing.py
@@ -28,7 +28,7 @@ try:
         QuboProblem,
     )
     from qbraid.programs.annealing.cpp_pyqubo import PyQuboModel
-    from qbraid.runtime.native.provider import _pyqubo_to_json
+    from qbraid.runtime.native.provider import _qubo_to_json
 
     pyqubo_not_installed = False
 except ImportError:
@@ -71,13 +71,11 @@ def test_problem_initialization():
         problem_type=ProblemType.QUBO,
         linear={"x1": 1.0, "x2": -1.5},
         quadratic={("x1", "x2"): 0.5},
-        offset=2.0,
     )
 
     assert problem.problem_type == ProblemType.QUBO
     assert problem.linear == {"x1": 1.0, "x2": -1.5}
     assert problem.quadratic == {("x1", "x2"): 0.5}
-    assert problem.offset == 2.0
     assert problem.num_variables() == 2
 
 
@@ -88,13 +86,11 @@ def test_problem_equality():
         problem_type=ProblemType.QUBO,
         linear={"x1": 1.0},
         quadratic={("x1", "x2"): 0.5},
-        offset=2.0,
     )
     problem2 = Problem(
         problem_type=ProblemType.QUBO,
         linear={"x1": 1.0},
         quadratic={("x2", "x1"): 0.5},
-        offset=2.0,
     )
 
     assert problem1 == problem2
@@ -104,11 +100,10 @@ def test_qubo_problem_initialization():
     """Tests the initialization of a QuboProblem instance with given
     quadratic coefficients and offset."""
     coefficients = {("x1", "x2"): 0.5, ("x2", "x3"): -1.0}
-    qubo_problem = QuboProblem(coefficients, offset=1.0)
+    qubo_problem = QuboProblem(coefficients)
 
     assert qubo_problem.problem_type == ProblemType.QUBO
     assert qubo_problem.quadratic == coefficients
-    assert qubo_problem.offset == 1.0
     assert qubo_problem.num_variables() == 3
 
 
@@ -144,13 +139,11 @@ def test_problem_encoder(mock_annealing_program):
         problem_type=ProblemType.QUBO,
         linear={"x1": 1.0, "x2": -1.5},
         quadratic={("x1", "x2"): 0.5},
-        offset=2.0,
     )
 
     problem_json = json.dumps(problem, cls=ProblemEncoder)
     expected_problem_json = json.dumps(
         {
-            "offset": 2.0,
             "problem_type": "qubo",
             "linear": {"x1": 1.0, "x2": -1.5},
             "quadratic": {'["x1", "x2"]': 0.5},
@@ -171,13 +164,6 @@ def test_problem_eq_different_type():
     """Test __eq__ returns False when compared with a non-Problem instance."""
     problem = Problem(problem_type=ProblemType.QUBO)
     assert problem != "Not a Problem instance"
-
-
-def test_problem_eq_different_offset():
-    """Test __eq__ returns False when offsets are different."""
-    problem1 = Problem(problem_type=ProblemType.QUBO, offset=1.0)
-    problem2 = Problem(problem_type=ProblemType.QUBO, offset=2.0)
-    assert problem1 != problem2
 
 
 def test_problem_eq_different_problem_type():
@@ -235,13 +221,11 @@ def test_problem_eq_all_attributes_same():
         problem_type=ProblemType.QUBO,
         linear={"x1": 1.0, "x2": -1.5},
         quadratic={("x1", "x2"): 0.5, ("x3", "x4"): -0.3},
-        offset=2.0,
     )
     problem2 = Problem(
         problem_type=ProblemType.QUBO,
         linear={"x1": 1.0, "x2": -1.5},
         quadratic={("x4", "x3"): -0.3, ("x2", "x1"): 0.5},
-        offset=2.0,
     )
     assert problem1 == problem2
 
@@ -261,14 +245,13 @@ def test_annealing_program_eq_different_type(mock_annealing_program):
     assert annealing_program != "Not an AnnealingProgram instance"
 
 
-def test_runtime_pyqubo_to_json(pyqubo_model):
+def test_runtime_qubo_to_json(pyqubo_model):
     """Test that the _pyqubo_to_json function returns the expected JSON string."""
-    pyqubo_json = _pyqubo_to_json(pyqubo_model)
+    pyqubo_json = _qubo_to_json(pyqubo_model)
     pyqubo_dict = {"problem": json.loads(pyqubo_json["problem"])}
 
     expected_dict = {
         "problem": {
-            "offset": 196.0,
             "problem_type": "qubo",
             "quadratic": {
                 '["s1", "s1"]': -160.0,

--- a/tests/programs/test_program_annealing.py
+++ b/tests/programs/test_program_annealing.py
@@ -118,7 +118,10 @@ def test_pyqubo_model_initialization(pyqubo_model):
 
 def get_program_classes():
     """Dynamically import and return program classes for testing."""
-    return [PyQuboModel, QuboProgram]
+    try:
+        return [PyQuboModel, QuboProgram]
+    except NameError:
+        pytest.skip("Required program classes are not available for testing.")
 
 
 @pytest.mark.parametrize("program_class", get_program_classes())

--- a/tests/programs/test_program_annealing.py
+++ b/tests/programs/test_program_annealing.py
@@ -121,7 +121,7 @@ def get_program_classes():
     try:
         return [PyQuboModel, QuboProgram]
     except NameError:
-        pytest.skip("Required program classes are not available for testing.")
+        return []
 
 
 @pytest.mark.parametrize("program_class", get_program_classes())

--- a/tests/programs/test_program_annealing.py
+++ b/tests/programs/test_program_annealing.py
@@ -116,7 +116,12 @@ def test_pyqubo_model_initialization(pyqubo_model):
     assert pyqubo_model_instance.program == pyqubo_model
 
 
-@pytest.mark.parametrize("program_class", [PyQuboModel, QuboProgram])
+def get_program_classes():
+    """Dynamically import and return program classes for testing."""
+    return [PyQuboModel, QuboProgram]
+
+
+@pytest.mark.parametrize("program_class", get_program_classes())
 def test_invalid_program_initialization(program_class):
     """Tests that initializing a program with an invalid input raises a ProgramTypeError."""
     try:

--- a/tests/programs/test_program_meta_typer.py
+++ b/tests/programs/test_program_meta_typer.py
@@ -27,6 +27,7 @@ from qbraid.programs.typer import (
     Qasm3String,
     Qasm3StringType,
     QasmStringType,
+    QuboCoefficientsDict,
     ValidationError,
 )
 
@@ -210,3 +211,84 @@ def test_ionq_dict_instance_meta_validate_field_invalid_cases(single, multiple, 
     """Test _validate_field raises ValidationError for invalid input cases."""
     with pytest.raises(ValidationError):
         IonQDictInstanceMeta._validate_field(single, multiple, field_name)
+
+
+def test_qubo_coefficients_dict_valid():
+    """Test with a valid QUBO coefficients dictionary."""
+    valid_dict = {
+        ("s1", "s1"): -160.0,
+        ("s4", "s2"): 16.0,
+        ("s3", "s1"): 224.0,
+        ("s2", "s2"): -96.0,
+        ("s4", "s1"): 32.0,
+        ("s1", "s2"): 64.0,
+        ("s3", "s2"): 112.0,
+        ("s3", "s3"): -196.0,
+        ("s4", "s4"): -52.0,
+        ("s4", "s3"): 56.0,
+    }
+    assert isinstance(valid_dict, QuboCoefficientsDict)
+
+
+def test_qubo_coefficients_dict_invalid_key_type():
+    """Test with an invalid key type (non-tuple key)."""
+    invalid_dict = {"s1": -160.0}  # Invalid because key is not a tuple
+    assert not isinstance(invalid_dict, QuboCoefficientsDict)
+
+
+def test_qubo_coefficients_dict_invalid_key_tuple_elements():
+    """Test with a tuple key containing non-string elements."""
+    invalid_dict = {
+        (1, "s2"): 32.0,  # Invalid because one element in the tuple is not a string
+        ("s3", 3): 64.0,  # Invalid because one element in the tuple is not a string
+    }
+    assert not isinstance(invalid_dict, QuboCoefficientsDict)
+
+
+def test_qubo_coefficients_dict_invalid_key_tuple_length():
+    """Test with a tuple key of incorrect length."""
+    invalid_dict = {
+        ("s1",): -160.0,  # Invalid because tuple length is 1
+        ("s2", "s3", "s4"): 96.0,  # Invalid because tuple length is 3
+    }
+    assert not isinstance(invalid_dict, QuboCoefficientsDict)
+
+
+def test_qubo_coefficients_dict_invalid_value_type():
+    """Test with a value that is not a float."""
+    invalid_dict = {
+        ("s1", "s2"): 64.0,
+        ("s3", "s3"): "string",  # Invalid because the value is not a float
+    }
+    assert not isinstance(invalid_dict, QuboCoefficientsDict)
+
+
+def test_qubo_coefficients_dict_empty():
+    """Test with an empty dictionary, which should be invalid."""
+    empty_dict = {}
+    assert not isinstance(empty_dict, QuboCoefficientsDict)
+
+
+def test_qubo_coefficients_dict_nested_invalid():
+    """Test with a nested dictionary, which should be invalid."""
+    nested_invalid_dict = {
+        ("s1", "s1"): -160.0,
+        ("s2", "s2"): {"nested_key": 32.0},  # Invalid because the value is a dict, not a float
+    }
+    assert not isinstance(nested_invalid_dict, QuboCoefficientsDict)
+
+
+def test_qubo_coefficients_dict_non_dict_type_invalid():
+    """Test with a non-dictionary type, which should be invalid."""
+    non_dict = "string"
+    assert not isinstance(non_dict, QuboCoefficientsDict)
+
+
+def test_qubo_coefficients_dict_instance_meta_alias():
+    """Test that __alias__ property returns the correct alias."""
+    assert QuboCoefficientsDict.__alias__ == "qubo"  # pylint: disable=comparison-with-callable
+
+
+def test_qubo_coefficients_dictt_instance_meta_bound():
+    """Test that __bound__ property returns dict."""
+    assert QuboCoefficientsDict.__bound__ == dict  # pylint: disable=comparison-with-callable

--- a/tests/runtime/native/test_nec_vector_annealer_runtime.py
+++ b/tests/runtime/native/test_nec_vector_annealer_runtime.py
@@ -1,0 +1,64 @@
+# Copyright (C) 2024 qBraid
+#
+# This file is part of the qBraid-SDK
+#
+# The qBraid-SDK is free software released under the GNU General Public License v3
+# or later. You can redistribute and/or modify it under the terms of the GPL v3.
+# See the LICENSE file in the project root or <https://www.gnu.org/licenses/gpl-3.0.html>.
+#
+# THERE IS NO WARRANTY for the qBraid-SDK, as per Section 15 of the GPL v3.
+
+"""
+Unit tests for remote job submissions to the NEC Vector Annealer using the QbraidProvider.
+
+"""
+import pytest
+from qbraid_core import QbraidSession
+
+from qbraid import QbraidProvider
+from qbraid._logging import logger
+from qbraid.runtime.schemas import QuboSolveParams
+
+
+def has_access() -> bool:
+    """Check if the user has access to the NEC Vector Annealer."""
+    try:
+        session = QbraidSession()
+
+        user_data = session.get_user()
+        permissions_nodes = user_data["permissionsNodes"]
+        return "nec.annealer" in permissions_nodes
+    except Exception as err:  # pylint: disable=broad-exception-caught
+        logger.error(err)
+
+    return False
+
+
+@pytest.mark.remote
+def test_submit_qubo_job_to_nec_vector_annealer():
+    """Test submitting a QUBO job to the NEC Vector Annealer."""
+    pyqubo = pytest.importorskip("pyqubo", reason="pyqubo is not installed")
+
+    if not has_access():
+        pytest.skip("User does not have access to the NEC Vector Annealer")
+
+    s1, s2, s3, s4 = [pyqubo.Spin(f"s{i}") for i in range(1, 5)]
+    H = (4 * s1 + 2 * s2 + 7 * s3 + s4) ** 2
+    model = H.compile()
+    qubo, offset = model.to_qubo()
+
+    params = QuboSolveParams(offset=offset)
+
+    provider = QbraidProvider()
+
+    device = provider.get_device("nec_vector_annealer")
+
+    job = device.run(qubo, params=params)
+
+    job.wait_for_final_state()
+
+    result = job.result()
+
+    server_auth_error = result.details["statusText"] == "Failed to authenticate with NEC server"
+
+    assert result.success or server_auth_error


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

- Register Qubo coefficients program type
- Remove offset from annealing problem types (now just in QuboSolveParams)
- Update runtime logic for nec vector annealer to support "qubo" program spec type
