### PR TITLE
program serialization and load_job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,11 @@ Types of changes:
 ### Added
 - Added `cudaq` to `QPROGRAM_REGISTRY` dynamic import list ([#882](https://github.com/qBraid/qBraid/pull/882))
 - Added `qiskit_ionq` conversion to transpiler and refactored `IonQDevice._apply_qiskit_ionq_conversion` accordingly ([#882](https://github.com/qBraid/qBraid/pull/882))
+- Added `qbraid.runtime.load_job` function that uses entrypoints to load provider job class and create instance with job id ([#883](https://github.com/qBraid/qBraid/pull/883))
+- Added `QuantumProgram.serialize` method to streamline creation of `ProgramSpec` classes in `QbraidProvider` ([#883](https://github.com/qBraid/qBraid/pull/883))
 
 ### Improved / Modified
+- Switched all `QbraidJob` sub-classes to only require `job_id` as positional argument, and any other args that used to be required for auth can now be loaded with credentials from environment variables ([#883](https://github.com/qBraid/qBraid/pull/883))
 
 ### Deprecated
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ aws = "qbraid.runtime.aws.job:BraketQuantumTask"
 azure = "qbraid.runtime.azure.job:AzureQuantumJob"
 ibm = "qbraid.runtime.ibm.job:QiskitJob"
 ionq = "qbraid.runtime.ionq.job:IonQJob"
-qbraid = "qbraid.runtime.native.job:QbraidJob"
+native = "qbraid.runtime.native.job:QbraidJob"
 oqc = "qbraid.runtime.oqc.job:OQCJob"
 
 [tool.setuptools.dynamic]

--- a/qbraid/programs/ahs/_model.py
+++ b/qbraid/programs/ahs/_model.py
@@ -55,6 +55,10 @@ class AnalogHamiltonianProgram(QuantumProgram, ABC):
     def to_dict(self) -> dict:
         """Return the dictionary representation of the program."""
 
+    def serialize(self) -> dict[str, str]:
+        """Return the program in a format suitable for submission to the qBraid API."""
+        return {"ahs": json.dumps(self, cls=AHSEncoder)}
+
     def __eq__(self, other: Any) -> bool:
         """Check if two programs are equal."""
         if not isinstance(other, self.__class__):

--- a/qbraid/programs/annealing/_model.py
+++ b/qbraid/programs/annealing/_model.py
@@ -112,6 +112,10 @@ class AnnealingProgram(QuantumProgram, ABC):
         """Serialize the annealing problem to a JSON string."""
         return json.dumps(self, cls=ProblemEncoder)
 
+    def serialize(self) -> dict[str, str]:
+        """Return the program in a format suitable for submission to the qBraid API."""
+        return {"problem": self.to_json()}
+
     def __eq__(self, other) -> bool:
         if not isinstance(other, self.__class__):
             return False

--- a/qbraid/programs/gate_model/_model.py
+++ b/qbraid/programs/gate_model/_model.py
@@ -135,3 +135,7 @@ class GateModelProgram(QuantumProgram, ABC):
     def transform(self, device: qbraid.runtime.QuantumDevice) -> None:
         """Transform program to according to device target profile."""
         return None
+
+    def serialize(self) -> dict[str, str]:
+        """Return the program in a format suitable for submission to the qBraid API."""
+        raise NotImplementedError

--- a/qbraid/programs/gate_model/braket.py
+++ b/qbraid/programs/gate_model/braket.py
@@ -57,7 +57,7 @@ class BraketCircuit(GateModelProgram):
         """Return the circuit depth (i.e., length of critical path)."""
         return self.program.depth
 
-    def _unitary(self) -> "np.ndarray":
+    def _unitary(self) -> np.ndarray:
         """Calculate unitary of circuit."""
         return self.program.to_unitary()
 
@@ -129,3 +129,16 @@ class BraketCircuit(GateModelProgram):
         """Transform program to according to device target profile."""
         if device.simulator:
             self.remove_idle_qubits()
+
+    def serialize(self) -> dict[str, str]:
+        """Return the program in a format suitable for submission to the qBraid API."""
+        # pylint: disable=import-outside-toplevel
+        from qbraid.programs.gate_model.qasm3 import OpenQasm3Program
+        from qbraid.transpiler.conversions.braket import braket_to_qasm3
+
+        # pylint: enable=import-outside-toplevel
+
+        qasm = braket_to_qasm3(self.program)
+        program = OpenQasm3Program(qasm)
+
+        return program.serialize()

--- a/qbraid/programs/gate_model/ionq.py
+++ b/qbraid/programs/gate_model/ionq.py
@@ -14,6 +14,7 @@ Module defining IonQProgram Class
 """
 from __future__ import annotations
 
+import json
 from enum import Enum
 from typing import Any
 
@@ -156,3 +157,7 @@ class IonQProgram(GateModelProgram):
                 raise ValueError(
                     f"Invalid gate '{gate}'. Must be in the '{gate_set_name.value}' gate set."
                 )
+
+    def serialize(self) -> dict[str, str]:
+        """Return the program in a format suitable for submission to the qBraid API."""
+        return {"ionqCircuit": json.dumps(self.program)}

--- a/qbraid/programs/gate_model/qasm2.py
+++ b/qbraid/programs/gate_model/qasm2.py
@@ -87,3 +87,7 @@ class OpenQasm2Program(GateModelProgram):
         if basis_gates is not None and len(basis_gates) > 0:
             transformed_qasm = rebase(self.program, basis_gates, **kwargs)
             self._program = normalize_qasm_gate_params(transformed_qasm)
+
+    def serialize(self) -> dict[str, str]:
+        """Return the program in a format suitable for submission to the qBraid API."""
+        return {"openQasm": pyqasm.dumps(self.module)}

--- a/qbraid/programs/gate_model/qasm3.py
+++ b/qbraid/programs/gate_model/qasm3.py
@@ -115,3 +115,7 @@ class OpenQasm3Program(GateModelProgram):
             transformed_qasm = rebase(self.program, basis_gates, **kwargs)
             self._program = normalize_qasm_gate_params(transformed_qasm)
             self._module.validate()
+
+    def serialize(self) -> dict[str, str]:
+        """Return the program in a format suitable for submission to the qBraid API."""
+        return {"openQasm": pyqasm.dumps(self.module)}

--- a/qbraid/programs/program.py
+++ b/qbraid/programs/program.py
@@ -81,3 +81,7 @@ class QuantumProgram(ABC):
     @abstractmethod
     def transform(self, device: qbraid.runtime.QuantumDevice) -> None:
         """Transform program to according to device target profile."""
+
+    @abstractmethod
+    def serialize(self) -> dict[str, str]:
+        """Return the program in a format suitable for submission to the qBraid API."""

--- a/qbraid/programs/spec.py
+++ b/qbraid/programs/spec.py
@@ -31,12 +31,12 @@ class ProgramSpec:
         program_type: Type[Any],
         alias: Optional[str] = None,
         overwrite: bool = False,
-        to_ir: Optional[Callable[[Any], Any]] = None,
+        serialize: Optional[Callable[[Any], Any]] = None,
         validate: Optional[Callable[[Any], None]] = None,
         experiment_type: Optional[ExperimentType] = None,
     ):
         self._program_type = program_type
-        self._to_ir = to_ir or (lambda program: program)
+        self._serialize = serialize or (lambda program: program)
         self._validate = validate or (lambda program: None)
 
         register_program_type(program_type, alias=alias, overwrite=overwrite)
@@ -75,17 +75,18 @@ class ProgramSpec:
         else:
             self._experiment_type = None
 
-    def to_ir(self, program: Any) -> Any:
+    def serialize(self, program: Any) -> Any:
         """
-        Convert the given program to an intermediate representation (IR) using the to_ir lambda.
+        Convert the given program to a format suitable for submission the
+        qBraid API using the serialize lambda.
 
         Args:
             program (Any): The program to convert.
 
         Returns:
-            Any: The program converted to an IR, or the program itself if to_ir is None.
+            Any: The serialized program, or the program itself if serialize is None.
         """
-        return self._to_ir(program)
+        return self._serialize(program)
 
     def validate(self, program: Any) -> None:
         """

--- a/qbraid/programs/typer.py
+++ b/qbraid/programs/typer.py
@@ -23,6 +23,7 @@ from .exceptions import QasmError as QbraidQasmError
 from .exceptions import ValidationError as ProgramValidationError
 
 IonQDictType = TypeVar("IonQDictType", bound=dict)
+QuboCoefficientsDictType = TypeVar("QuboCoefficientsDictType", bound=dict)
 
 
 class QbraidMetaType(ABCMeta):

--- a/qbraid/runtime/__init__.py
+++ b/qbraid/runtime/__init__.py
@@ -34,6 +34,7 @@ Functions
 .. autosummary::
    :toctree: ../stubs/
 
+    load_job
     display_jobs_from_data
 
 Classes
@@ -65,6 +66,7 @@ Exceptions
     QbraidRuntimeError
     ResourceNotFoundError
     DeviceProgramTypeMismatchError
+    JobLoaderError
 
 """
 import importlib
@@ -81,6 +83,7 @@ from .exceptions import (
     ResourceNotFoundError,
 )
 from .job import QuantumJob
+from .loader import JobLoaderError, load_job
 from .noise import NoiseModel, NoiseModelSet
 from .options import RuntimeOptions
 from .profile import TargetProfile
@@ -99,11 +102,13 @@ __all__ = [
     "DeviceStatus",
     "JobStatus",
     "display_jobs_from_data",
+    "load_job",
     "JobStateError",
     "ProgramValidationError",
     "QbraidRuntimeError",
     "ResourceNotFoundError",
     "DeviceProgramTypeMismatchError",
+    "JobLoaderError",
     "TargetProfile",
     "QuantumJob",
     "QuantumProvider",

--- a/qbraid/runtime/azure/job.py
+++ b/qbraid/runtime/azure/job.py
@@ -14,9 +14,10 @@ Module defining AzureQuantumJob class
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from azure.quantum.target.microsoft import MicrosoftEstimatorResult
+from azure.quantum.workspace import Workspace
 
 from qbraid._logging import logger
 from qbraid.runtime.azure.result_builder import AzureGateModelResultBuilder
@@ -35,9 +36,9 @@ if TYPE_CHECKING:
 class AzureQuantumJob(QuantumJob):
     """Azure job class."""
 
-    def __init__(self, job_id: str, workspace: azure.quantum.Workspace, **kwargs):
+    def __init__(self, job_id: str, workspace: Optional[Workspace] = None, **kwargs):
         super().__init__(job_id=job_id, **kwargs)
-        self._workspace = workspace
+        self._workspace = workspace or Workspace()
         self._job = self.workspace.get_job(self.id)
 
     @property

--- a/qbraid/runtime/azure/provider.py
+++ b/qbraid/runtime/azure/provider.py
@@ -57,8 +57,8 @@ class AzureQuantumProvider(QuantumProvider):
             credential (ClientSecretCredential, optional): Optional credential to be used
                 if the workspace lacks one.
         """
-        if not workspace:
-            workspace = Workspace()
+        workspace = workspace or Workspace()
+
         if not workspace.credential:
             if credential:
                 workspace.credential = credential

--- a/qbraid/runtime/azure/provider.py
+++ b/qbraid/runtime/azure/provider.py
@@ -42,16 +42,23 @@ class AzureQuantumProvider(QuantumProvider):
         workspace (Workspace): The configured Azure Quantum workspace.
     """
 
-    def __init__(self, workspace: Workspace, credential: Optional[ClientSecretCredential] = None):
+    def __init__(
+        self,
+        workspace: Optional[Workspace] = None,
+        credential: Optional[ClientSecretCredential] = None,
+    ):
         """
         Initializes an AzureQuantumProvider instance with a specified Workspace. It sets the
         credential for the workspace if it is not already set and a credential is provided.
 
         Args:
-            workspace (Workspace): An initialized Azure Quantum Workspace object.
-            credential (Optional[ClientSecretCredential]): Optional credential to be used
+            workspace (Workspace, optional): An Azure Quantum Workspace object. If not provided,
+                will be initialized with the provided credential or from environment variables.
+            credential (ClientSecretCredential, optional): Optional credential to be used
                 if the workspace lacks one.
         """
+        if not workspace:
+            workspace = Workspace()
         if not workspace.credential:
             if credential:
                 workspace.credential = credential
@@ -88,15 +95,17 @@ class AzureQuantumProvider(QuantumProvider):
 
         if input_data_format == InputDataFormat.MICROSOFT.value:
             program_spec = ProgramSpec(
-                pyqir.Module, alias="pyqir", to_ir=lambda module: module.bitcode
+                pyqir.Module, alias="pyqir", serialize=lambda module: module.bitcode
             )
         elif input_data_format == InputDataFormat.IONQ.value:
-            program_spec = ProgramSpec(IonQDict, alias="ionq", to_ir=lambda ionq_dict: ionq_dict)
+            program_spec = ProgramSpec(
+                IonQDict, alias="ionq", serialize=lambda ionq_dict: ionq_dict
+            )
         elif input_data_format == InputDataFormat.QUANTINUUM.value:
-            program_spec = ProgramSpec(str, alias="qasm2", to_ir=lambda qasm: qasm)
+            program_spec = ProgramSpec(str, alias="qasm2", serialize=lambda qasm: qasm)
         elif input_data_format == InputDataFormat.RIGETTI.value:
             program_spec = ProgramSpec(
-                pyquil.Program, alias="pyquil", to_ir=lambda program: program.out()
+                pyquil.Program, alias="pyquil", serialize=lambda program: program.out()
             )
         else:
             program_spec = None

--- a/qbraid/runtime/device.py
+++ b/qbraid/runtime/device.py
@@ -375,7 +375,7 @@ class QuantumDevice(ABC):
             return run_input
 
         target_spec = self._get_target_spec(run_input)
-        return target_spec.to_ir(run_input)
+        return target_spec.serialize(run_input)
 
     def apply_runtime_profile(
         self, run_input: qbraid.programs.QPROGRAM

--- a/qbraid/runtime/ibm/job.py
+++ b/qbraid/runtime/ibm/job.py
@@ -14,11 +14,11 @@ Module defining QiskitJob Class
 """
 from __future__ import annotations
 
-import os
 from typing import TYPE_CHECKING, Optional
 
+from qbraid_core._import import LazyLoader
 from qiskit.primitives.containers.primitive_result import PrimitiveResult
-from qiskit_ibm_runtime import QiskitRuntimeService, RuntimeJobV2
+from qiskit_ibm_runtime import RuntimeJobV2
 from qiskit_ibm_runtime.exceptions import RuntimeInvalidStateError
 
 from qbraid._logging import logger
@@ -35,6 +35,9 @@ if TYPE_CHECKING:
     import qiskit.result
     import qiskit_ibm_runtime
 
+    import qbraid.runtime.ibm
+
+qbraid_rt_ibm: qbraid.runtime.ibm = LazyLoader("qbraid_rt_ibm", globals(), "qbraid.runtime.ibm")
 
 IBM_JOB_STATUS_MAP = {
     "INITIALIZING": JobStatus.INITIALIZING,
@@ -81,9 +84,7 @@ class QiskitJob(QuantumJob):
                 service = self._device._service
             else:
                 try:
-                    token = os.getenv("QISKIT_IBM_TOKEN")
-                    channel = os.getenv("QISKIT_IBM_CHANNEL", "ibm_quantum")
-                    service = QiskitRuntimeService(channel=channel, token=token)
+                    service = qbraid_rt_ibm.QiskitRuntimeProvider().runtime_service
                 except Exception as err:
                     raise QbraidRuntimeError("Failed to initialize the quantum service.") from err
 

--- a/qbraid/runtime/ionq/job.py
+++ b/qbraid/runtime/ionq/job.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Optional, Union
 
+from qbraid_core._import import LazyLoader
+
 from qbraid.runtime.enums import JobStatus
 from qbraid.runtime.exceptions import QbraidRuntimeError
 from qbraid.runtime.job import QuantumJob
@@ -26,7 +28,9 @@ from qbraid.runtime.result import Result
 from qbraid.runtime.result_data import GateModelResultData, MeasCount, MeasProb
 
 if TYPE_CHECKING:
-    import qbraid.runtime.ionq.provider
+    import qbraid.runtime.ionq
+
+qbraid_rt_ionq: qbraid.runtime.ionq = LazyLoader("qbraid_rt_ionq", globals(), "qbraid.runtime.ionq")
 
 
 class IonQJobError(QbraidRuntimeError):
@@ -36,12 +40,14 @@ class IonQJobError(QbraidRuntimeError):
 class IonQJob(QuantumJob):
     """IonQ job class."""
 
-    def __init__(self, job_id: str, session: qbraid.runtime.ionq.provider.IonQSession, **kwargs):
+    def __init__(
+        self, job_id: str, session: Optional[qbraid.runtime.ionq.IonQSession] = None, **kwargs
+    ):
         super().__init__(job_id=job_id, **kwargs)
-        self._session = session
+        self._session = session or qbraid_rt_ionq.IonQSession()
 
     @property
-    def session(self) -> qbraid.runtime.ionq.provider.IonQSession:
+    def session(self) -> qbraid.runtime.ionq.IonQSession:
         """Return the IonQ session."""
         return self._session
 

--- a/qbraid/runtime/ionq/provider.py
+++ b/qbraid/runtime/ionq/provider.py
@@ -128,8 +128,8 @@ class IonQProvider(QuantumProvider):
             experiment_type=ExperimentType.GATE_MODEL,
             num_qubits=data.get("qubits"),
             program_spec=[
-                ProgramSpec(str, alias="qasm2", to_ir=qasm2_to_ionq),
-                ProgramSpec(str, alias="qasm3", to_ir=qasm3_to_ionq),
+                ProgramSpec(str, alias="qasm2", serialize=qasm2_to_ionq),
+                ProgramSpec(str, alias="qasm3", serialize=qasm3_to_ionq),
             ],
             provider_name="IonQ",
             basis_gates=basis_gates,

--- a/qbraid/runtime/loader.py
+++ b/qbraid/runtime/loader.py
@@ -1,0 +1,91 @@
+# Copyright (C) 2025 qBraid
+#
+# This file is part of the qBraid-SDK
+#
+# The qBraid-SDK is free software released under the GNU General Public License v3
+# or later. You can redistribute and/or modify it under the terms of the GPL v3.
+# See the LICENSE file in the project root or <https://www.gnu.org/licenses/gpl-3.0.html>.
+#
+# THERE IS NO WARRANTY for the qBraid-SDK, as per Section 15 of the GPL v3.
+
+"""
+Module containing top-level qbraid job loader functionality
+utilizing entrypoints via ``importlib``
+
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, overload
+
+from qbraid._entrypoints import load_entrypoint
+from qbraid.exceptions import QbraidError
+
+if TYPE_CHECKING:
+    from qbraid.runtime import QuantumJob
+    from qbraid.runtime.aws import BraketQuantumTask
+    from qbraid.runtime.azure import AzureQuantumJob
+    from qbraid.runtime.ibm import QiskitJob
+    from qbraid.runtime.ionq import IonQJob
+    from qbraid.runtime.native import QbraidJob
+    from qbraid.runtime.oqc import OQCJob
+
+
+class JobLoaderError(QbraidError):
+    """Raised when an error occurs while loading a quantum job."""
+
+
+@overload
+def load_job(job_id: str, provider: Literal["native", "qbraid"], **kwargs) -> QbraidJob: ...
+
+
+@overload
+def load_job(job_id: str, provider: Literal["aws", "braket"], **kwargs) -> BraketQuantumTask: ...
+
+
+@overload
+def load_job(job_id: str, provider: Literal["ibm", "qiskit"], **kwargs) -> QiskitJob: ...
+
+
+@overload
+def load_job(job_id: str, provider: Literal["azure"], **kwargs) -> AzureQuantumJob: ...
+
+
+@overload
+def load_job(job_id: str, provider: Literal["ionq"], **kwargs) -> IonQJob: ...
+
+
+@overload
+def load_job(job_id: str, provider: Literal["oqc"], **kwargs) -> OQCJob: ...
+
+
+@overload
+def load_job(job_id: str, provider: str, **kwargs) -> QuantumJob: ...
+
+
+def load_job(job_id: str, provider: str = "qbraid", **kwargs) -> QuantumJob:
+    """Load a quantum job object from a supported provider.
+
+    Args:
+        job_id: The provider-specific job identifier.
+        provider: The name of the provider module within in the ``qbraid.runtime`` package.
+
+    Returns:
+        QuantumJob: A quantum job object of the inferred subclass.
+
+    Raises:
+        JobLoaderError: If the job cannot be loaded.
+    """
+    provider_aliases = {"qbraid": "native", "qiskit": "ibm", "braket": "aws"}
+
+    provider_module = provider_aliases.get(provider, provider).lower()
+
+    try:
+        job_class = load_entrypoint("jobs", provider_module)
+    except Exception as err:
+        raise JobLoaderError(
+            f"Error loading QuantumJob sub-class for provider '{provider}'."
+        ) from err
+
+    job_instance = job_class(job_id, **kwargs)
+
+    return job_instance

--- a/qbraid/runtime/native/device.py
+++ b/qbraid/runtime/native/device.py
@@ -310,6 +310,7 @@ class QbraidDevice(QuantumDevice):
         """
         dynamic_params = {
             "openQasm": None,
+            "ionqCircuit": None,
             "bitcode": None,
             "problem": None,
             "numVariables": None,

--- a/qbraid/runtime/oqc/job.py
+++ b/qbraid/runtime/oqc/job.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any, Optional, Union
 
+from qbraid_core._import import LazyLoader
+
 from qbraid.runtime.enums import JobStatus
 from qbraid.runtime.exceptions import ResourceNotFoundError
 from qbraid.runtime.job import QuantumJob
@@ -25,6 +27,10 @@ from qbraid.runtime.result_data import GateModelResultData
 
 if TYPE_CHECKING:
     from qcaas_client.client import OQCClient
+
+    import qbraid.runtime.oqc
+
+qbraid_rt_oqc: qbraid.runtime.oqc = LazyLoader("qbraid_rt_oqc", globals(), "qbraid.runtime.oqc")
 
 RESULTS_FORMAT = {
     2: "raw",
@@ -61,9 +67,9 @@ OPTIMIZATIONS = {
 class OQCJob(QuantumJob):
     """Oxford Quantum Circuit job class."""
 
-    def __init__(self, job_id: str, client: OQCClient, **kwargs):
+    def __init__(self, job_id: str, client: Optional[OQCClient] = None, **kwargs):
         super().__init__(job_id=job_id, **kwargs)
-        self._client = client
+        self._client = client or qbraid_rt_oqc.OQCProvider().client
         self._qpu_id: Optional[str] = None
         self._terminal_status: Optional[JobStatus] = None
 

--- a/tests/programs/test_program_annealing.py
+++ b/tests/programs/test_program_annealing.py
@@ -30,7 +30,7 @@ try:
     )
     from qbraid.programs.annealing.cpp_pyqubo import PyQuboModel
     from qbraid.programs.annealing.qubo import QuboProgram
-    from qbraid.runtime.native.provider import _qubo_to_json
+    from qbraid.runtime.native.provider import _serliaze_qubo
 
     pyqubo_not_installed = False
 except ImportError:
@@ -256,9 +256,9 @@ def test_annealing_program_eq_different_type(mock_annealing_program):
     assert annealing_program != "Not an AnnealingProgram instance"
 
 
-def test_runtime_qubo_to_json(pyqubo_model):
+def test_runtime_serliaze_qubo(pyqubo_model):
     """Test that the _pyqubo_to_json function returns the expected JSON string."""
-    pyqubo_json = _qubo_to_json(pyqubo_model)
+    pyqubo_json = _serliaze_qubo(pyqubo_model)
     pyqubo_dict = {"problem": json.loads(pyqubo_json["problem"])}
 
     expected_dict = {

--- a/tests/programs/test_program_circuits_ionq.py
+++ b/tests/programs/test_program_circuits_ionq.py
@@ -14,6 +14,7 @@
 Unit tests for qbraid.programs.ionq.IonQProgram
 
 """
+import json
 import numpy as np
 import pytest
 
@@ -47,6 +48,11 @@ def test_ionq_program_bits(ionq_program: IonQProgram):
     """Test the qubits and clbits properties."""
     assert ionq_program.num_qubits == 3
     assert ionq_program.num_clbits == 0
+
+
+def test_ionq_program_serialize(ionq_program: IonQProgram, ionq_dict: IonQDict):
+    """Test the qubits and clbits properties."""
+    assert ionq_program.serialize() == {"ionqCircuit": json.dumps(ionq_dict)}
 
 
 def test_ionq_program_type_error():

--- a/tests/programs/test_program_circuits_ionq.py
+++ b/tests/programs/test_program_circuits_ionq.py
@@ -15,6 +15,7 @@ Unit tests for qbraid.programs.ionq.IonQProgram
 
 """
 import json
+
 import numpy as np
 import pytest
 

--- a/tests/programs/test_program_type_registry_qir.py
+++ b/tests/programs/test_program_type_registry_qir.py
@@ -44,12 +44,12 @@ def pyqir_bell() -> Module:
 @pytest.fixture
 def pyqir_spec() -> ProgramSpec:
     """Returns a ProgramSpec for the QIR bell circuit."""
-    return ProgramSpec(pyqir.Module, alias="pyqir", to_ir=lambda module: module.bitcode)
+    return ProgramSpec(pyqir.Module, alias="pyqir", serialize=lambda module: module.bitcode)
 
 
 def test_load_program_pyqir(pyqir_bell: Module, pyqir_spec: ProgramSpec):
     """Test program spec to IR conversion for a QIR program."""
-    program_ir = pyqir_spec.to_ir(pyqir_bell)
+    program_ir = pyqir_spec.serialize(pyqir_bell)
     assert isinstance(program_ir, bytes)
     assert program_ir == pyqir_bell.bitcode
 

--- a/tests/runtime/ibm/test_qiskit_runtime.py
+++ b/tests/runtime/ibm/test_qiskit_runtime.py
@@ -320,7 +320,9 @@ def test_job_service_initialization():
 
 def test_job_service_initialization_failure():
     """Test handling of service initialization failure."""
-    with patch("qbraid.runtime.ibm.provider.QiskitRuntimeService", side_effect=IBMNotAuthorizedError):
+    with patch(
+        "qbraid.runtime.ibm.provider.QiskitRuntimeService", side_effect=IBMNotAuthorizedError
+    ):
         job_id = "test_job_id"
         with pytest.raises(QbraidRuntimeError) as excinfo:
             QiskitJob(job_id)

--- a/tests/runtime/ibm/test_qiskit_runtime.py
+++ b/tests/runtime/ibm/test_qiskit_runtime.py
@@ -308,7 +308,7 @@ def test_job_initialize_service_from_device(mock_service):
 
 def test_job_service_initialization():
     """Test job retrieval when initializing a new service."""
-    with patch("qbraid.runtime.ibm.job.QiskitRuntimeService") as mock_service_class:
+    with patch("qbraid.runtime.ibm.provider.QiskitRuntimeService") as mock_service_class:
         mock_service = MagicMock(spec=QiskitRuntimeService)
         mock_service.job.return_value = MagicMock(spec=RuntimeJob)
         mock_service_class.return_value = mock_service
@@ -320,7 +320,7 @@ def test_job_service_initialization():
 
 def test_job_service_initialization_failure():
     """Test handling of service initialization failure."""
-    with patch("qbraid.runtime.ibm.job.QiskitRuntimeService", side_effect=IBMNotAuthorizedError):
+    with patch("qbraid.runtime.ibm.provider.QiskitRuntimeService", side_effect=IBMNotAuthorizedError):
         job_id = "test_job_id"
         with pytest.raises(QbraidRuntimeError) as excinfo:
             QiskitJob(job_id)

--- a/tests/runtime/native/test_aws_simulators_runtime.py
+++ b/tests/runtime/native/test_aws_simulators_runtime.py
@@ -13,12 +13,12 @@ Unit tests for submissions to AWS SV1, DM1, TN1 via qBraid native runtime.
 
 """
 
-from qbraid.runtime.native.provider import _braket_to_json
+from qbraid.runtime.native.provider import _serialize_program
 
 
 def test_braket_circuit_to_json(braket_circuit, qasm3_circuit):
     """Test conversion of Braket circuit to JSON."""
-    qasm_json = _braket_to_json(braket_circuit)
+    qasm_json = _serialize_program(braket_circuit)
     assert len(qasm_json) == 1
     assert qasm_json.keys() == {"openQasm"}
     assert qasm_json["openQasm"].strip() == qasm3_circuit.strip()

--- a/tests/runtime/native/test_quera_aquila_runtime.py
+++ b/tests/runtime/native/test_quera_aquila_runtime.py
@@ -95,7 +95,7 @@ def test_get_aquila_device(device_id, mock_provider):
     assert device.id == device_id
 
 
-def test_ahs_program_to_ir(mock_device, braket_ahs, ahs_dict):
+def test_prepare_ahs_program(mock_device, braket_ahs, ahs_dict):
     """Test conversion of AHS program to IR."""
     assert mock_device.prepare(braket_ahs) == {"ahs": json.dumps(ahs_dict)}
 

--- a/tests/runtime/test_load_job.py
+++ b/tests/runtime/test_load_job.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2025 qBraid
+#
+# This file is part of the qBraid-SDK
+#
+# The qBraid-SDK is free software released under the GNU General Public License v3
+# or later. You can redistribute and/or modify it under the terms of the GPL v3.
+# See the LICENSE file in the project root or <https://www.gnu.org/licenses/gpl-3.0.html>.
+#
+# THERE IS NO WARRANTY for the qBraid-SDK, as per Section 15 of the GPL v3.
+
+"""
+Unit tests for loading jobs using entrypoints
+
+"""
+
+import pytest
+
+from qbraid.runtime import JobLoaderError, load_job
+
+from ._resources import JOB_DATA_QIR
+
+
+@pytest.fixture
+def job_id():
+    """Mock job data for testing"""
+    return JOB_DATA_QIR["qbraidJobId"]
+
+
+def test_load_job(mock_client, job_id):
+    """Test loading a job using entrypoints"""
+    job = load_job(job_id, "qbraid", client=mock_client)
+    assert job.id == job_id
+
+
+def test_load_job_error(job_id):
+    """Test that JobLoaderError is raised when loading a job fails."""
+    provider = "fake_provider"
+
+    with pytest.raises(
+        JobLoaderError,
+        match=f"Error loading QuantumJob sub-class for provider '{provider}'.",
+    ):
+        load_job(job_id, provider)


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

- Added `qbraid.runtime.load_job` function that uses entrypoints to load provider job class and create instance with job id
- Switched all `QbraidJob` sub-classes to only require `job_id` as positional argument, and any other args that used to be required for auth can now be loaded with credentials from environment variables 
- Added `QuantumProgram.serialize` method to streamline creation of `ProgramSpec` classes in `QbraidProvider`