### PR TITLE
replace gate names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,11 @@ Types of changes:
 ## [Unreleased]
 
 ### Added
+- Added `p` to `z` gate name mapping to `openqasm3_to_ionq` conversion ([#854](https://github.com/qBraid/qBraid/pull/854))
 
 ### Improved / Modified
 - Unit tests that require the `pyqir` dependency are now automatically skipped if pyqir is not installed. ([#846](https://github.com/qBraid/qBraid/pull/846))
+- Renamed the function `replace_gate_name` to `replace_gate_names` and updated its implementation to accept a dictionary of gate name mappings instead of individual old and new gate names. (`qbraid/passes/qasm/compat.py`) ([#854](https://github.com/qBraid/qBraid/pull/854))
 
 ### Deprecated
 

--- a/qbraid/passes/qasm/__init__.py
+++ b/qbraid/passes/qasm/__init__.py
@@ -25,7 +25,7 @@ Functions
     decompose_qasm3
     decompose_qasm2
     insert_gate_def
-    replace_gate_name
+    replace_gate_names
     add_stdgates_include
     remove_stdgates_include
     convert_qasm_pi_to_decimal
@@ -45,7 +45,7 @@ from .compat import (
     remove_include_statements,
     remove_measurements,
     remove_stdgates_include,
-    replace_gate_name,
+    replace_gate_names,
 )
 from .decompose import decompose_qasm2, decompose_qasm3, rebase
 from .format import remove_unused_gates
@@ -58,7 +58,7 @@ __all__ = [
     "decompose_qasm2",
     "decompose_qasm3",
     "insert_gate_def",
-    "replace_gate_name",
+    "replace_gate_names",
     "add_stdgates_include",
     "remove_stdgates_include",
     "convert_qasm_pi_to_decimal",

--- a/qbraid/transpiler/conversions/openqasm3/openqasm3_to_ionq.py
+++ b/qbraid/transpiler/conversions/openqasm3/openqasm3_to_ionq.py
@@ -36,6 +36,7 @@ IONQ_ONE_QUBIT_GATE_MAP = {
     "not": "not",
     "y": "y",
     "z": "z",
+    "p": "z",
     "h": "h",
     "s": "s",
     "si": "si",

--- a/qbraid/transpiler/conversions/qasm3/qasm3_to_braket.py
+++ b/qbraid/transpiler/conversions/qasm3/qasm3_to_braket.py
@@ -21,7 +21,7 @@ from qbraid_core._import import LazyLoader
 from qbraid.passes.qasm.compat import (
     convert_qasm_pi_to_decimal,
     remove_stdgates_include,
-    replace_gate_name,
+    replace_gate_names,
 )
 from qbraid.programs.exceptions import QasmError
 from qbraid.transpiler.annotations import weight
@@ -52,8 +52,7 @@ def transform_notation(qasm3: str) -> str:
     }
 
     qasm3 = remove_stdgates_include(qasm3)
-    for old, new in replacements.items():
-        qasm3 = replace_gate_name(qasm3, old, new)
+    qasm3 = replace_gate_names(qasm3, replacements)
     qasm3 = convert_qasm_pi_to_decimal(qasm3)
     return qasm3
 

--- a/qbraid/transpiler/conversions/qasm3/qasm3_to_qiskit.py
+++ b/qbraid/transpiler/conversions/qasm3/qasm3_to_qiskit.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING
 
 from qbraid_core._import import LazyLoader
 
-from qbraid.passes.qasm.compat import add_stdgates_include, insert_gate_def, replace_gate_name
+from qbraid.passes.qasm.compat import add_stdgates_include, insert_gate_def, replace_gate_names
 from qbraid.transpiler.annotations import weight
 
 qiskit_qasm3 = LazyLoader("qiskit_qasm3", globals(), "qiskit.qasm3")
@@ -46,8 +46,7 @@ def transform_notation(qasm3: str) -> str:
         "cphaseshift": "cp",
     }
 
-    for old, new in replacements.items():
-        qasm3 = replace_gate_name(qasm3, old, new)
+    qasm3 = replace_gate_names(qasm3, replacements)
     qasm3 = add_stdgates_include(qasm3)
     qasm3 = insert_gate_def(qasm3, "iswap")
     qasm3 = insert_gate_def(qasm3, "sxdg")

--- a/tests/passes/test_qasm3_compat.py
+++ b/tests/passes/test_qasm3_compat.py
@@ -13,6 +13,7 @@ Unit tests for QASM preprocessing functions
 
 """
 import re
+import textwrap
 
 import pytest
 
@@ -25,7 +26,7 @@ from qbraid.passes.qasm.compat import (
     normalize_qasm_gate_params,
     remove_include_statements,
     remove_stdgates_include,
-    replace_gate_name,
+    replace_gate_names,
     simplify_parentheses_in_qasm,
 )
 from qbraid.passes.qasm.format import _remove_empty_lines
@@ -62,42 +63,78 @@ def test_convert_pi_to_decimal(qasm3_str_pi, qasm3_str_decimal):
     assert qasm_out == qasm3_str_decimal
 
 
-def test_replace_gate_name_normal():
-    """Test replacing gate name in qasm string"""
-    qasm = "cnot q[0], q[1];"
-    assert replace_gate_name(qasm, "cnot", "cx") == "cx q[0], q[1];"
+@pytest.mark.parametrize(
+    "qasm_body, old_gate, new_gate, expected_body",
+    [
+        (
+            "cnot q[0], q[1];",
+            "cnot",
+            "cx",
+            "cx q[0], q[1];",
+        ),
+        (
+            "cnot q[0], q[1];",
+            "cnot",
+            "custom",
+            "custom q[0], q[1];",
+        ),
+        (
+            "cnot q[0], q[1];",
+            "notmatched",
+            "cx",
+            "cnot q[0], q[1];",
+        ),
+    ],
+)
+def test_replace_gate_name_qubit_2(qasm_body, old_gate, new_gate, expected_body):
+    """Test replacing gate names in QASM strings for two qubit gates."""
+    qasm = f"OPENQASM 3; qubit[2] q; {qasm_body}"
+    expected_output = f"OPENQASM 3;\nqubit[2] q;\n{expected_body}\n"
+    assert replace_gate_names(qasm, {old_gate: new_gate}) == expected_output
+
+    qasm2 = f"OPENQASM 2; qreg q[2]; {qasm_body}"
+    qasm2_expected_output = f"OPENQASM 2;\nqreg q[2];\n{expected_body}\n"
+    assert replace_gate_names(qasm2, {old_gate: new_gate}) == qasm2_expected_output
 
 
-def test_replace_gate_name_forced():
-    """Test forced replace of gate name in qasm string"""
-    qasm = "x q[0];"
-    assert replace_gate_name(qasm, "x", "pauli_x", force_replace=True) == "pauli_x q[0];"
+@pytest.mark.parametrize(
+    "qasm_body, old_gate, new_gate, expected_body",
+    [
+        (
+            "x q[0];",
+            "x",
+            "pauli_x",
+            "pauli_x q[0];",
+        ),
+        (
+            "p(3.14) q[0];",
+            "p",
+            "phaseshift",
+            "phaseshift(3.14) q[0];",
+        ),
+        (
+            "v q[0];",
+            "v",
+            "sx",
+            "sx q[0];",
+        ),
+        (
+            "ti q[0];",
+            "ti",
+            "tdg",
+            "tdg q[0];",
+        ),
+    ],
+)
+def test_replace_gate_name_qubit_1(qasm_body, old_gate, new_gate, expected_body):
+    """Test replacing gate names in QASM strings for one qubit gates."""
+    qasm3 = f"OPENQASM 3; qubit[1] q; {qasm_body}"
+    qasm3_expected_output = f"OPENQASM 3;\nqubit[1] q;\n{expected_body}\n"
+    assert replace_gate_names(qasm3, {old_gate: new_gate}) == qasm3_expected_output
 
-
-def test_replace_gate_name_with_parameters():
-    """Test replacing gate name with parameters in qasm string"""
-    qasm = "p(3.14) q[0];"
-    assert replace_gate_name(qasm, "p", "phaseshift") == "phaseshift(3.14) q[0];"
-
-
-def test_no_replacement_when_not_matched():
-    """Test not replacing gate name in qasm string when not matched"""
-    qasm = "cnot q[0], q[1];"
-    assert replace_gate_name(qasm, "cnot", "notvalid", force_replace=False) == "cnot q[0], q[1];"
-
-
-def test_force_replace_when_not_matched():
-    """Test force replacing gate name in qasm string when not matched"""
-    qasm = "cnot q[0], q[1];"
-    assert replace_gate_name(qasm, "cnot", "notvalid", force_replace=True) == "notvalid q[0], q[1];"
-
-
-def test_replace_non_parameterized_with_parameterized():
-    """Test replacing non-parameterized gates with parameterized gates in qasm string"""
-    qasm = "v q[0];"
-    assert replace_gate_name(qasm, "v", "sx") == "sx q[0];"
-    qasm = "ti q[0];"
-    assert replace_gate_name(qasm, "ti", "tdg") == "tdg q[0];"
+    qasm2 = f"OPENQASM 2; qreg q[1]; {qasm_body}"
+    qasm2_expected_output = f"OPENQASM 2;\nqreg q[1];\n{expected_body}\n"
+    assert replace_gate_names(qasm2, {old_gate: new_gate}) == qasm2_expected_output
 
 
 @pytest.mark.parametrize(
@@ -106,9 +143,7 @@ def test_replace_non_parameterized_with_parameterized():
         (
             """
         OPENQASM 3.0;
-
         qubit[2] q;
-
         cnot q[0], q[1];
         sx q[0];
         p(3.14) q[1];
@@ -116,9 +151,7 @@ def test_replace_non_parameterized_with_parameterized():
         """,
             """
         OPENQASM 3.0;
-
         qubit[2] q;
-
         cx q[0], q[1];
         v q[0];
         phaseshift(3.14) q[1];
@@ -129,10 +162,10 @@ def test_replace_non_parameterized_with_parameterized():
 )
 def test_parameterized_replacement(qasm3_in, qasm3_out):
     """Test replacing non-parameterized gates with parameterized gates in qasm3 string"""
-    qasm3 = replace_gate_name(qasm3_in, "cnot", "cx")
-    qasm3 = replace_gate_name(qasm3, "sx", "v")
-    qasm3 = replace_gate_name(qasm3, "p", "phaseshift")
-    qasm3 = replace_gate_name(qasm3, "cp", "cphaseshift")
+    replacements = {"cnot": "cx", "sx": "v", "p": "phaseshift", "cp": "cphaseshift"}
+    qasm3 = replace_gate_names(qasm3_in, replacements)
+    qasm3 = textwrap.dedent(qasm3).strip()
+    qasm3_out = textwrap.dedent(qasm3_out).strip()
     assert qasm3 == qasm3_out
 
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

- Renamed the function `replace_gate_name` to `replace_gate_names` and updated its implementation to accept a dictionary of gate name mappings instead of individual old and new gate names. (`qbraid/passes/qasm/compat.py`)
- Added `p` to `z` gate name mapping to `openqasm3_to_ionq` conversion
