### PR TITLE
Allow min tolerance in postprocessing check of result probabilities sum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Types of changes:
 
 ### Improved / Modified
 - Switched all `QbraidJob` sub-classes to only require `job_id` as positional argument, and any other args that used to be required for auth can now be loaded with credentials from environment variables ([#883](https://github.com/qBraid/qBraid/pull/883))
+- Allow some minimum tolerance when checking for the sum of result probabilities from job to be equal to 1 ([#889](https://github.com/qBraid/qBraid/pull/889))
 
 ### Deprecated
 

--- a/qbraid/runtime/postprocess.py
+++ b/qbraid/runtime/postprocess.py
@@ -14,6 +14,7 @@ Module for post-processing of raw results data.
 """
 from __future__ import annotations
 
+from math import isclose
 from typing import Any, Union
 
 
@@ -250,7 +251,7 @@ def distribute_counts(probs: dict[Any, float], shots: int) -> dict[Any, int]:
         >>> distribute_counts(probs, shots)
         {0: 9, 1: 1}
     """
-    if not sum(probs.values()) == 1:
+    if not isclose(sum(probs.values()), 1.0):
         raise ValueError("Probabilities must sum to 1.")
 
     if not all(0 <= prob <= 1 for prob in probs.values()):

--- a/tests/runtime/test_result.py
+++ b/tests/runtime/test_result.py
@@ -745,6 +745,14 @@ def test_distribute_counts_valid_input():
     assert result == {0: 9, 1: 1}, "Counts do not match expected values."
 
 
+def test_distribute_counts_probabilities_close_to_1():
+    """Test distribute_counts with valid input (sum of probabilities close to 1)."""
+    probs = {0: 0.888888888, 1:  0.111111111}
+    shots = 10
+    result = distribute_counts(probs, shots)
+    assert result == {0: 9, 1: 1}, "Counts do not match expected values."
+
+
 def test_distribute_counts_probabilities_not_sum_to_1():
     """Test distribute_counts with probabilities that do not sum to 1."""
     probs = {0: 0.9, 1: 0.2}

--- a/tests/runtime/test_result.py
+++ b/tests/runtime/test_result.py
@@ -747,7 +747,7 @@ def test_distribute_counts_valid_input():
 
 def test_distribute_counts_probabilities_close_to_1():
     """Test distribute_counts with valid input (sum of probabilities close to 1)."""
-    probs = {0: 0.888888888, 1:  0.111111111}
+    probs = {0: 0.888888888, 1: 0.111111111}
     shots = 10
     result = distribute_counts(probs, shots)
     assert result == {0: 9, 1: 1}, "Counts do not match expected values."


### PR DESCRIPTION
Fixes an issue with IonQ backends, whose result probabilities not always sum to exactly 1.

Data from a real IonQ scenario:
```
'probabilities': ... {'0': 0.097980373, '1': 0.251172315, '2': 0.639023034, '3': 0.011824277} ...
```
where the sum is 0.999999999 and not exactly 1.

# Testing

Unit tested with `tox -e unit-tests -- tests/runtime/test_result.py`

