### PR TITLE
Add `qpu.forte-enterprise` devices IonQ rt tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Types of changes:
 ### Added
 - Added `qibo` to dynamic `QPROGRAM_REGISTRY` imports ([#891](https://github.com/qBraid/qBraid/pull/891))
 - Fixed `plt.show` / `plt.save_fig` bug in `plot conversion_graph` ([#893](https://github.com/qBraid/qBraid/pull/893))
+- Added [IonQ Forte Enterpres](https://ionq.com/quantum-systems/forte-enterprise) devices to `IonQProvider` runtime tests ([#894](https://github.com/qBraid/qBraid/pull/894))
 
 ### Improved / Modified
 -  Updated conversion graph and `QPROGRAM_REGISTRY` on README.md ([#891](https://github.com/qBraid/qBraid/pull/891))

--- a/tests/runtime/ionq/test_ionq_runtime.py
+++ b/tests/runtime/ionq/test_ionq_runtime.py
@@ -86,6 +86,24 @@ DEVICE_DATA = [
         "noise_models": ["aria-1", "harmony", "ideal"],
         "degraded": False,
     },
+    {
+        "backend": "qpu.forte-enterprise-1",
+        "status": "unavailable",
+        "qubits": 36,
+        "average_queue_time": 2333081000,
+        "last_updated": 1738692095,
+        "has_access": False,
+        "degraded": False,
+    },
+    {
+        "backend": "qpu.forte-enterprise-2",
+        "status": "unavailable",
+        "qubits": 36,
+        "average_queue_time": 0,
+        "last_updated": 1738692095,
+        "has_access": False,
+        "degraded": False,
+    },
 ]
 
 POST_JOB_RESPONSE = {
@@ -232,6 +250,8 @@ def test_ionq_provider_device_unavailable():
             elif device_id == "simulator":
                 res["status"] = "available"
             elif device_id == "qpu.forte-1":
+                res["status"] = "unavailable"
+            elif device_id.startswith("qpu.forte-enterprise"):
                 res["status"] = "unavailable"
             elif device_id == "fake_device":
                 res["status"] = "fake_status"


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

- Add `qpu.forte-enterprise` devices to `IonQProvider` runtime tests
