### PR TITLE
Runtime fixes + translate alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ Types of changes:
 - Added `qibo_to_qasm2` conversion to transpiler ([#895](https://github.com/qBraid/qBraid/pull/895))
 - Added `stim` to dynamic `QPROGRAM_REGISTRY` imports and `stim_to_cirq` conversion to transpiler ([#895](https://github.com/qBraid/qBraid/pull/895))
 - Added `Qasm2KirinString` metatype to support qasm2 strings adapted for QuEra kirin qasm parser through qBraid native runtime. ([#896](https://github.com/qBraid/qBraid/pull/896))
+- Added `translate` functions as alias for `transpile`, but also that can chain multiple conversions together ([#899](https://github.com/qBraid/qBraid/pull/899)). For example:
+
+```python
+from qbraid import translate
+
+circuit_out = translate(circuit_in, "qasm3", "braket", "cirq")
+```
 
 ### Improved / Modified
 -  Updated conversion graph and `QPROGRAM_REGISTRY` on README.md ([#891](https://github.com/qBraid/qBraid/pull/891))
@@ -34,6 +41,8 @@ Types of changes:
 ### Removed
 
 ### Fixed
+- Handling of empty counts dict in `format_counts` pre-processing function ([#899](https://github.com/qBraid/qBraid/pull/899))
+- Skipping NEC remote tests if device is not online ([#899](https://github.com/qBraid/qBraid/pull/899))
 
 ### Dependencies
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ Discord = "https://discord.gg/TPBU2sa8Et"
 
 [project.optional-dependencies]
 azure = ["azure-quantum>=2.0,<2.3", "azure-storage-blob>=12.20,<13.0", "azure-identity>=1.17,<2.0"]
-bloqade = ["bloqade>=0.15.13"]
+bloqade = ["bloqade>=0.15.13,<=0.15.14"]
 braket = ["amazon-braket-sdk>=1.83.0,<1.90.0", "pytket-braket>=0.30,<0.40"]
 cirq = ["cirq-core>=1.3,<1.5", "cirq-ionq>=1.3,<1.5", "ply>=3.6", "attrs>=21.3.0"]
 cudaq = ["cudaq>=0.9.0"]

--- a/qbraid/__init__.py
+++ b/qbraid/__init__.py
@@ -92,12 +92,7 @@ _lazy = {
         "Session",
         "TargetProfile",
     ],
-    "transpiler": [
-        "Conversion",
-        "ConversionGraph",
-        "ConversionScheme",
-        "transpile",
-    ],
+    "transpiler": ["Conversion", "ConversionGraph", "ConversionScheme", "transpile", "translate"],
     "visualization": [],
 }
 
@@ -141,6 +136,7 @@ if TYPE_CHECKING:
     from .transpiler import Conversion as Conversion
     from .transpiler import ConversionGraph as ConversionGraph
     from .transpiler import ConversionScheme as ConversionScheme
+    from .transpiler import translate as translate
     from .transpiler import transpile as transpile
 
 

--- a/qbraid/runtime/postprocess.py
+++ b/qbraid/runtime/postprocess.py
@@ -111,6 +111,9 @@ def format_counts(
         >>> format_counts(counts, decimal=True)
         {0: 46, 1: 0, 2: 79, 3: 13}
     """
+    if not counts:
+        return counts
+
     input_is_dec = False
     input_is_bin = False
 

--- a/qbraid/transpiler/__init__.py
+++ b/qbraid/transpiler/__init__.py
@@ -31,6 +31,7 @@ Functions
    :toctree: ../stubs/
 
    transpile
+   translate
    requires_extras
 
 Exceptions
@@ -45,7 +46,7 @@ Exceptions
 
 """
 from .annotations import requires_extras
-from .converter import transpile
+from .converter import translate, transpile
 from .edge import Conversion
 from .exceptions import ConversionPathNotFoundError, NodeNotFoundError, ProgramConversionError
 from .graph import ConversionGraph
@@ -54,6 +55,7 @@ from .scheme import ConversionScheme
 __all__ = [
     "requires_extras",
     "transpile",
+    "translate",
     "Conversion",
     "ConversionGraph",
     "ConversionScheme",

--- a/qbraid/transpiler/conversions/__init__.py
+++ b/qbraid/transpiler/conversions/__init__.py
@@ -14,15 +14,6 @@ quantum software program types.
 
 .. currentmodule:: qbraid.transpiler.conversions
 
-Functions
-----------
-
-.. autosummary::
-   :toctree: ../stubs/
-
-   update_registered_conversions
-
-
 Submodules
 -----------
 
@@ -57,7 +48,7 @@ valid_combinations_cache = set()
 conversion_functions = []
 
 
-def update_registered_conversions() -> None:
+def _update_registered_conversions() -> None:
     """
     Dynamically update the list of conversion functions based on current
     NATIVE_REGISTRY and QPROGRAM_REGISTRY. Adds valid conversion functions
@@ -108,4 +99,4 @@ def update_registered_conversions() -> None:
             pass
 
 
-update_registered_conversions()
+_update_registered_conversions()

--- a/qbraid/transpiler/conversions/qiskit/qiskit_extras.py
+++ b/qbraid/transpiler/conversions/qiskit/qiskit_extras.py
@@ -64,7 +64,7 @@ def qiskit_to_pyqir(circuit: qiskit.circuit.QuantumCircuit) -> pyqir.Module:
         Module: PyQIR module
     """
     # tuple of module and list of entry points
-    module, _ = qiskit_qir.to_qir_module(circuit, record_output=False)
+    module, _ = qiskit_qir.to_qir_module(circuit)
     return module
 
 

--- a/qbraid/transpiler/converter.py
+++ b/qbraid/transpiler/converter.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import warnings
 from copy import deepcopy
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from qbraid_core._import import LazyLoader
 
@@ -163,17 +163,18 @@ def transpile(
     )
 
 
-def chain_calls(func, initial_value, *args, **kwargs):
+def chain_calls(func: Callable[[Any, Any], Any], initial_value, *args, **kwargs) -> Any:
     """
     Apply a function iteratively over a sequence of arguments.
 
     Args:
-        func (callable): The function to apply.
-        initial_value: The initial input to the first call.
-        *args: The sequence of arguments for subsequent calls.
+        func (Callable[[Any, Any], Any]): The function to apply.
+        initial_value (Any): The initial input to the first call.
+        *args (Any): The sequence of arguments for subsequent calls.
+        **kwargs (Any): Additional keyword arguments for the function.
 
     Returns:
-        The result of the final call.
+        Any: The result of the final call.
     """
     result = initial_value
     for arg in args:

--- a/qbraid/transpiler/converter.py
+++ b/qbraid/transpiler/converter.py
@@ -14,6 +14,7 @@ Module for transpiling quantum programs between different quantum programming la
 """
 from __future__ import annotations
 
+import functools
 import warnings
 from copy import deepcopy
 from typing import TYPE_CHECKING, Optional
@@ -161,3 +162,11 @@ def transpile(
             else "."
         )
     )
+
+
+@functools.wraps(transpile)
+def translate(*args, **kwargs):
+    return transpile(*args, **kwargs)
+
+
+translate.__doc__ = f"An alias for ``transpile``. {transpile.__doc__}"

--- a/qbraid/transpiler/converter.py
+++ b/qbraid/transpiler/converter.py
@@ -14,7 +14,6 @@ Module for transpiling quantum programs between different quantum programming la
 """
 from __future__ import annotations
 
-import functools
 import warnings
 from copy import deepcopy
 from typing import TYPE_CHECKING, Optional
@@ -164,9 +163,33 @@ def transpile(
     )
 
 
-@functools.wraps(transpile)
-def translate(*args, **kwargs):
-    return transpile(*args, **kwargs)
+def chain_calls(func, initial_value, *args, **kwargs):
+    """
+    Apply a function iteratively over a sequence of arguments.
+
+    Args:
+        func (callable): The function to apply.
+        initial_value: The initial input to the first call.
+        *args: The sequence of arguments for subsequent calls.
+
+    Returns:
+        The result of the final call.
+    """
+    result = initial_value
+    for arg in args:
+        result = func(result, arg, **kwargs)
+    return result
 
 
-translate.__doc__ = f"An alias for ``transpile``. {transpile.__doc__}"
+def translate(program, *targets, **kwargs):
+    """
+    Chain multiple transpile calls on a program.
+
+    Args:
+        program: The quantum program to transpile.
+        *targets: A sequence of target formats.
+
+    Returns:
+        The final transpiled program.
+    """
+    return chain_calls(transpile, program, *targets, **kwargs)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,14 +6,14 @@ pyquil>=4.4; python_version < "3.13"
 qcs-sdk-python<0.21.10; python_version < "3.13"
 pytket>=1.31
 qiskit>=1.0,<1.4
-# cudaq>=0.9.0; python_version < "3.13"
+cudaq>=0.9.0; python_version < "3.13"
 
 # transpiler extras
 ply>=3.6
 cirq-ionq>=1.3,<1.5
 qbraid-qir>=0.2.0,<=0.3.0
 pytket-braket>=0.35.1,<0.40.0
-bloqade>=0.15.13; python_version < "3.13"
+bloqade>=0.15.13,<=0.15.14; python_version < "3.13"
 qiskit-qasm3-import>=0.5.1
 qiskit-aer>=0.15.0; python_version < "3.13"
 qiskit-qir

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ pyquil>=4.4; python_version < "3.13"
 qcs-sdk-python<0.21.10; python_version < "3.13"
 pytket>=1.31
 qiskit>=1.0,<1.4
-cudaq>=0.9.0; python_version < "3.13"
+# cudaq>=0.9.0; python_version < "3.13"
 
 # transpiler extras
 ply>=3.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ openqasm3[parser]>=0.4.0
 qbraid-core>=0.1.25
 pydantic>2.0.0
 typing-extensions>=4.0.0
-pyqasm>=0.1.0
+pyqasm>=0.1.0,<0.2.0

--- a/tests/runtime/native/test_nec_vector_annealer_runtime.py
+++ b/tests/runtime/native/test_nec_vector_annealer_runtime.py
@@ -17,6 +17,7 @@ from qbraid_core import QbraidSession
 
 from qbraid import QbraidProvider
 from qbraid._logging import logger
+from qbraid.runtime import DeviceStatus
 from qbraid.runtime.native.result import NECVectorAnnealerResultData
 from qbraid.runtime.schemas import QuboSolveParams
 
@@ -53,6 +54,9 @@ def test_submit_qubo_job_to_nec_vector_annealer():
     provider = QbraidProvider()
 
     device = provider.get_device("nec_vector_annealer")
+
+    if device.status() != DeviceStatus.ONLINE:
+        pytest.skip("NEC Vector Annealer is not online")
 
     job = device.run(qubo, params=params)
 

--- a/tests/runtime/test_result.py
+++ b/tests/runtime/test_result.py
@@ -204,6 +204,13 @@ def test_format_counts(counts_raw, expected_out, include_zero_values):
     assert list(counts_out.items()) == list(expected_out.items())  # check ordering of keys
 
 
+def test_format_counts_empty_input():
+    """Test formatting of empty input."""
+    counts = {}
+    expected = {}
+    assert format_counts(counts) == expected
+
+
 def test_normalize_different_key_lengths():
     """Test normalization of measurement counts with different key lengths."""
     measurements = [{"0": 10, "1": 15}, {"00": 5, "01": 8, "10": 12}]

--- a/tests/transpiler/test_translate.py
+++ b/tests/transpiler/test_translate.py
@@ -1,0 +1,91 @@
+# Copyright (C) 2025 qBraid
+#
+# This file is part of the qBraid-SDK
+#
+# The qBraid-SDK is free software released under the GNU General Public License v3
+# or later. You can redistribute and/or modify it under the terms of the GPL v3.
+# See the LICENSE file in the project root or <https://www.gnu.org/licenses/gpl-3.0.html>.
+#
+# THERE IS NO WARRANTY for the qBraid-SDK, as per Section 15 of the GPL v3.
+
+"""
+Unit tests for the chain_calls function in qbraid.transpiler.converter.
+
+"""
+from cirq import Circuit
+from openqasm3.ast import Program
+
+from qbraid.transpiler.converter import chain_calls, translate
+
+from .cirq_utils import _equal
+
+
+def test_chain_calls_addition():
+    """Test that chain_calls can add a sequence of numbers."""
+
+    def add(x, y):
+        return x + y
+
+    result = chain_calls(add, 0, 1, 2, 3, 4)
+    assert result == 10
+
+
+def test_chain_calls_multiplication():
+    """Test that chain_calls can multiply a sequence of numbers."""
+
+    def multiply(x, y):
+        return x * y
+
+    result = chain_calls(multiply, 1, 2, 3, 4)
+    assert result == 24
+
+
+def test_chain_calls_with_kwargs():
+    """Test that chain_calls can handle keyword arguments."""
+
+    def power(x, y, exponent=1):
+        return x + (y**exponent)
+
+    result = chain_calls(power, 0, 2, 3, exponent=2)
+    assert result == 13
+
+
+def test_chain_calls_empty_args():
+    """Test that chain_calls can handle an empty sequence of arguments."""
+
+    def add(x, y):
+        return x + y
+
+    result = chain_calls(add, 5)
+    assert result == 5
+
+
+def test_chain_calls_non_numeric():
+    """Test that chain_calls can concatenate a sequence of strings."""
+
+    def concatenate(x, y):
+        return x + y
+
+    result = chain_calls(concatenate, "Hello", " ", "World", "!")
+    assert result == "Hello World!"
+
+
+def test_translate():
+    """Test that translate can chain multiple transpile calls on a program."""
+    qasm = """
+    OPENQASM 2.0;
+    include "qelib1.inc";
+    qreg q[2];
+    creg c[2];
+    h q[0];
+    cx q[0], q[1];
+    measure q -> c;
+    """
+
+    program = translate(qasm, "openqasm3")
+    circuit_one = translate(program, "qasm2", "cirq")
+    circuit_two = translate(program, "qasm3", "braket", "cirq")
+
+    assert isinstance(program, Program)
+    assert all(isinstance(circuit, Circuit) for circuit in (circuit_one, circuit_two))
+    assert _equal(circuit_one, circuit_two)


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

- Handle counts dict empty in format counts fn
- Add `translate` functions as alias for `transpile`, but also that can chain multiple conversions together 

For example:

```python
from qbraid import translate

circuit_out = translate(circuit_in, "qasm3", "braket", "cirq")
```