### PR TITLE
add support for ionq controlled gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ Types of changes:
 - Added `p` to `z` gate name mapping to `openqasm3_to_ionq` conversion ([#854](https://github.com/qBraid/qBraid/pull/854))
 - Added `preflight` parameter to the `submit` method and to the `RuntimeJobModel` class ([#856](https://github.com/qBraid/qBraid/pull/856))
 - Added remote test for native IonQ runtime ([#856](https://github.com/qBraid/qBraid/pull/856))
+- Added `distribute_counts` function to adjust probabilistic counts ensuring the total equals the number of shots. ([#858](https://github.com/qBraid/qBraid/pull/858))
+- Added support for controlled gates in `openqasm3_to_ionq` conversion ([#858](https://github.com/qBraid/qBraid/pull/858)):
+
+```text
+cx, cy, cz, crx, cry, crz, ch, ccnot, cs, csi, ct, cti, cv, cvi
+```
 
 ### Improved / Modified
 - Unit tests that require the `pyqir` dependency are now automatically skipped if pyqir is not installed. ([#846](https://github.com/qBraid/qBraid/pull/846))
@@ -25,6 +31,9 @@ Types of changes:
 - Updated the `IonQDevice.transform` method to replace gate names in the input using the newly defined `IONQ_GATE_MAP` before loading and transforming the program ([#855](https://github.com/qBraid/qBraid/pull/855))
 - Updated gate naming conventions in `IONQ_QIS_GATES` list for consistency with [IonQ supported gates API](https://docs.ionq.com/api-reference/v0.3/writing-quantum-programs#supported-gates) ([#856](https://github.com/qBraid/qBraid/pull/856))
 - Updated the `rebase` function to include `gate_mappings` and `case_sensitive` parameters for gate name replacement.([#856](https://github.com/qBraid/qBraid/pull/856))
+- Updated the `rebase` function to handle gate mappings with predicates. ([#858](https://github.com/qBraid/qBraid/pull/858))
+- Refactored gate mappings and added validation for gate parameters and qubit counts in `openqasm3_to_ionq` conversion ([#858](https://github.com/qBraid/qBraid/pull/858))
+- Integrated `distribute_counts` function in `convert_to_counts` method in `IonQJob` ([#858](https://github.com/qBraid/qBraid/pull/858))
 
 ### Deprecated
 

--- a/qbraid/passes/qasm/decompose.py
+++ b/qbraid/passes/qasm/decompose.py
@@ -392,6 +392,8 @@ def rebase(
 
     if gate_mappings is not None:
         converted_program = _replace_gate_names(converted_program, gate_mappings, case_sensitive)
+        if require_predicates:
+            gateset = {gate_mappings.get(gate, gate) for gate in gateset}
 
     # Check if the program meets the compilation predicates
     try:

--- a/qbraid/programs/gate_model/ionq.py
+++ b/qbraid/programs/gate_model/ionq.py
@@ -40,6 +40,20 @@ IONQ_QIS_GATES = [
     "v",
     "vi",
     "swap",
+    "cx",
+    "cy",
+    "cz",
+    "crx",
+    "cry",
+    "crz",
+    "ch",
+    "ccnot",
+    "cs",
+    "csi",
+    "ct",
+    "cti",
+    "cv",
+    "cvi",
 ]
 
 IONQ_NATIVE_GATES_BASE = ["gpi", "gpi2"]

--- a/qbraid/runtime/ionq/job.py
+++ b/qbraid/runtime/ionq/job.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 from qbraid.runtime.enums import JobStatus
 from qbraid.runtime.exceptions import QbraidRuntimeError
 from qbraid.runtime.job import QuantumJob
-from qbraid.runtime.postprocess import normalize_counts
+from qbraid.runtime.postprocess import distribute_counts, normalize_counts
 from qbraid.runtime.result import Result
 from qbraid.runtime.result_data import GateModelResultData, MeasCount, MeasProb
 
@@ -91,7 +91,7 @@ class IonQJob(QuantumJob):
             """Helper function to normalize probabilities and convert to counts."""
             probs_dec = {int(key): value for key, value in meas_prob.items()}
             probs_normal = normalize_counts(probs_dec)
-            return {state: int(prob * shots) for state, prob in probs_normal.items()}
+            return distribute_counts(probs_normal, shots)
 
         if all(isinstance(value, dict) for value in probabilities.values()):
             return [convert_to_counts(probs) for probs in probabilities.values()]

--- a/qbraid/runtime/postprocess.py
+++ b/qbraid/runtime/postprocess.py
@@ -226,3 +226,47 @@ def normalize_tuples(measurements: list[list[tuple[int, ...]]]) -> list[list[tup
         normalized_measurements.append(normalized_sublist)
 
     return normalized_measurements
+
+
+def distribute_counts(probs: dict[Any, float], shots: int) -> dict[Any, int]:
+    """
+    Adjusts probabilistic counts to ensure the total equals the number of shots.
+
+    Args:
+        probs (dict[Any, float]): A dictionary mapping states to their probabilities.
+        shots (int): The total number of shots to distribute among the states.
+
+    Returns:
+        dict[Any, int]: A dictionary mapping states to their adjusted counts such that
+            the sum of counts equals `shots`.
+
+    Raises:
+        ValueError: If probabilities do not sum to 1, are not in the range [0, 1],
+            or if shots is negative.
+
+    Example:
+        >>> probs = {0: 0.86, 1: 0.14}
+        >>> shots = 10
+        >>> distribute_counts(probs, shots)
+        {0: 9, 1: 1}
+    """
+    if not sum(probs.values()) == 1:
+        raise ValueError("Probabilities must sum to 1.")
+
+    if not all(0 <= prob <= 1 for prob in probs.values()):
+        raise ValueError("Probabilities must be between 0 and 1.")
+
+    if shots < 0:
+        raise ValueError("Number of shots must be non-negative.")
+
+    counts = {state: round(prob * shots) for state, prob in probs.items()}
+
+    diff = shots - sum(counts.values())
+
+    for state in sorted(counts.keys(), key=lambda k: -probs[k]):
+        if diff == 0:
+            break
+        counts[state] += 1 if diff > 0 else -1
+        diff -= 1 if diff > 0 else -1
+
+    return counts

--- a/tests/runtime/test_device.py
+++ b/tests/runtime/test_device.py
@@ -893,7 +893,7 @@ def test_provider_get_basis_gates_ionq():
     basis_gates = QbraidProvider._get_basis_gates(device_data)
     native = {"gpi", "gpi2", "ms", "zz"}
     unique = set(basis_gates)
-    assert len(unique) == len(basis_gates) == 20
+    assert len(unique) == len(basis_gates) == 34
     assert native.issubset(unique)
 
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

- `qbraid/programs/gate_model/ionq.py`: Added support for new gates including `cx`, `cy`, `cz`, `crx`, `cry`, `crz`, `ch`, `ccnot`, `cs`, `csi`, `ct`, `cti`, `cv`, `cvi`.
- `qbraid/passes/qasm/decompose.py`: Updated the `rebase` function to handle gate mappings with predicates.
- `qbraid/transpiler/conversions/openqasm3/openqasm3_to_ionq.py`: Refactored gate mappings and added validation for gate parameters and qubit counts.
- `qbraid/runtime/postprocess.py`: Added `distribute_counts` function to adjust probabilistic counts ensuring the total equals the number of shots.
- `qbraid/runtime/ionq/job.py`: Integrated `distribute_counts` function in `convert_to_counts` method.


