### PR TITLE
IonQ runtime fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,20 +18,46 @@ Types of changes:
 ### Fixed
 
 ### Added
-- Added step to remove qasm barriers before submitting to qBraid QIR device ([#880](https://github.com/qBraid/qBraid/pull/880))
-- Added `id` gate to list of supported IonQ gates (but is still skipped in `IonQDict` conversion step) ([#880](https://github.com/qBraid/qBraid/pull/880))
 
 ### Improved / Modified
-- Improved `IonQDevice.transform` method with try/except logic using `pyqasm.unroll` ([#880](https://github.com/qBraid/qBraid/pull/880))
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
-- Fixed type checking in transpiler `weight` and `requires_extras` annotations / decorators ([#880](https://github.com/qBraid/qBraid/pull/880))
 
 ### Dependencies
+
+## [0.9.2] - 2025-01-23
+
+### Added
+- Added `id` gate to list of supported IonQ gates (but is still skipped in `IonQDict` conversion step) ([#880](https://github.com/qBraid/qBraid/pull/880))
+- Added `qiskit-ionq` integration into `IonQDevice.run` method so that if user has `qiskit-ionq` installed, we just go directly through their native `qiskit.QuantumCircuit` $\rightarrow$ `IonQDict` conversion rather than using our own. ([#880](https://github.com/qBraid/qBraid/pull/880))
+
+```python
+from qiskit import QuantumCircuit
+
+from qbraid.runtime import IonQProvider
+from qbraid.programs.gate_model.ionq import GateSet
+
+
+circuit = QuantumCircuit(1)
+circuit.u(0.1, 0.2, 0.3, 0)
+
+provider = IonQProvider()
+device = provider.get_device("simulator")
+
+job = device.run(circuit, shots=100, gateset=GateSet.NATIVE, ionq_compiler_synthesis=False)
+```
+
+If `qiskit-ionq` not installed, the above code will fail. But with `qiskit-ionq` installed, it will work.
+
+### Improved / Modified
+- Improved `IonQDevice.transform` method with try/except logic using `pyqasm.unroll` ([#880](https://github.com/qBraid/qBraid/pull/880))
+
+### Fixed
+- Fixed type checking in transpiler `weight` and `requires_extras` annotations / decorators ([#880](https://github.com/qBraid/qBraid/pull/880))
 
 ## [0.9.1] - 2025-01-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,14 +18,18 @@ Types of changes:
 ### Fixed
 
 ### Added
+- Added step to remove qasm barriers before submitting to qBraid QIR device ([#880](https://github.com/qBraid/qBraid/pull/880))
+- Added `id` gate to list of supported IonQ gates (but is still skipped in `IonQDict` conversion step) ([#880](https://github.com/qBraid/qBraid/pull/880))
 
 ### Improved / Modified
+- Improved `IonQDevice.transform` method with try/except logic using `pyqasm.unroll` ([#880](https://github.com/qBraid/qBraid/pull/880))
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+- Fixed type checking in transpiler `weight` and `requires_extras` annotations / decorators ([#880](https://github.com/qBraid/qBraid/pull/880))
 
 ### Dependencies
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,14 @@ pytket = "qbraid.programs.gate_model.pytket:PytketCircuit"
 qasm2 = "qbraid.programs.gate_model.qasm2:OpenQasm2Program"
 qasm3 = "qbraid.programs.gate_model.qasm3:OpenQasm3Program"
 
+[project.entry-points."qbraid.jobs"]
+aws = "qbraid.runtime.aws.job:BraketQuantumTask"
+azure = "qbraid.runtime.azure.job:AzureQuantumJob"
+ibm = "qbraid.runtime.ibm.job:QiskitJob"
+ionq = "qbraid.runtime.ionq.job:IonQJob"
+qbraid = "qbraid.runtime.native.job:QbraidJob"
+oqc = "qbraid.runtime.oqc.job:OQCJob"
+
 [tool.setuptools.dynamic]
 version = {attr = "qbraid._version.__version__"}
 dependencies = {file = ["requirements.txt"]}

--- a/qbraid/programs/gate_model/ionq.py
+++ b/qbraid/programs/gate_model/ionq.py
@@ -54,6 +54,7 @@ IONQ_QIS_GATES = [
     "cti",
     "cv",
     "cvi",
+    "id",
 ]
 
 IONQ_NATIVE_GATES_BASE = ["gpi", "gpi2"]

--- a/qbraid/programs/gate_model/qasm2.py
+++ b/qbraid/programs/gate_model/qasm2.py
@@ -78,9 +78,9 @@ class OpenQasm2Program(GateModelProgram):
     def transform(self, device: qbraid.runtime.QuantumDevice, **kwargs) -> None:
         """Transform program to according to device target profile."""
         if device.id == "quera_qasm_simulator":
-            self._module.remove_measurements()
             self._module.unroll()
-            self.program = pyqasm.dumps(self._module)
+            self._module.remove_measurements()
+            self._program = pyqasm.dumps(self._module)
 
         basis_gates = device.profile.get("basis_gates")
 

--- a/qbraid/programs/gate_model/qasm3.py
+++ b/qbraid/programs/gate_model/qasm3.py
@@ -109,6 +109,11 @@ class OpenQasm3Program(GateModelProgram):
 
     def transform(self, device: qbraid.runtime.QuantumDevice, **kwargs) -> None:
         """Transform program to according to device target profile."""
+        if device.id == "qbraid_qir_simulator":
+            self._module.unroll()
+            self._module.remove_barriers()
+            self._program = pyqasm.dumps(self._module)
+
         basis_gates = device.profile.get("basis_gates")
 
         if basis_gates is not None and len(basis_gates) > 0:

--- a/qbraid/programs/gate_model/qasm3.py
+++ b/qbraid/programs/gate_model/qasm3.py
@@ -109,11 +109,6 @@ class OpenQasm3Program(GateModelProgram):
 
     def transform(self, device: qbraid.runtime.QuantumDevice, **kwargs) -> None:
         """Transform program to according to device target profile."""
-        if device.id == "qbraid_qir_simulator":
-            self._module.unroll()
-            self._module.remove_barriers()
-            self._program = pyqasm.dumps(self._module)
-
         basis_gates = device.profile.get("basis_gates")
 
         if basis_gates is not None and len(basis_gates) > 0:

--- a/qbraid/runtime/ionq/device.py
+++ b/qbraid/runtime/ionq/device.py
@@ -20,8 +20,8 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 import pyqasm
 
 from qbraid._logging import logger
-from qbraid.programs import load_program
 from qbraid.passes import CompilationError
+from qbraid.programs import load_program
 from qbraid.programs.gate_model.qasm2 import OpenQasm2Program
 from qbraid.programs.gate_model.qasm3 import OpenQasm3Program
 from qbraid.programs.typer import IonQDict, IonQDictType, QasmStringType

--- a/qbraid/runtime/ionq/device.py
+++ b/qbraid/runtime/ionq/device.py
@@ -99,7 +99,6 @@ class IonQDevice(QuantumDevice):
             program._module.unroll()
             program._program = pyqasm.dumps(program._module)
             program.transform(device=self, gate_mappings=IONQ_GATE_MAP)
-            raise err
         return program.program
 
     @staticmethod

--- a/qbraid/transpiler/conversions/braket/braket_to_cirq.py
+++ b/qbraid/transpiler/conversions/braket/braket_to_cirq.py
@@ -72,7 +72,7 @@ def braket_gate_to_matrix(gate: braket_gates.Unitary) -> np.ndarray:
     return bk_circuit.to_unitary()
 
 
-@weight(1)
+@weight(0.99)
 def braket_to_cirq(circuit: BKCircuit) -> cirq_circuits.Circuit:
     """Returns a Cirq circuit equivalent to the input Braket circuit.
 

--- a/qbraid/transpiler/conversions/openqasm3/openqasm3_to_ionq.py
+++ b/qbraid/transpiler/conversions/openqasm3/openqasm3_to_ionq.py
@@ -90,6 +90,12 @@ IONQ_THREE_QUBIT_GATE_MAP = {
     "toffoli": "cnot",
 }
 
+IONQ_THREE_QUBIT_GATE_ALIASES = {
+    "ccnot": "ccnot",
+    "ccx": "ccnot",
+    "toffoli": "ccnot",
+}
+
 
 def extract_params(statement: openqasm3.ast.QuantumGate) -> list[str]:
     """Extracts the parameter(s) from a QuantumGate statement.
@@ -147,6 +153,10 @@ def _parse_gates(program: Union[OpenQasm2Program, OpenQasm3Program]) -> list[dic
     for statement in original_program.statements:
         if isinstance(statement, openqasm3.ast.QuantumGate):
             name = statement.name.name.lower()
+
+            if name == "id":
+                continue
+
             qubits = statement.qubits
             qubit_values = []
 

--- a/qbraid/transpiler/conversions/qiskit/qiskit_to_qasm2.py
+++ b/qbraid/transpiler/conversions/qiskit/qiskit_to_qasm2.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from qbraid.programs.typer import Qasm2StringType
 
 
-@weight(1)
+@weight(0.999)
 def qiskit_to_qasm2(circuit: qiskit_.QuantumCircuit) -> Qasm2StringType:
     """Returns OpenQASM 2 string equivalent to the input Qiskit circuit.
 

--- a/qbraid/visualization/exceptions.py
+++ b/qbraid/visualization/exceptions.py
@@ -7,6 +7,7 @@
 # See the LICENSE file in the project root or <https://www.gnu.org/licenses/gpl-3.0.html>.
 #
 # THERE IS NO WARRANTY for the qBraid-SDK, as per Section 15 of the GPL v3.
+
 """
 Module for exceptions raised by visualization tools.
 

--- a/qbraid/visualization/plot_conversions.py
+++ b/qbraid/visualization/plot_conversions.py
@@ -7,6 +7,7 @@
 # See the LICENSE file in the project root or <https://www.gnu.org/licenses/gpl-3.0.html>.
 #
 # THERE IS NO WARRANTY for the qBraid-SDK, as per Section 15 of the GPL v3.
+
 """
 Module for plotting qBraid transpiler quantum program conversion graphs.
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,15 +11,16 @@ cudaq>=0.9.0; python_version < "3.13"
 ply>=3.6
 cirq-ionq>=1.3,<1.5
 qbraid-qir>=0.2.0,<=0.3.0
-qiskit-qasm3-import>=0.5.1
-qiskit-aer>=0.15.0; python_version < "3.13"
 pytket-braket>=0.35.1,<0.39.0
 bloqade>=0.15.13; python_version < "3.13"
+qiskit-qasm3-import>=0.5.1
+qiskit-aer>=0.15.0; python_version < "3.13"
 qiskit-qir
+qiskit-ionq>=0.5.12
 
 # optional runtime dependencies
-oqc-qcaas-client>=3.11.0; python_version < "3.13"
 qiskit-ibm-runtime>=0.25.0,<0.35
+oqc-qcaas-client>=3.11.0; python_version < "3.13"
 azure-quantum>=2.0,<2.3
 azure-storage-blob>=12.20,<13.0
 azure-identity>=1.17,<2.0

--- a/tests/fixtures/pytket/circuits.py
+++ b/tests/fixtures/pytket/circuits.py
@@ -7,6 +7,7 @@
 # See the LICENSE file in the project root or <https://www.gnu.org/licenses/gpl-3.0.html>.
 #
 # THERE IS NO WARRANTY for the qBraid-SDK, as per Section 15 of the GPL v3.
+
 """
 Module containing pytket programs used for testing
 

--- a/tests/runtime/ionq/test_ionq_runtime.py
+++ b/tests/runtime/ionq/test_ionq_runtime.py
@@ -14,11 +14,11 @@
 Unit tests for IonQProvider class
 
 """
-import uuid
 import textwrap
+import uuid
 from itertools import combinations
 from typing import Any, Optional
-from unittest.mock import Mock, patch, call, ANY
+from unittest.mock import ANY, Mock, call, patch
 
 import pytest
 
@@ -130,6 +130,7 @@ CHARACTERIZATION_DATA = {
     "id": "f518d0c9-34c6-4854-890e-a0e4f339bd64",
     "backend": "qpu.harmony",
 }
+
 
 def assert_qasm_equal(qasm1, qasm2):
     """Assert that two QASM strings are equal."""
@@ -407,10 +408,12 @@ def test_ionq_device_transform_retry():
         qasm_compat = device.transform(qasm_input)
         assert_qasm_equal(qasm_compat, qasm_out)
 
-        mock_logger.debug.assert_has_calls([
-            call("Failed to transform OpenQASM program for IonQ: %s", ANY),
-            call("Retrying using pyqasm.unroll()...")
-        ])
+        mock_logger.debug.assert_has_calls(
+            [
+                call("Failed to transform OpenQASM program for IonQ: %s", ANY),
+                call("Retrying using pyqasm.unroll()..."),
+            ]
+        )
         assert mock_logger.debug.call_count == 2
 
 

--- a/tests/runtime/ionq/test_ionq_runtime.py
+++ b/tests/runtime/ionq/test_ionq_runtime.py
@@ -335,6 +335,31 @@ def test_ionq_device_transform_run_input(qis_input, qis_input_decomp):
         assert provider == dummy_provider
 
 
+# def test_ionq_device_transform_retry():
+#     """Test transforming OpenQASM 2 string to supported gates + json format."""
+#     qasm_input = """
+#     OPENQASM 2.0;
+#     include "qelib1.inc";
+#     qreg q[1];
+#     u2(2.25,0.76) q[0];
+#     """
+
+#     with (
+#         patch("qbraid.runtime.ionq.provider.Session") as mock_session,
+#         patch(
+#             "qbraid.runtime.ionq.provider.IonQProvider._get_characterization"
+#         ) as mock_get_characterization,
+#     ):
+
+#         mock_get_characterization.side_effect = mock_characterization
+#         mock_session.return_value.get.return_value.json.return_value = DEVICE_DATA
+
+#         provider = IonQProvider(api_key="fake_api_key")
+#         test_devices = provider.get_devices()
+#         device = test_devices[0]
+#         qasm_compat = device.transform(qasm_input)
+
+
 @pytest.mark.parametrize("circuit", range(FIXTURE_COUNT), indirect=True)
 @patch("qbraid_core.sessions.Session.get")
 @patch("qbraid_core.sessions.Session.post")

--- a/tests/runtime/ionq/test_ionq_runtime.py
+++ b/tests/runtime/ionq/test_ionq_runtime.py
@@ -14,6 +14,7 @@
 Unit tests for IonQProvider class
 
 """
+import importlib.util
 import textwrap
 import uuid
 from itertools import combinations
@@ -759,6 +760,9 @@ def qiskit_circuit():
     return qc
 
 
+@pytest.mark.skipif(
+    importlib.util.find_spec("qiskit_ionq") is None, reason="qiskit-ionq not installed."
+)
 @pytest.mark.parametrize("gateset", ["native", "qis"])
 def test_qiskit_ionq_conversion_type(qiskit_circuit, gateset):
     """Test that the output of the qiskit_ionq conversion is an IonQDict."""
@@ -772,6 +776,9 @@ def test_qiskit_ionq_conversion_type(qiskit_circuit, gateset):
     assert isinstance(output, IonQDict)
 
 
+@pytest.mark.skipif(
+    importlib.util.find_spec("qiskit_ionq") is None, reason="qiskit-ionq not installed."
+)
 @pytest.mark.parametrize(
     "gateset,expected",
     [

--- a/tests/runtime/ionq/test_ionq_runtime.py
+++ b/tests/runtime/ionq/test_ionq_runtime.py
@@ -850,3 +850,25 @@ def test_ionq_device_run_warnings(monkeypatch):
     assert "IonQ compiler synthesis option is only applicable" in str(record[1].message)
 
     device.submit.assert_called()
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("qiskit_ionq") is None, reason="qiskit-ionq not installed."
+)
+def test_ionq_device_run_batch_with_qiskit_ionq(qiskit_circuit):
+    """Test calling IonQDevice.run with batch of qiskit circuits
+    and qiskit-ionq installed."""
+    device = IonQDevice(
+        TargetProfile(device_id="simulator", simulator=True),
+        IonQSession("fake_api_key"),
+    )
+    with patch("qbraid_core.sessions.Session.get") as mock_get:
+        mock_get.return_value.json.return_value = DEVICE_DATA
+
+    device.submit = Mock(return_value=[Mock(), Mock()])
+
+    qiskit_batch = [qiskit_circuit, qiskit_circuit]
+
+    device.run(qiskit_batch, shots=1000, gateset=GateSet.QIS)
+
+    device.submit.assert_called_once()

--- a/tests/runtime/ionq/test_ionq_runtime.py
+++ b/tests/runtime/ionq/test_ionq_runtime.py
@@ -420,8 +420,10 @@ def test_ionq_device_transform_retry():
 @pytest.mark.parametrize("circuit", range(FIXTURE_COUNT), indirect=True)
 @patch("qbraid_core.sessions.Session.get")
 @patch("qbraid_core.sessions.Session.post")
-def test_ionq_device_run_submit_job(mock_post, mock_get, circuit):
+def test_ionq_device_run_submit_job(mock_post, mock_get, circuit, monkeypatch):
     """Test running a fake job."""
+    monkeypatch.setattr("qbraid.runtime.ionq.device.importlib.util.find_spec", lambda _: None)
+
     mock_get_response = Mock()
     mock_get_response.json.side_effect = [
         DEVICE_DATA,  # provider.get_device("simulator")
@@ -471,7 +473,8 @@ def test_ionq_device_run_submit_job(mock_post, mock_get, circuit):
 @pytest.mark.parametrize("circuit", range(FIXTURE_COUNT), indirect=True)
 @patch("qbraid_core.sessions.Session.get")
 @patch("qbraid_core.sessions.Session.post")
-def test_ionq_failed_job(mock_post, mock_get, circuit):
+@patch("importlib.util.find_spec", return_value=None)
+def test_ionq_failed_job(mock_find_spec, mock_post, mock_get, circuit):
     """Test running a fake job."""
     GET_JOB_RESPONSE["status"] = "failed"
     mock_get_response = Mock()

--- a/tests/runtime/test_device.py
+++ b/tests/runtime/test_device.py
@@ -903,7 +903,7 @@ def test_provider_get_basis_gates_ionq():
     basis_gates = QbraidProvider._get_basis_gates(device_data)
     native = {"gpi", "gpi2", "ms", "zz"}
     unique = set(basis_gates)
-    assert len(unique) == len(basis_gates) == 34
+    assert len(unique) == len(basis_gates) == 35
     assert native.issubset(unique)
 
 

--- a/tests/transpiler/qasm/test_qasm_to_ionq.py
+++ b/tests/transpiler/qasm/test_qasm_to_ionq.py
@@ -54,6 +54,7 @@ def test_ionq_device_extract_gate_data():
     s q[0];
     sdg q[0];
     si q[0];
+    id q[0];
     t q[0];
     tdg q[0];
     ti q[1];

--- a/tests/transpiler/test_conversion_edge.py
+++ b/tests/transpiler/test_conversion_edge.py
@@ -28,8 +28,7 @@ from qbraid.transpiler.edge import Conversion
 from qbraid.transpiler.graph import ConversionGraph
 
 
-@requires_extras("alice")
-@requires_extras("bob")
+@requires_extras("alice", "bob")
 def dummy_func():
     """Dummy function for testing requires_extras decorator."""
 
@@ -39,7 +38,7 @@ def test_requires_extras_appends_dependency():
     Test that the requires_extras decorator correctly appends a dependency
     to the function's attribute list.
     """
-    assert getattr(dummy_func, "requires_extras") == ["bob", "alice"]
+    assert getattr(dummy_func, "requires_extras") == ["alice", "bob"]
 
 
 def test_raise_for_unsupported_program_input():

--- a/tox.ini
+++ b/tox.ini
@@ -77,7 +77,7 @@ commands =
 [testenv:headers]
 envdir = .tox/linters
 skip_install = true
-deps = qbraid-cli>=0.8.2
+deps = qbraid-cli==0.9.4
 commands =
     qbraid admin headers tests bin qbraid --type=gpl {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -77,7 +77,7 @@ commands =
 [testenv:headers]
 envdir = .tox/linters
 skip_install = true
-deps = qbraid-cli==0.9.4
+deps = qbraid-cli>=0.9.9
 commands =
     qbraid admin headers tests bin qbraid --type=gpl {posargs}
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

- Add `id` gate to list of supported IonQ gates, but skip in transformation
- Add retry in IonQDevice transform method using pyqasm unrolling
- Remove qasm barriers before submitting to qBraid QIR device
- fix some type checking in transpiler weight and requires extras annotations
- IonQ runtime updates related to:
    - #877 
    - #840
