### PR TITLE
bloqade batch assign on aquila native runtime fix

### DIFF
--- a/qbraid/_version.py
+++ b/qbraid/_version.py
@@ -14,4 +14,4 @@ Module containing version information
 Version number (major.minor.patch[-label])
 
 """
-__version__ = "0.8.8"
+__version__ = "0.8.9.dev"

--- a/qbraid/runtime/__init__.py
+++ b/qbraid/runtime/__init__.py
@@ -26,6 +26,7 @@ Data Types
     JobStatus
     NoiseModel
     NoiseModelSet
+    ValidationLevel
 
 Functions
 ------------
@@ -71,7 +72,7 @@ from typing import TYPE_CHECKING
 
 from ._display import display_jobs_from_data
 from .device import QuantumDevice
-from .enums import DeviceStatus, JobStatus
+from .enums import DeviceStatus, JobStatus, ValidationLevel
 from .exceptions import (
     DeviceProgramTypeMismatchError,
     JobStateError,
@@ -115,6 +116,7 @@ __all__ = [
     "AhsResultData",
     "AhsShotResult",
     "AnnealingResultData",
+    "ValidationLevel",
 ]
 
 _lazy = {

--- a/qbraid/runtime/native/__init__.py
+++ b/qbraid/runtime/native/__init__.py
@@ -28,6 +28,16 @@ Classes
     QbraidJob
     QirRunner
 
+ResultData Subclasses
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: ../stubs/
+
+    QuEraQasmSimulatorResultData
+    QbraidQirSimulatorResultData
+    NECVectorAnnealerResultData
+
 """
 from qbraid_core import QbraidClient, QbraidSession, Session
 from qbraid_core.services.quantum.runner import QirRunner
@@ -35,6 +45,11 @@ from qbraid_core.services.quantum.runner import QirRunner
 from .device import QbraidDevice
 from .job import QbraidJob
 from .provider import QbraidProvider
+from .result import (
+    NECVectorAnnealerResultData,
+    QbraidQirSimulatorResultData,
+    QuEraQasmSimulatorResultData,
+)
 
 __all__ = [
     "Session",
@@ -44,4 +59,7 @@ __all__ = [
     "QbraidDevice",
     "QbraidJob",
     "QirRunner",
+    "QuEraQasmSimulatorResultData",
+    "QbraidQirSimulatorResultData",
+    "NECVectorAnnealerResultData",
 ]

--- a/qbraid/runtime/native/device.py
+++ b/qbraid/runtime/native/device.py
@@ -353,14 +353,17 @@ class QbraidDevice(QuantumDevice):
                 aux_payload = self._construct_aux_payload(program, program_spec)
             if transpile_option:
                 program = self.transpile(program, program_spec)
-            self.validate([program], suppress_device_warning=i != 0)
-            if native_target:
-                aux_payload = self._construct_aux_payload(program, program_spec)
-            run_input_json = self.to_ir(program)
-            self._validate_run_input_payload(run_input_json, self._target_spec)
-            runtime_payload = {**aux_payload, **run_input_json}
-            job = self.submit(run_input=runtime_payload, shots=shots, tags=tags, **kwargs)
-            jobs.append(job)
+            is_batched_output = is_single_input and isinstance(program, list)
+            program_batch = program if is_batched_output else [program]
+            self.validate(program_batch, suppress_device_warning=i != 0)
+            for program in program_batch:
+                if native_target:
+                    aux_payload = self._construct_aux_payload(program, program_spec)
+                run_input_json = self.to_ir(program)
+                self._validate_run_input_payload(run_input_json, self._target_spec)
+                runtime_payload = {**aux_payload, **run_input_json}
+                job = self.submit(run_input=runtime_payload, shots=shots, tags=tags, **kwargs)
+                jobs.append(job)
 
         return jobs[0] if is_single_input else jobs
 

--- a/qbraid/runtime/schemas/__init__.py
+++ b/qbraid/runtime/schemas/__init__.py
@@ -13,7 +13,7 @@ Module defining qBraid runtime schemas.
 
 .. currentmodule:: qbraid.runtime.schemas
 
-Classes
+Models
 --------
 
 .. autosummary::
@@ -24,6 +24,7 @@ Classes
     DevicePricing
     DeviceData
     ExperimentMetadata
+    AhsExperimentMetadata
     AnnealingExperimentMetadata
     GateModelExperimentMetadata
     QuEraQasmSimulationMetadata
@@ -32,8 +33,17 @@ Classes
     RuntimeJobModel
     QuboSolveParams
 
+Classes
+---------
+
+.. autosummary::
+   :toctree: ../stubs/
+
+    Credits
+    USD
+
 """
-from .base import QbraidSchemaBase, QbraidSchemaHeader
+from .base import USD, Credits, QbraidSchemaBase, QbraidSchemaHeader
 from .device import DeviceData, DevicePricing
 from .experiment import (
     AhsExperimentMetadata,
@@ -51,13 +61,15 @@ __all__ = [
     "QbraidSchemaHeader",
     "DevicePricing",
     "DeviceData",
-    "ExperimentMetadata",
-    "AnnealingExperimentMetadata",
-    "GateModelExperimentMetadata",
-    "QuEraQasmSimulationMetadata",
-    "QbraidQirSimulationMetadata",
     "AhsExperimentMetadata",
-    "TimeStamps",
-    "RuntimeJobModel",
+    "AnnealingExperimentMetadata",
+    "ExperimentMetadata",
+    "GateModelExperimentMetadata",
+    "QbraidQirSimulationMetadata",
     "QuboSolveParams",
+    "QuEraQasmSimulationMetadata",
+    "RuntimeJobModel",
+    "TimeStamps",
+    "Credits",
+    "USD",
 ]


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

- Resolved an issue where passing `bloqade.builder.assign.BatchAssign` to `QbraidDevice("quera_aquila")` caused the transpile step to incorrectly wrap its output list in another list, leading to errors in `QuantumDevice.validate` and `QuantumDevice.to_ir`. The native `QbraidDevice` class now adapts when the transpile input is a single object but the output is a list, properly iterating through the sub-batch for final submission.
- Made remote tests for `QbraidDevice("nec_vector_annealer")` more robust
- Added "new" classes to the relevant runtime module scopes:
    - `qbraid.schemas`: `AhsExperimentMetadata` model, `USD` and `Credits` classes
    - `qbraid.runtime`: `ValidationLevel` enum
    - `qbraid.runtime.native`: Device-specific `ResultData` subclasses
