### PR TITLE
housekeep, rzz, code coverage

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -25,7 +25,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -17,6 +17,7 @@ jobs:
   pypi-publish:
     name: Build dist & upload to PyPI
     runs-on: ubuntu-latest
+    if: ${{ github.actor == 'github-actions[bot]' || github.actor == 'ryanhill1' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,7 @@ jobs:
   pypi-publish:
     name: Build dist & upload to PyPI
     runs-on: ubuntu-latest
+    if: ${{ github.actor == 'github-actions[bot]' || github.actor == 'ryanhill1' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,13 @@ Types of changes:
 ### Fixed
 
 ### Added
+- Added testing code coverage for custom `rzz`, `u3`, and `u2` for Cirq $\rightarrow$ PyQuil ([#862](https://github.com/qBraid/qBraid/pull/862))
 
 ### Improved / Modified
 - Vastly reduced size of `qbraid.passes.qasm`, `qbraid.programs.gate_model.qasm2` and `qbraid.programs.gate_model.qasm3` modules as a result of `pyqasm` integration. ([#808](https://github.com/qBraid/qBraid/pull/808))
+- Restricted PyPI publish jobs to specific actors for better security and maintainability. ([#862](https://github.com/qBraid/qBraid/pull/862))
+- Updated `MANIFEST.in` to refine file inclusion/exclusion and enhanced `pyproject.toml` by adjusting dependencies and aligning with `requirements.txt`. ([#862](https://github.com/qBraid/qBraid/pull/862))
+- Enhanced qbraid transpiler QASM2 to Cirq for external gate handling, and updated custom Cirq `RZZGate` to use radians convention to more closely match cirq API. ([#862](https://github.com/qBraid/qBraid/pull/862))
 
 ### Deprecated
 
@@ -27,6 +31,8 @@ Types of changes:
 - Dropped support for Python 3.9 ([#808](https://github.com/qBraid/qBraid/pull/808))
 
 ### Fixed
+- Removed Python 3.9 from daily test matrix ([#862](https://github.com/qBraid/qBraid/pull/862))
+- Fixed OQC test edge case datetime bug ([#862](https://github.com/qBraid/qBraid/pull/862))
 
 ### Dependencies
 - Integrated `pyqasm` as project dependency. ([#808](https://github.com/qBraid/qBraid/pull/808))

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,21 @@
-include *.txt *.md *.ini *.json
-recursive-include docs *.rst *.py *.png *.ico
+# Top-level metadata and configuration files
+include *.md
+include LICENSE
+include pyproject.toml
+
+# Package files
 recursive-include qbraid *.py *.qasm
 include qbraid/py.typed
-prune docs/build/
-exclude examples/*
+
+# Documentation
+graft docs
+prune docs/build
+prune docs/stubs
+
+# Development and testing
+include tox.ini
+include requirements-dev.txt
+recursive-include tests *.py *.qasm
+
+# Exclude bytecode files
+global-exclude *.py[cod]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qbraid"
-dynamic = ["version"]
+dynamic = ["version", "dependencies"]
 description = "Platform-agnostic quantum runtime framework."
 authors = [{name = "qBraid Development Team"}, {email = "contact@qbraid.com"}]
 readme = "README.md"
@@ -31,15 +31,6 @@ classifiers = [
     "Operating System :: Unix",
     "Operating System :: MacOS",
 ]
-dependencies = [
-    "rustworkx>=0.15.0",
-    "numpy>=1.17",
-    "openqasm3[parser]>=0.4.0",
-    "qbraid-core>=0.1.29",
-    "pydantic>2.0.0",
-    "typing-extensions>=4.0.0",
-    "pyqasm>=0.1.0",
-]
 requires-python = ">=3.10"
 
 [project.urls]
@@ -62,7 +53,7 @@ pyqubo = ["pyqubo>=1.4.0"]
 pyquil = ["pyquil>=4.4"]
 pytket = ["pytket>=1.31"]
 qir = ["qbraid-qir>=0.2.0,<=0.2.3", "qbraid-core[runner]>=0.1.29"]
-qiskit = ["qiskit>=0.44,<1.3", "qiskit-ibm-runtime>=0.25.0,<0.35", "qiskit-qasm3-import>=0.4.2", "qiskit-qir>=0.5.0"]
+qiskit = ["qiskit>=1.0,<1.3", "qiskit-ibm-runtime>=0.25.0,<0.35", "qiskit-qasm3-import>=0.5.1", "qiskit-qir>=0.5.0"]
 quera = ["flair-visual[vis]>=0.5.3"]
 visualization = ["ipython", "matplotlib", "pylatexenc", "ipympl"]
 test = ["pytest", "pytest-cov", "sympy", "packaging"]
@@ -85,6 +76,7 @@ qasm3 = "qbraid.programs.gate_model.qasm3:OpenQasm3Program"
 
 [tool.setuptools.dynamic]
 version = {attr = "qbraid._version.__version__"}
+dependencies = {file = ["requirements.txt"]}
 
 [tool.pytest.ini_options]
 minversion = "6.0"
@@ -150,7 +142,7 @@ output = "build/coverage/coverage.xml"
 
 [tool.black]
 line-length = 100
-target-version = ['py39', 'py310', 'py311', 'py312']
+target-version = ['py310', 'py311', 'py312']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/qbraid/_about.py
+++ b/qbraid/_about.py
@@ -88,7 +88,7 @@ def about() -> None:
             version = importlib.metadata.distribution(pkg).version
             if pkg in core_packages:
                 core_dependencies[pkg] = version
-            if pkg in optional_packages:
+            elif pkg in optional_packages:
                 optional_dependencies[pkg] = version
         except importlib.metadata.PackageNotFoundError:
             continue

--- a/qbraid/transpiler/conversions/cirq/cirq_quil_output.py
+++ b/qbraid/transpiler/conversions/cirq/cirq_quil_output.py
@@ -20,6 +20,7 @@
 Module defining qBraid Cirq QuilOutput.
 
 """
+from __future__ import annotations
 
 import string
 from fractions import Fraction
@@ -64,7 +65,7 @@ class QuilFormatter(string.Formatter):
     """A unique formatter to correctly output values to QUIL."""
 
     def __init__(
-        self, qubit_id_map: dict["cirq.Qid", str], measurement_id_map: dict[str, str]
+        self, qubit_id_map: dict[cirq.Qid, str], measurement_id_map: dict[str, str]
     ) -> None:
         """Inits QuilFormatter.
 
@@ -364,11 +365,12 @@ def _zzpow_gate(op: cirq.Operation, formatter: QuilFormatter) -> str:
 
 def _rzz_gate(op: cirq.Operation, formatter: QuilFormatter) -> str:
     gate = cast(RZZGate, op.gate)
+    if gate._rads == 1:
+        return formatter.format("CZ {0} {1}\n", op.qubits[0], op.qubits[1])
+    if gate._rads == 0:
+        return formatter.format("I {0}\nI {1}\n", op.qubits[0], op.qubits[1])
     return formatter.format(
-        "CPHASE({0}) {1} {2}\n",
-        gate._half_turns * np.pi,
-        op.qubits[0],
-        op.qubits[1],
+        "RZZ({0}) {1} {2}\n", exponent_to_pi_string(gate._rads * np.pi), op.qubits[0], op.qubits[1]
     )
 
 

--- a/qbraid/transpiler/conversions/cirq/cirq_to_pyquil.py
+++ b/qbraid/transpiler/conversions/cirq/cirq_to_pyquil.py
@@ -32,11 +32,11 @@ pyquil = LazyLoader("pyquil", globals(), "pyquil")
 
 if TYPE_CHECKING:
     import cirq.circuits
-    import pyquil as pyquil_
+    from pyquil import Program
 
 
 @weight(0.74)
-def cirq_to_pyquil(circuit: cirq.circuits.Circuit) -> pyquil_.Program:
+def cirq_to_pyquil(circuit: cirq.circuits.Circuit) -> Program:
     """Returns a pyQuil Program equivalent to the input Cirq circuit.
 
     Args:

--- a/qbraid/transpiler/conversions/openqasm3/openqasm3_to_ionq.py
+++ b/qbraid/transpiler/conversions/openqasm3/openqasm3_to_ionq.py
@@ -231,7 +231,7 @@ def _parse_gates(program: Union[OpenQasm2Program, OpenQasm3Program]) -> list[dic
 
                 elif ionq_name in TWO_QUBIT_PARAM_ANGLE_PHASE:
                     params = extract_params(statement)
-                    if len(params) not in {2, 3}:
+                    if len(params) not in {2, 3}:  # pragma: no cover
                         raise ValueError(
                             f"Invalid number of parameters for the '{name}' gate. "
                             f"Expected 2 or 3, got {len(params)}"

--- a/qbraid/transpiler/conversions/qasm2/cirq_qasm_parser.py
+++ b/qbraid/transpiler/conversions/qasm2/cirq_qasm_parser.py
@@ -341,7 +341,7 @@ class QasmParser:
         ),
         'rzz': QasmGateStatement(
             qasm_gate='rzz',
-            cirq_gate=(lambda params: rzz(params[0])),
+            cirq_gate=(lambda params: rzz(params[0] / np.pi)),
             num_params=1,
             num_args=2,
         ),

--- a/qbraid/transpiler/conversions/qasm2/cirq_qasm_parser.py
+++ b/qbraid/transpiler/conversions/qasm2/cirq_qasm_parser.py
@@ -285,9 +285,9 @@ class QasmParser:
         'ccx': QasmGateStatement(qasm_gate='ccx', num_params=0, num_args=3, cirq_gate=ops.CCX),
         'c3x': QasmGateStatement(qasm_gate='c3x', num_params=0, num_args=4, cirq_gate=ops.ControlledGate(ops.CCX)),
         'c4x': QasmGateStatement(qasm_gate='c4x', num_params=0, num_args=5, cirq_gate=ops.ControlledGate(ops.ControlledGate(ops.CCX))),
-        'sdg': QasmGateStatement(qasm_gate='sdg', num_params=0, num_args=1, cirq_gate=ops.S**-1),
-        'csdg': QasmGateStatement(qasm_gate='csdg', num_params=0, num_args=2, cirq_gate=ops.ControlledGate(ops.S**-1)),
-        'tdg': QasmGateStatement(qasm_gate='tdg', num_params=0, num_args=1, cirq_gate=ops.T**-1),
+        'sdg': QasmGateStatement(qasm_gate='sdg', num_params=0, num_args=1, cirq_gate=ops.ZPowGate(exponent=-0.5)),
+        'csdg': QasmGateStatement(qasm_gate='csdg', num_params=0, num_args=2, cirq_gate=ops.ControlledGate(ops.ZPowGate(exponent=-0.5))),
+        'tdg': QasmGateStatement(qasm_gate='tdg', num_params=0, num_args=1, cirq_gate=ops.ZPowGate(exponent=-0.25)),
         'crz': QasmGateStatement(
             qasm_gate='crz',
             cirq_gate=(lambda params: ops.ControlledGate(ops.rz(params[0]))),

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,13 +4,13 @@ cirq-core>=1.3,<1.5
 pennylane<0.40
 pyquil>=4.4; python_version < "3.12"
 pytket>=1.31; python_version >= "3.10"
-qiskit>=0.44,<1.3
+qiskit>=1.0,<1.3
 
 # transpiler extras
 ply>=3.6
 cirq-ionq>=1.3,<1.5
 qbraid-qir>=0.2.0,<=0.2.3
-qiskit-qasm3-import>=0.4.2
+qiskit-qasm3-import>=0.5.1
 pytket-braket>=0.35.1,<0.39.0; python_version >= "3.10"
 bloqade>=0.15.13
 qiskit-qir

--- a/tests/fixtures/qiskit/gates.py
+++ b/tests/fixtures/qiskit/gates.py
@@ -79,11 +79,11 @@ def generate_params(varnames: list[str], seed: Optional[int] = None):
     return params
 
 
-def get_qiskit_gates(seed: Optional[int] = None):
+def get_qiskit_gates(seed: Optional[int] = None, exclude: list[str] = []):
     """Returns a dictionary of all qiskit gates with random parameters"""
     qiskit_gates = {attr: None for attr in dir(sg) if attr[0] in string.ascii_uppercase}
     for gate in qiskit_gates:
         varnames = [v for v in getattr(sg, gate).__init__.__code__.co_varnames if v != "self"]
         params = generate_params(varnames, seed=seed)
         qiskit_gates[gate] = getattr(sg, gate)(**params)
-    return {k: v for k, v in qiskit_gates.items() if v is not None}
+    return {k: v for k, v in qiskit_gates.items() if v is not None and k not in exclude}

--- a/tests/runtime/oqc/test_oqc_runtime.py
+++ b/tests/runtime/oqc/test_oqc_runtime.py
@@ -158,7 +158,7 @@ TOSHIKO_EXEC_ESTIMATE = {
 def online_window() -> str:
     """Return a window start time for an online QPU."""
     now = datetime.datetime.now()
-    start_time = f"{now.year}-{now.month}-{now.day} {(now.hour - 1):02}:00:00"
+    start_time = f"{now.year}-{now.month}-{now.day} {(now.hour):02}:00:00"
     end_time = f"{now.year}-{now.month}-{now.day} {(now.hour):02}:59:59"
     return start_time, end_time
 

--- a/tests/transpiler/qasm/test_cirq_custom.py
+++ b/tests/transpiler/qasm/test_cirq_custom.py
@@ -42,10 +42,10 @@ class FakeArgs:
 
 def test_rzz_gate():
     """Test RZZGate"""
-    theta = 0.2
-    gate = RZZGate(theta)
+    rads = 0.2
+    gate = RZZGate(rads)
 
-    itheta2 = 1j * float(theta) / 2
+    itheta2 = 1j * rads * np.pi / 2
     expected_unitary = np.array(
         [
             [np.exp(-itheta2), 0, 0, 0],
@@ -56,7 +56,7 @@ def test_rzz_gate():
     )
     assert gate._num_qubits_() == 2
     assert gate._unitary_().all() == expected_unitary.all()
-    assert gate._circuit_diagram_info_(args=FakeArgs(1)).wire_symbols[0] == "RZZ(0.1)"
+    assert gate._circuit_diagram_info_(args=FakeArgs(1)).wire_symbols[0] == "RZZ(0.2)"
 
 
 def test_rzz_gate_method():
@@ -64,7 +64,7 @@ def test_rzz_gate_method():
     id_gate = rzz(0)
     assert isinstance(id_gate, IdentityGate)
 
-    diagonal = rzz(2 * np.pi)
+    diagonal = rzz(2)
     assert isinstance(diagonal, TwoQubitDiagonalGate)
 
     random_rzz = rzz(0.5)

--- a/tests/transpiler/qiskit/test_conversions_qiskit.py
+++ b/tests/transpiler/qiskit/test_conversions_qiskit.py
@@ -194,7 +194,7 @@ def test_crz_gate_from_qiskit(qubits):
 
 
 @pytest.mark.parametrize("qubits", ([0, 1], [1, 0]))
-@pytest.mark.parametrize("theta", (0, 2 * np.pi, np.pi / 2, np.pi / 4))
+@pytest.mark.parametrize("theta", (0, np.pi, 2 * np.pi, np.pi / 2, np.pi / 4))
 def test_rzz_gate_from_qiskit(qubits, theta):
     """Tests converting Rzz gate from Qiskit to Cirq."""
     qiskit_circuit = QuantumCircuit(2)

--- a/tests/transpiler/qiskit/test_coverage_from_qiskit.py
+++ b/tests/transpiler/qiskit/test_coverage_from_qiskit.py
@@ -28,7 +28,7 @@ def is_package_installed(package_name: str) -> bool:
     return importlib.util.find_spec(package_name) is not None
 
 
-ALL_TARGETS = [("braket", 1.0), ("cirq", 1.0), ("pyquil", 1.0), ("pytket", 0.98)]
+ALL_TARGETS = [("braket", 1.0), ("cirq", 1.0), ("pyquil", 0.98), ("pytket", 1.0)]
 AVAILABLE_TARGETS = [(name, version) for name, version in ALL_TARGETS if is_package_installed(name)]
 
 qiskit_gates = get_qiskit_gates(seed=0, exclude=["GlobalPhaseGate"])

--- a/tests/transpiler/qiskit/test_coverage_from_qiskit.py
+++ b/tests/transpiler/qiskit/test_coverage_from_qiskit.py
@@ -28,10 +28,10 @@ def is_package_installed(package_name: str) -> bool:
     return importlib.util.find_spec(package_name) is not None
 
 
-ALL_TARGETS = [("braket", 0.98), ("cirq", 0.98), ("pyquil", 0.98), ("pytket", 0.98)]
+ALL_TARGETS = [("braket", 1.0), ("cirq", 1.0), ("pyquil", 1.0), ("pytket", 0.98)]
 AVAILABLE_TARGETS = [(name, version) for name, version in ALL_TARGETS if is_package_installed(name)]
 
-qiskit_gates = get_qiskit_gates(seed=0)
+qiskit_gates = get_qiskit_gates(seed=0, exclude=["GlobalPhaseGate"])
 
 graph = ConversionGraph(require_native=True)
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,9 +10,7 @@ skip_missing_interpreter = true
 [testenv]
 commands_pre = python -m pip install .
 basepython = python3
-deps =
-    -r{toxinidir}/requirements.txt
-    -r{toxinidir}/requirements-dev.txt
+deps = -r{toxinidir}/requirements-dev.txt
 pass_env =
     AWS_ACCESS_KEY_ID
     AWS_SECRET_ACCESS_KEY
@@ -53,7 +51,7 @@ envdir = .tox/linters
 skip_install = true
 deps = pylint
 commands =
-    pylint {posargs} qbraid bin tests --disable=C0103,C0414,E0401,R0801,R0902,R0903,R0911,R0912,R0914,R0917,W0212,W0511 --extension-pkg-whitelist=rustworkx
+    pylint {posargs} qbraid bin tests --disable=C0103,C0414,E0401,R0801,R0902,R0903,R0911,R0912,R0914,R0917,W0212,W0511,W0621 --extension-pkg-whitelist=rustworkx
 
 [testenv:black]
 envdir = .tox/linters


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

- Removed Python 3.9 from daily test matrix and restricted PyPI publish jobs to specific actors for better security and maintainability.
- Updated `MANIFEST.in` to refine file inclusion/exclusion and enhanced `pyproject.toml` by adjusting dependencies and aligning with `requirements.txt`.
- Enhanced qbraid transpiler functions with better type annotations, external gate handling, and radians-based updates for the `RZZGate`.
- Added testing code coverage for custom `rzz`, `u3`, and `u2` for Cirq $\rightarrow$ PyQuil