### PR TITLE
result data type hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@ Types of changes:
 ## [Unreleased]
 
 ### Added
+- Added support for specifying different `quera_qasm_simulator` backends in the `QbraidDevice.run` method using the "backend" keyword argument (e.g., "cirq", "cirq-gpu") ([#836](https://github.com/qBraid/qBraid/pull/836))
 
 ### Improved / Modified
+- Enhanced type hinting for the `Result.data` property by leveraging a custom `typing.TypeVar`, enabling automatic adaptation to the specific `ResultData` subclass being accessed. ([#836](https://github.com/qBraid/qBraid/pull/836))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,19 +17,24 @@ Types of changes:
 ### Added
 
 ### Improved / Modified
-- `OQCDevice.transform()` method now removes "include" statements from qasm strings, as they are not supported by the OQC cloud. ([#831](https://github.com/qBraid/qBraid/pull/831))
-- Extended `OQCDevice.get_next_window()` to fallback and attempt to extract next (or current) start window from `OQCClient.get_qpu_execution_estimates()` if `OQCClient.get_next_window()` raises an exception (e.g. for non-AWS windows). Now can return next widow `datetime` for Toshiko QPU. ([#831](https://github.com/qBraid/qBraid/pull/831))
-- Updated `OQCDevice.submit()` to so that we no longer explicitly set the `CompilerConfig` defaults and rather leave optional arguments as `None` if not provided. ([#831](https://github.com/qBraid/qBraid/pull/831))
-- Updated `QuEraQasmSimulatorResultData` for `flair-visual` version 0.5.3 and for correspondiong qBraid Quantum Jobs API QuEra endpoint updates, which consolidate returned data into single `quera_simulation_result` dictionary field ([#832](https://github.com/qBraid/qBraid/pull/832))
 
 ### Deprecated
 
 ### Removed
-- Removed `qbraid.passes.compat.rename_qasm_registers()`. Function did not work properly, and is no longer even needed for OQC runtime as submission format is now `qasm3`, not `qasm2`. ([#831](https://github.com/qBraid/qBraid/pull/831))
 
 ### Fixed
 
 ### Dependencies
+
+## [0.8.7] - 2024-11-21
+
+### Improved / Modified
+- `OQCDevice.transform()` method now removes "include" statements from qasm strings, as they are not supported by the OQC cloud. ([#831](https://github.com/qBraid/qBraid/pull/831))
+- Extended `OQCDevice.get_next_window()` to fallback and attempt to extract next (or current) start window from `OQCClient.get_qpu_execution_estimates()` if `OQCClient.get_next_window()` raises an exception (e.g. for non-AWS windows). Now can return next widow `datetime` for Toshiko QPU. ([#831](https://github.com/qBraid/qBraid/pull/831))
+- Updated `OQCDevice.submit()` to so that we no longer explicitly set the `CompilerConfig` defaults and rather leave optional arguments as `None` if not provided. ([#831](https://github.com/qBraid/qBraid/pull/831))
+
+### Removed
+- Removed `qbraid.passes.compat.rename_qasm_registers()`. Function did not work properly, and is no longer even needed for OQC runtime as submission format is now `qasm3`, not `qasm2`. ([#831](https://github.com/qBraid/qBraid/pull/831))
 
 ## [0.8.6] - 2024-11-11
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -32,6 +32,9 @@ authors:
     family-names: Jacobson
   - given-names: Caleb
     family-names: McIrvin
+  - given-names: Phillip
+    family-names: Weinberg
+    affiliation: QuEra Computing
   - given-names: Swaraj
     family-names: Purohit
   - given-names: Jason
@@ -60,7 +63,7 @@ authors:
     orcid: https://orcid.org/0000-0003-2032-3993
 repository-code: 'https://github.com/qBraid/qBraid'
 url: 'https://sdk.qbraid.com/en/stable/'
-repository-artifact: 'https://github.com/qBraid/qBraid/releases/tag/v0.8.6'
+repository-artifact: 'https://github.com/qBraid/qBraid/releases/tag/v0.8.7'
 keywords:
   - python
   - quantum-computing
@@ -69,6 +72,6 @@ keywords:
   - qir
   - runtime
 license: GPL-3.0
-version: 0.8.6
+version: 0.8.7
 doi: 10.5281/zenodo.12627596
-date-released: '2024-11-11'
+date-released: '2024-11-21'

--- a/qbraid/_version.py
+++ b/qbraid/_version.py
@@ -14,4 +14,4 @@ Module containing version information
 Version number (major.minor.patch[-label])
 
 """
-__version__ = "0.8.7"
+__version__ = "0.8.8.dev"

--- a/qbraid/runtime/__init__.py
+++ b/qbraid/runtime/__init__.py
@@ -84,12 +84,12 @@ from .noise import NoiseModel, NoiseModelSet
 from .options import RuntimeOptions
 from .profile import TargetProfile
 from .provider import QuantumProvider
-from .result import (
+from .result import Result
+from .result_data import (
     AhsResultData,
     AhsShotResult,
     AnnealingResultData,
     GateModelResultData,
-    Result,
     ResultData,
 )
 

--- a/qbraid/runtime/aws/job.py
+++ b/qbraid/runtime/aws/job.py
@@ -26,7 +26,8 @@ from qbraid._logging import logger
 from qbraid.runtime.enums import JobStatus
 from qbraid.runtime.exceptions import JobStateError
 from qbraid.runtime.job import QuantumJob
-from qbraid.runtime.result import AhsResultData, GateModelResultData, Result
+from qbraid.runtime.result import Result
+from qbraid.runtime.result_data import AhsResultData, GateModelResultData
 
 from .result_builder import BraketAhsResultBuilder, BraketGateModelResultBuilder
 from .tracker import get_quantum_task_cost

--- a/qbraid/runtime/aws/result_builder.py
+++ b/qbraid/runtime/aws/result_builder.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 
 from qbraid.runtime.exceptions import QbraidRuntimeError
-from qbraid.runtime.result import AhsShotResult
+from qbraid.runtime.result_data import AhsShotResult
 
 if TYPE_CHECKING:
     from braket.tasks.analog_hamiltonian_simulation_quantum_task_result import (

--- a/qbraid/runtime/azure/job.py
+++ b/qbraid/runtime/azure/job.py
@@ -23,7 +23,8 @@ from qbraid.runtime.azure.result_builder import AzureGateModelResultBuilder
 from qbraid.runtime.enums import JobStatus
 from qbraid.runtime.exceptions import JobStateError
 from qbraid.runtime.job import QuantumJob
-from qbraid.runtime.result import GateModelResultData, Result
+from qbraid.runtime.result import Result
+from qbraid.runtime.result_data import GateModelResultData
 
 from .io_format import OutputDataFormat
 

--- a/qbraid/runtime/ibm/job.py
+++ b/qbraid/runtime/ibm/job.py
@@ -23,7 +23,8 @@ from qbraid._logging import logger
 from qbraid.runtime.enums import JobStatus
 from qbraid.runtime.exceptions import JobStateError, QbraidRuntimeError
 from qbraid.runtime.job import QuantumJob
-from qbraid.runtime.result import GateModelResultData, Result
+from qbraid.runtime.result import Result
+from qbraid.runtime.result_data import GateModelResultData
 
 from .result_builder import QiskitGateModelResultBuilder
 

--- a/qbraid/runtime/ionq/job.py
+++ b/qbraid/runtime/ionq/job.py
@@ -22,7 +22,8 @@ from qbraid.runtime.enums import JobStatus
 from qbraid.runtime.exceptions import QbraidRuntimeError
 from qbraid.runtime.job import QuantumJob
 from qbraid.runtime.postprocess import normalize_counts
-from qbraid.runtime.result import GateModelResultData, MeasCount, MeasProb, Result
+from qbraid.runtime.result import Result
+from qbraid.runtime.result_data import GateModelResultData, MeasCount, MeasProb
 
 if TYPE_CHECKING:
     import qbraid.runtime.ionq.provider

--- a/qbraid/runtime/job.py
+++ b/qbraid/runtime/job.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from .enums import JobStatus
 from .exceptions import JobStateError, ResourceNotFoundError
+from .result import T
 
 if TYPE_CHECKING:
     import qbraid.runtime
@@ -85,7 +86,7 @@ class QuantumJob(ABC):
             sleep(poll_interval)
 
     @abstractmethod
-    def result(self) -> qbraid.runtime.Result:
+    def result(self) -> qbraid.runtime.Result[T]:
         """Return the results of the job."""
 
     @abstractmethod

--- a/qbraid/runtime/job.py
+++ b/qbraid/runtime/job.py
@@ -85,7 +85,7 @@ class QuantumJob(ABC):
             sleep(poll_interval)
 
     @abstractmethod
-    def result(self) -> Any:
+    def result(self) -> qbraid.runtime.Result:
         """Return the results of the job."""
 
     @abstractmethod

--- a/qbraid/runtime/native/device.py
+++ b/qbraid/runtime/native/device.py
@@ -85,6 +85,7 @@ class QbraidDevice(QuantumDevice):
         noise_model: Optional[str] = None,
         seed: Optional[int] = None,
         timeout: Optional[int] = None,
+        backend: Optional[str] = None,
         params: Optional[dict[str, Any]] = None,
         error_mitigation: Optional[dict[str, Any]] = None,
     ) -> qbraid.runtime.QbraidJob:
@@ -107,6 +108,8 @@ class QbraidDevice(QuantumDevice):
                 Only applicable for certain devices. Defaults to None.
             timeout (int, optional): The maximum time in seconds to wait for the job
                 to complete after execution has started. Defaults to None.
+            backend (str, optional): The backend to use for the job. Only applicable for
+                simulator devices that support multiple backend executables. Defaults to None.
             params (dict, optional): Additional parameters to include in the job payload.
             error_mitigation (dict, optional): Dictionary containing error mitigation
                 parameters. Only applicable for certain devices. Defaults to None.
@@ -131,6 +134,7 @@ class QbraidDevice(QuantumDevice):
             "timeout": timeout,
             "noiseModel": noise_model,
             "memory": memory,
+            "backend": backend,
             "params": params_json,
             "errorMitigation": error_mitig_json,
             **run_input,

--- a/qbraid/runtime/native/job.py
+++ b/qbraid/runtime/native/job.py
@@ -23,7 +23,8 @@ from qbraid.programs import ExperimentType
 from qbraid.runtime.enums import JobStatus
 from qbraid.runtime.exceptions import JobStateError, QbraidRuntimeError
 from qbraid.runtime.job import QuantumJob
-from qbraid.runtime.result import GateModelResultData, Result
+from qbraid.runtime.result import Result
+from qbraid.runtime.result_data import GateModelResultData
 from qbraid.runtime.schemas import (
     AnnealingExperimentMetadata,
     QbraidQirSimulationMetadata,

--- a/qbraid/runtime/native/result.py
+++ b/qbraid/runtime/native/result.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Optional
 
 from qbraid.exceptions import QbraidError
-from qbraid.runtime.result import AnnealingResultData, GateModelResultData
+from qbraid.runtime.result_data import AnnealingResultData, GateModelResultData
 
 if TYPE_CHECKING:
     import flair_visual.animation.runtime.qpustate

--- a/qbraid/runtime/oqc/job.py
+++ b/qbraid/runtime/oqc/job.py
@@ -20,10 +20,11 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 from qbraid.runtime.enums import JobStatus
 from qbraid.runtime.exceptions import ResourceNotFoundError
 from qbraid.runtime.job import QuantumJob
-from qbraid.runtime.result import GateModelResultData, Result
+from qbraid.runtime.result import Result
+from qbraid.runtime.result_data import GateModelResultData
 
 if TYPE_CHECKING:
-    from qcaas_client.client import OQCClient, QPUTaskErrors
+    from qcaas_client.client import OQCClient
 
 RESULTS_FORMAT = {
     2: "raw",

--- a/qbraid/runtime/result.py
+++ b/qbraid/runtime/result.py
@@ -15,308 +15,18 @@ Module containing models for schema-conformant Results.
 from __future__ import annotations
 
 import datetime
-from abc import ABC, abstractmethod
-from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Optional, TypeVar, Union
+from typing import Any, Generic, TypeVar
 
-import numpy as np
 from qbraid_core import deprecated
 from qbraid_core.system.generic import _datetime_to_str
 
-from qbraid.programs import ExperimentType
+from .result_data import ResultData
 
-from .postprocess import counts_to_probabilities, normalize_counts
-from .schemas.experiment import AnnealingExperimentMetadata, GateModelExperimentMetadata
+T = TypeVar("T", bound=ResultData)
 
-KeyType = TypeVar("KeyType", str, int)
 
-MeasCount = dict[KeyType, int]
-
-MeasProb = dict[KeyType, float]
-
-
-class ResultData(ABC):
-    """Abstract base class for runtime results linked to a
-    specific :class:`~qbraid.programs.ExperimentType`.
-    """
-
-    @property
-    @abstractmethod
-    def experiment_type(self) -> ExperimentType:
-        """Returns the experiment type."""
-
-    @abstractmethod
-    def to_dict(self) -> dict[str, Any]:
-        """Converts the result data to a dictionary."""
-
-
-class GateModelResultData(ResultData):
-    """Class for storing and accessing the results of a gate model quantum job."""
-
-    def __init__(
-        self,
-        measurement_counts: Optional[Union[MeasCount, list[MeasCount]]] = None,
-        measurements: Optional[Union[np.ndarray, list[np.ndarray]]] = None,
-        **kwargs,
-    ):
-        """Create a new GateModelResult instance."""
-        self._measurement_counts = measurement_counts
-        self._measurements = measurements
-        self._unscoped_data = kwargs
-        self._cache = {
-            "bin_nz": None,
-            "bin_wz": None,
-            "dec_nz": None,
-            "dec_wz": None,
-            "prob_bin_nz": None,
-            "prob_bin_wz": None,
-            "prob_dec_nz": None,
-            "prob_dec_wz": None,
-            "to_dict": None,
-        }
-
-    @property
-    def experiment_type(self) -> ExperimentType:
-        """Returns the experiment type."""
-        return ExperimentType.GATE_MODEL
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> GateModelResultData:
-        """Creates a new GateModelResult instance from a dictionary."""
-        measurement_counts = data.pop("measurement_counts", data.pop("measurementCounts", None))
-        measurements = data.pop("measurements", None)
-
-        if isinstance(measurements, list):
-            measurements = np.array(measurements, dtype=object)
-
-        return cls(measurement_counts=measurement_counts, measurements=measurements, **data)
-
-    @classmethod
-    def from_object(cls, model: GateModelExperimentMetadata, **kwargs) -> GateModelResultData:
-        """Creates a new GateModelResultData instance from a GateModelExperimentMetadata object."""
-        return cls.from_dict(model.model_dump(**kwargs))
-
-    @property
-    def measurements(self) -> Optional[Union[np.ndarray, list[np.ndarray]]]:
-        """Returns the measurements data of the run."""
-        return self._measurements
-
-    @property
-    def measurement_counts(self) -> Optional[Union[MeasCount, list[MeasCount]]]:
-        """Returns the histogram data of the run as passed in the constructor."""
-        return self._measurement_counts
-
-    def get_counts(
-        self, include_zero_values: bool = False, decimal: bool = False
-    ) -> Union[MeasCount, list[MeasCount]]:
-        """
-        Returns the histogram data of the run with optional zero values and binary/decimal keys.
-
-        Args:
-            include_zero_values (bool): Whether to include states with zero counts.
-            decimal (bool): Whether to return counts with decimal keys (instead of binary).
-
-        Returns:
-            Union[dict[str, int], list[dict[str, int]]]: The histogram data.
-
-        Raises:
-            ValueError: If counts data is not available.
-        """
-        if self._measurement_counts is None:
-            raise ValueError("Counts data is not available.")
-
-        cache_key = f"{'dec' if decimal else 'bin'}_{'wz' if include_zero_values else 'nz'}"
-
-        if self._cache[cache_key] is not None:
-            return self._cache[cache_key]
-
-        counts = normalize_counts(
-            self._measurement_counts, include_zero_values=include_zero_values, decimal=decimal
-        )
-
-        self._cache[cache_key] = counts
-
-        return counts
-
-    def get_probabilities(
-        self, include_zero_values: bool = False, decimal: bool = False
-    ) -> Union[MeasProb, list[MeasProb]]:
-        """
-        Returns the probabilities of the measurement outcomes based on counts.
-
-        Args:
-            include_zero_values (bool): Whether to include states with zero probabilities.
-            decimal (bool): Whether to return probabilities with decimal keys (instead of binary).
-
-        Returns:
-            Union[MeasProb, list[MeasProb]: Probabilities of measurement outcomes.
-
-        Raises:
-            ValueError: If probabilities data is not available.
-        """
-        cache_key = f"prob_{'dec' if decimal else 'bin'}_{'wz' if include_zero_values else 'nz'}"
-
-        if self._cache[cache_key] is not None:
-            return self._cache[cache_key]
-
-        counts = self.get_counts(include_zero_values=include_zero_values, decimal=decimal)
-        probabilities = counts_to_probabilities(counts)
-
-        self._cache[cache_key] = probabilities
-
-        return probabilities
-
-    def to_dict(self) -> dict[str, Any]:
-        """Converts the GateModelResulData instance to a dictionary."""
-        if self._cache["to_dict"] is not None:
-            return self._cache["to_dict"]
-
-        counts = self.get_counts()
-        probabilities = self.get_probabilities()
-        shots = sum(counts.values())
-        num_measured_qubits = len(next(iter(counts)))
-        data = {
-            "shots": shots,
-            "num_measured_qubits": num_measured_qubits,
-            "measurement_counts": counts,
-            "measurement_probabilities": probabilities,
-            "measurements": self._measurements,
-        }
-        self._cache["to_dict"] = data
-
-        return data
-
-    @staticmethod
-    def _format_array(arr: np.ndarray) -> str:
-        return f"array(shape={arr.shape}, dtype={arr.dtype})"
-
-    def __repr__(self) -> str:
-        if isinstance(self._measurements, np.ndarray):
-            measurements_info = self._format_array(self._measurements)
-        elif isinstance(self._measurements, list) and all(
-            isinstance(arr, np.ndarray) for arr in self._measurements
-        ):
-            measurements_info = (
-                "[" + ", ".join(self._format_array(arr) for arr in self._measurements) + "]"
-            )
-        else:
-            measurements_info = self._measurements
-
-        return (
-            f"{self.__class__.__name__}("
-            f"measurement_counts={self._measurement_counts}, "
-            f"measurements={measurements_info}"
-            f")"
-        )
-
-
-@dataclass
-class AhsShotResult:
-    """Class for storing the results of a single shot in an analog Hamiltonian simulation job."""
-
-    success: bool
-    pre_sequence: Optional[np.ndarray] = None
-    post_sequence: Optional[np.ndarray] = None
-
-    @staticmethod
-    def _sequences_equal(seq1: Optional[np.ndarray], seq2: Optional[np.ndarray]) -> bool:
-        """Helper function to compare two sequences, handling None values."""
-        return (seq1 is None and seq2 is None) or (
-            seq1 is not None and seq2 is not None and np.array_equal(seq1, seq2)
-        )
-
-    def __eq__(self, other):
-        if not isinstance(other, AhsShotResult):
-            return False
-        return (
-            self.success == other.success
-            and self._sequences_equal(self.pre_sequence, other.pre_sequence)
-            and self._sequences_equal(self.post_sequence, other.post_sequence)
-        )
-
-
-class AhsResultData(ResultData):
-    """Class for storing and accessing the results of an analog Hamiltonian simulation job."""
-
-    def __init__(
-        self,
-        measurement_counts: Optional[dict[str, int]] = None,
-        measurements: Optional[list[AhsShotResult]] = None,
-    ):
-        self._measurement_counts = measurement_counts
-        self._measurements = measurements
-
-    @property
-    def experiment_type(self) -> ExperimentType:
-        """Returns the experiment type."""
-        return ExperimentType.AHS
-
-    @property
-    def measurements(self) -> Optional[list[AhsShotResult]]:
-        """Returns the measurements data of the run."""
-        return self._measurements
-
-    def get_counts(self) -> Optional[dict[str, int]]:
-        """Returns the histogram data of the run."""
-        return self._measurement_counts
-
-    def to_dict(self) -> dict[str, Any]:
-        """Converts the AhsResultData instance to a dictionary."""
-        return {
-            "measurement_counts": self._measurement_counts,
-            "measurements": self._measurements,
-        }
-
-
-class AnnealingResultData(ResultData):
-    """Class for storing and accessing the results of an annealing job."""
-
-    def __init__(
-        self, solutions: Optional[list[dict[str, Any]]] = None, num_solutions: Optional[int] = None
-    ):
-        self._solutions = solutions
-        self._num_solutions = num_solutions
-
-    @property
-    def experiment_type(self) -> ExperimentType:
-        """Returns the experiment type."""
-        return ExperimentType.ANNEALING
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any] = None) -> AnnealingResultData:
-        """Creates a new AnnealingResultData instance from a dictionary."""
-        return cls(
-            solutions=data.get("solutions"),
-            num_solutions=data.get("num_solutions", data.get("numSolutions")),
-        )
-
-    @classmethod
-    def from_object(cls, model: AnnealingExperimentMetadata, **kwargs) -> AnnealingResultData:
-        """Creates a new AnnealingResultData instance from a AnnealingExperimentMetadata object."""
-        return cls.from_dict(model.model_dump(**kwargs))
-
-    @property
-    def solutions(self) -> Optional[list[dict[str, Any]]]:
-        """Returns the solutions data of the run."""
-        return self._solutions
-
-    @property
-    def num_solutions(self) -> Optional[int]:
-        """Returns the number of solutions."""
-        if self._num_solutions is None and self._solutions is not None:
-            self._num_solutions = len(self._solutions)
-        return self._num_solutions
-
-    def to_dict(self) -> dict[str, Any]:
-        """Converts the AnnealingResultData instance to a dictionary."""
-        return {
-            "solutions": self.solutions,
-            "num_solutions": self.num_solutions,
-        }
-
-
-class Result:
+class Result(Generic[T]):
     """Represents the results of a quantum job. This class is intended
     to be initialized by a QuantumJob class.
 
@@ -334,7 +44,7 @@ class Result:
         device_id: str,
         job_id: str,
         success: bool,
-        data: ResultData,
+        data: T,
         **kwargs,
     ):
         """Create a new Result object."""
@@ -345,7 +55,7 @@ class Result:
         self._details = kwargs or {}
 
     @property
-    def data(self) -> ResultData:
+    def data(self) -> T:
         """Returns the result of the job."""
         return self._data
 

--- a/qbraid/runtime/result_data.py
+++ b/qbraid/runtime/result_data.py
@@ -1,0 +1,312 @@
+# Copyright (C) 2024 qBraid
+#
+# This file is part of the qBraid-SDK
+#
+# The qBraid-SDK is free software released under the GNU General Public License v3
+# or later. You can redistribute and/or modify it under the terms of the GPL v3.
+# See the LICENSE file in the project root or <https://www.gnu.org/licenses/gpl-3.0.html>.
+#
+# THERE IS NO WARRANTY for the qBraid-SDK, as per Section 15 of the GPL v3.
+
+"""
+Module containing models for schema-conformant ResultData classes.
+
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Optional, TypeVar, Union
+
+import numpy as np
+
+from qbraid.programs import ExperimentType
+
+from .postprocess import counts_to_probabilities, normalize_counts
+from .schemas.experiment import AnnealingExperimentMetadata, GateModelExperimentMetadata
+
+KeyType = TypeVar("KeyType", str, int)
+
+MeasCount = dict[KeyType, int]
+
+MeasProb = dict[KeyType, float]
+
+
+class ResultData(ABC):
+    """Abstract base class for runtime results linked to a
+    specific :class:`~qbraid.programs.ExperimentType`.
+    """
+
+    @property
+    @abstractmethod
+    def experiment_type(self) -> ExperimentType:
+        """Returns the experiment type."""
+
+    @abstractmethod
+    def to_dict(self) -> dict[str, Any]:
+        """Converts the result data to a dictionary."""
+
+
+class GateModelResultData(ResultData):
+    """Class for storing and accessing the results of a gate model quantum job."""
+
+    def __init__(
+        self,
+        measurement_counts: Optional[Union[MeasCount, list[MeasCount]]] = None,
+        measurements: Optional[Union[np.ndarray, list[np.ndarray]]] = None,
+        **kwargs,
+    ):
+        """Create a new GateModelResult instance."""
+        self._measurement_counts = measurement_counts
+        self._measurements = measurements
+        self._unscoped_data = kwargs
+        self._cache = {
+            "bin_nz": None,
+            "bin_wz": None,
+            "dec_nz": None,
+            "dec_wz": None,
+            "prob_bin_nz": None,
+            "prob_bin_wz": None,
+            "prob_dec_nz": None,
+            "prob_dec_wz": None,
+            "to_dict": None,
+        }
+
+    @property
+    def experiment_type(self) -> ExperimentType:
+        """Returns the experiment type."""
+        return ExperimentType.GATE_MODEL
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> GateModelResultData:
+        """Creates a new GateModelResult instance from a dictionary."""
+        measurement_counts = data.pop("measurement_counts", data.pop("measurementCounts", None))
+        measurements = data.pop("measurements", None)
+
+        if isinstance(measurements, list):
+            measurements = np.array(measurements, dtype=object)
+
+        return cls(measurement_counts=measurement_counts, measurements=measurements, **data)
+
+    @classmethod
+    def from_object(cls, model: GateModelExperimentMetadata, **kwargs) -> GateModelResultData:
+        """Creates a new GateModelResultData instance from a GateModelExperimentMetadata object."""
+        return cls.from_dict(model.model_dump(**kwargs))
+
+    @property
+    def measurements(self) -> Optional[Union[np.ndarray, list[np.ndarray]]]:
+        """Returns the measurements data of the run."""
+        return self._measurements
+
+    @property
+    def measurement_counts(self) -> Optional[Union[MeasCount, list[MeasCount]]]:
+        """Returns the histogram data of the run as passed in the constructor."""
+        return self._measurement_counts
+
+    def get_counts(
+        self, include_zero_values: bool = False, decimal: bool = False
+    ) -> Union[MeasCount, list[MeasCount]]:
+        """
+        Returns the histogram data of the run with optional zero values and binary/decimal keys.
+
+        Args:
+            include_zero_values (bool): Whether to include states with zero counts.
+            decimal (bool): Whether to return counts with decimal keys (instead of binary).
+
+        Returns:
+            Union[dict[str, int], list[dict[str, int]]]: The histogram data.
+
+        Raises:
+            ValueError: If counts data is not available.
+        """
+        if self._measurement_counts is None:
+            raise ValueError("Counts data is not available.")
+
+        cache_key = f"{'dec' if decimal else 'bin'}_{'wz' if include_zero_values else 'nz'}"
+
+        if self._cache[cache_key] is not None:
+            return self._cache[cache_key]
+
+        counts = normalize_counts(
+            self._measurement_counts, include_zero_values=include_zero_values, decimal=decimal
+        )
+
+        self._cache[cache_key] = counts
+
+        return counts
+
+    def get_probabilities(
+        self, include_zero_values: bool = False, decimal: bool = False
+    ) -> Union[MeasProb, list[MeasProb]]:
+        """
+        Returns the probabilities of the measurement outcomes based on counts.
+
+        Args:
+            include_zero_values (bool): Whether to include states with zero probabilities.
+            decimal (bool): Whether to return probabilities with decimal keys (instead of binary).
+
+        Returns:
+            Union[MeasProb, list[MeasProb]: Probabilities of measurement outcomes.
+
+        Raises:
+            ValueError: If probabilities data is not available.
+        """
+        cache_key = f"prob_{'dec' if decimal else 'bin'}_{'wz' if include_zero_values else 'nz'}"
+
+        if self._cache[cache_key] is not None:
+            return self._cache[cache_key]
+
+        counts = self.get_counts(include_zero_values=include_zero_values, decimal=decimal)
+        probabilities = counts_to_probabilities(counts)
+
+        self._cache[cache_key] = probabilities
+
+        return probabilities
+
+    def to_dict(self) -> dict[str, Any]:
+        """Converts the GateModelResulData instance to a dictionary."""
+        if self._cache["to_dict"] is not None:
+            return self._cache["to_dict"]
+
+        counts = self.get_counts()
+        probabilities = self.get_probabilities()
+        shots = sum(counts.values())
+        num_measured_qubits = len(next(iter(counts)))
+        data = {
+            "shots": shots,
+            "num_measured_qubits": num_measured_qubits,
+            "measurement_counts": counts,
+            "measurement_probabilities": probabilities,
+            "measurements": self._measurements,
+        }
+        self._cache["to_dict"] = data
+
+        return data
+
+    @staticmethod
+    def _format_array(arr: np.ndarray) -> str:
+        return f"array(shape={arr.shape}, dtype={arr.dtype})"
+
+    def __repr__(self) -> str:
+        if isinstance(self._measurements, np.ndarray):
+            measurements_info = self._format_array(self._measurements)
+        elif isinstance(self._measurements, list) and all(
+            isinstance(arr, np.ndarray) for arr in self._measurements
+        ):
+            measurements_info = (
+                "[" + ", ".join(self._format_array(arr) for arr in self._measurements) + "]"
+            )
+        else:
+            measurements_info = self._measurements
+
+        return (
+            f"{self.__class__.__name__}("
+            f"measurement_counts={self._measurement_counts}, "
+            f"measurements={measurements_info}"
+            f")"
+        )
+
+
+@dataclass
+class AhsShotResult:
+    """Class for storing the results of a single shot in an analog Hamiltonian simulation job."""
+
+    success: bool
+    pre_sequence: Optional[np.ndarray] = None
+    post_sequence: Optional[np.ndarray] = None
+
+    @staticmethod
+    def _sequences_equal(seq1: Optional[np.ndarray], seq2: Optional[np.ndarray]) -> bool:
+        """Helper function to compare two sequences, handling None values."""
+        return (seq1 is None and seq2 is None) or (
+            seq1 is not None and seq2 is not None and np.array_equal(seq1, seq2)
+        )
+
+    def __eq__(self, other):
+        if not isinstance(other, AhsShotResult):
+            return False
+        return (
+            self.success == other.success
+            and self._sequences_equal(self.pre_sequence, other.pre_sequence)
+            and self._sequences_equal(self.post_sequence, other.post_sequence)
+        )
+
+
+class AhsResultData(ResultData):
+    """Class for storing and accessing the results of an analog Hamiltonian simulation job."""
+
+    def __init__(
+        self,
+        measurement_counts: Optional[dict[str, int]] = None,
+        measurements: Optional[list[AhsShotResult]] = None,
+    ):
+        self._measurement_counts = measurement_counts
+        self._measurements = measurements
+
+    @property
+    def experiment_type(self) -> ExperimentType:
+        """Returns the experiment type."""
+        return ExperimentType.AHS
+
+    @property
+    def measurements(self) -> Optional[list[AhsShotResult]]:
+        """Returns the measurements data of the run."""
+        return self._measurements
+
+    def get_counts(self) -> Optional[dict[str, int]]:
+        """Returns the histogram data of the run."""
+        return self._measurement_counts
+
+    def to_dict(self) -> dict[str, Any]:
+        """Converts the AhsResultData instance to a dictionary."""
+        return {
+            "measurement_counts": self._measurement_counts,
+            "measurements": self._measurements,
+        }
+
+
+class AnnealingResultData(ResultData):
+    """Class for storing and accessing the results of an annealing job."""
+
+    def __init__(
+        self, solutions: Optional[list[dict[str, Any]]] = None, num_solutions: Optional[int] = None
+    ):
+        self._solutions = solutions
+        self._num_solutions = num_solutions
+
+    @property
+    def experiment_type(self) -> ExperimentType:
+        """Returns the experiment type."""
+        return ExperimentType.ANNEALING
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] = None) -> AnnealingResultData:
+        """Creates a new AnnealingResultData instance from a dictionary."""
+        return cls(
+            solutions=data.get("solutions"),
+            num_solutions=data.get("num_solutions", data.get("numSolutions")),
+        )
+
+    @classmethod
+    def from_object(cls, model: AnnealingExperimentMetadata, **kwargs) -> AnnealingResultData:
+        """Creates a new AnnealingResultData instance from a AnnealingExperimentMetadata object."""
+        return cls.from_dict(model.model_dump(**kwargs))
+
+    @property
+    def solutions(self) -> Optional[list[dict[str, Any]]]:
+        """Returns the solutions data of the run."""
+        return self._solutions
+
+    @property
+    def num_solutions(self) -> Optional[int]:
+        """Returns the number of solutions."""
+        if self._num_solutions is None and self._solutions is not None:
+            self._num_solutions = len(self._solutions)
+        return self._num_solutions
+
+    def to_dict(self) -> dict[str, Any]:
+        """Converts the AnnealingResultData instance to a dictionary."""
+        return {
+            "solutions": self.solutions,
+            "num_solutions": self.num_solutions,
+        }

--- a/tests/runtime/test_device.py
+++ b/tests/runtime/test_device.py
@@ -268,7 +268,7 @@ def test_quera_simulator_workflow(mock_provider, cirq_uniform, valid_qasm2_no_me
     device = provider.get_device("quera_qasm_simulator")
 
     shots = 10
-    job = device.run(circuit, shots=shots)
+    job = device.run(circuit, shots=shots, backend="cirq-gpu")
     assert isinstance(job, QbraidJob)
     assert job.is_terminal_state()
 
@@ -285,6 +285,7 @@ def test_quera_simulator_workflow(mock_provider, cirq_uniform, valid_qasm2_no_me
     assert result.success
     assert result.job_id == JOB_DATA_QUERA["qbraidJobId"]
     assert result.device_id == JOB_DATA_QUERA["qbraidDeviceId"]
+    assert result.data.backend == "cirq-gpu"
 
     counts = result.data.get_counts()
     probabilities = result.data.get_probabilities()

--- a/tests/runtime/test_result.py
+++ b/tests/runtime/test_result.py
@@ -28,12 +28,12 @@ from qbraid.runtime.postprocess import (
     normalize_bit_lengths,
     normalize_counts,
 )
-from qbraid.runtime.result import (
+from qbraid.runtime.result import Result
+from qbraid.runtime.result_data import (
     AhsResultData,
     AhsShotResult,
     AnnealingResultData,
     GateModelResultData,
-    Result,
 )
 
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

- Enhanced type hinting for the `Result.data` property by leveraging a custom `typing.TypeVar`, enabling automatic adaptation to the specific `ResultData` subclass being accessed.
- Added support for specifying different `quera_qasm_simulator` backends in the `QbraidDevice.run` method using the "backend" keyword argument (e.g., "cirq", "cirq-gpu")