### PR TITLE
IonQ zz bug + housekeep

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -60,7 +60,7 @@ jobs:
           VERSION=$(python3 bin/bump_version.py $BUMP_TYPE)
           python3 bin/update_citation.py $VERSION
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          git add pyproject.toml CITATION.cff
+          git add qbraid/_version.py CITATION.cff
           git commit -m "Bump $BUMP_TYPE version to $VERSION"
           git push origin qbraid-bot/${{ github.run_id }}
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,53 @@
+name: Deploy to GitHub Pages
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox>=4.2.0
+
+      - name: Build Sphinx documentation
+        run: tox -e docs
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'docs/build/html'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/.github/workflows/pr-compliance.yml
+++ b/.github/workflows/pr-compliance.yml
@@ -11,7 +11,7 @@
 name: PR Compliance
 
 on:
-  pull_request:
+  pull_request_target:
     branches: ['main']
     types: [opened, reopened, ready_for_review, synchronize]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,16 +25,22 @@ Types of changes:
 ```
 
 - Added bin script + logic in version bump workflow to automatically update `CITATION.ff` ([#915](https://github.com/qBraid/qBraid/pull/915))
+- Added a workflow for deploying to GitHub Pages on release publication or manual dispatch. ([#917](https://github.com/qBraid/qBraid/pull/917))
 
 ### Improved / Modified
 - Disabled validation step in remote (native) IonQ runtime test when constructing `IonQDict` via `qiskit-ionq` ([#915](https://github.com/qBraid/qBraid/pull/915))
 - Enabled loading `azure.quantum.Workspace` from `AZURE_QUANTUM_CONNECTION_STRING` environment variable in `AzureQuantumProvider` class ([#915](https://github.com/qBraid/qBraid/pull/915))
+- Adjusted docs side navigation search styling for better alignment.
+- Added support for interpreting `zz` as a QIS gate in `openqasm3_to_ionq` and refactored `determine_gateset` accordingly ([#917](https://github.com/qBraid/qBraid/pull/917))
+- Modified `openqasm3_to_ionq` to emit warning instead of raise error when circuits contains measurements. ([#917](https://github.com/qBraid/qBraid/pull/917))
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+- Updated `bump-version.yml` to track `qbraid/_version.py` instead of `pyproject.toml`. ([#917](https://github.com/qBraid/qBraid/pull/917))
+- Fixed bug where `BraketQuantumTask._task.arn` undefined if instaniated without `AwsQuantumTask` object ([#917](https://github.com/qBraid/qBraid/pull/917))
 
 ### Dependencies
 - Updated qBraid-CLI dependency to >= 0.10.0 ([#915](https://github.com/qBraid/qBraid/pull/915))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Types of changes:
 ### Improved / Modified
 - Disabled validation step in remote (native) IonQ runtime test when constructing `IonQDict` via `qiskit-ionq` ([#915](https://github.com/qBraid/qBraid/pull/915))
 - Enabled loading `azure.quantum.Workspace` from `AZURE_QUANTUM_CONNECTION_STRING` environment variable in `AzureQuantumProvider` class ([#915](https://github.com/qBraid/qBraid/pull/915))
-- Adjusted docs side navigation search styling for better alignment.
+- Adjusted docs side navigation search styling for better alignment. ([#917](https://github.com/qBraid/qBraid/pull/917))
 - Added support for interpreting `zz` as a QIS gate in `openqasm3_to_ionq` and refactored `determine_gateset` accordingly ([#917](https://github.com/qBraid/qBraid/pull/917))
 - Modified `openqasm3_to_ionq` to emit warning instead of raise error when circuits contains measurements. ([#917](https://github.com/qBraid/qBraid/pull/917))
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -67,7 +67,7 @@ authors:
   orcid: https://orcid.org/0000-0003-2032-3993
 repository-code: https://github.com/qBraid/qBraid
 url: https://sdk.qbraid.com/en/stable/
-repository-artifact: https://github.com/qBraid/qBraid/releases/tag/v0.9.3
+repository-artifact: https://github.com/qBraid/qBraid/releases/tag/v0.9.4
 keywords:
 - python
 - quantum-computing
@@ -76,6 +76,6 @@ keywords:
 - qir
 - runtime
 license: GPL-3.0
-version: 0.9.3
+version: 0.9.4
 doi: 10.5281/zenodo.12627596
-date-released: '2025-01-27'
+date-released: '2025-02-20'

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -47,8 +47,10 @@
 .wy-side-nav-search > a {
     color: var(--font-color0);
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: center;
+    padding-top: 8px;
+    margin-left: -14px;
 }
 
 .wy-side-nav-search > a::before {
@@ -58,6 +60,9 @@
     background-repeat: no-repeat;
     width: 28px;
     height: 28px;
+    margin-right: 4px;
+    position: relative;
+    top: 6px;
 }
 
 .wy-side-nav-search > div.version,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,12 +33,17 @@ The qBraid-SDK, and all of its dependencies, can also be installed using `pip <h
    pip install qbraid
 
 
+.. note::
+
+   The qBraid-SDK requires Python 3.10 or later.
+
+
 Resources
 ----------
 
 - `User Guide <https://docs.qbraid.com/sdk/user-guide>`_
 - `Example Notebooks <https://github.com/qBraid/qbraid-lab-demo>`_
-- `API Reference <https://sdk.qbraid.com/en/latest/api/qbraid.html>`_
+- `API Reference <https://qbraid.github.io/qBraid/api/qbraid.html>`_
 - `Source Code <https://github.com/qBraid/qBraid>`_
 
 
@@ -59,19 +64,19 @@ Resources
    :caption: QIR API Reference
    :hidden:
 
-   qbraid_qir <https://sdk.qbraid.com/projects/qir/en/stable/api/qbraid_qir.html>
-   qbraid_qir.cirq <https://sdk.qbraid.com/projects/qir/en/stable/api/qbraid_qir.cirq.html>
-   qbraid_qir.qasm3 <https://sdk.qbraid.com/projects/qir/en/stable/api/qbraid_qir.qasm3.html>
+   qbraid_qir <https://qbraid.github.io/qbraid-qir/api/qbraid_qir.html>
+   qbraid_qir.cirq <https://qbraid.github.io/qbraid-qir/api/qbraid_qir.cirq.html>
+   qbraid_qir.qasm3 <https://qbraid.github.io/qbraid-qir/api/qbraid_qir.qasm3.html>
 
 .. toctree::
    :caption: CORE API Reference
    :hidden:
 
-   qbraid_core <https://sdk.qbraid.com/projects/core/en/stable/api/qbraid_core.html>
-   qbraid_core.services <https://sdk.qbraid.com/projects/core/en/stable/api/qbraid_core.services.html>
+   qbraid_core <https://qbraid.github.io/qbraid-core/api/qbraid_core.html>
+   qbraid_core.services <https://qbraid.github.io/qbraid-core/api/qbraid_core.services.html>
 
 .. toctree::
    :caption: PYQASM API Reference
    :hidden:
 
-   pyqasm <https://sdk.qbraid.com/projects/pyqasm/en/stable/api/pyqasm.html>
+   pyqasm <https://qbraid.github.io/pyqasm/api/pyqasm.html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ filterwarnings = [
     "ignore::urllib3.exceptions.InsecureRequestWarning",
     "ignore::RuntimeWarning:numpy.linalg.linalg",
     "ignore::pytest.PytestCollectionWarning",
+    "ignore:No gate definition.*:RuntimeWarning:qiskit.providers.backend_compat"
 ]
 
 [tool.coverage.run]

--- a/qbraid/programs/gate_model/ionq.py
+++ b/qbraid/programs/gate_model/ionq.py
@@ -56,6 +56,7 @@ IONQ_QIS_GATES = [
     "cv",
     "cvi",
     "id",
+    "zz",
 ]
 
 IONQ_NATIVE_GATES_BASE = ["gpi", "gpi2"]
@@ -121,15 +122,21 @@ class IonQProgram(GateModelProgram):
             raise ValueError("Circuit is empty. Must contain at least one gate.")
 
         native_gate_set = set(IONQ_NATIVE_GATES)
-        first_gate_native = circuit[0].get("gate") in native_gate_set
+
+        def is_native_gate(gate_info: dict) -> bool:
+            """Helper function to determine if a gate is native."""
+            gate = gate_info.get("gate")
+            if gate == "zz":
+                return gate_info.get("angle") is not None
+            return gate in native_gate_set
+
+        first_gate_native = is_native_gate(circuit[0])
 
         for instr in circuit:
-            gate = instr.get("gate")
-            is_native = gate in native_gate_set
-
-            if is_native != first_gate_native:
+            if is_native_gate(instr) != first_gate_native:
                 raise ValueError(
-                    f"Invalid gate '{gate}'. Cannot mix native and QIS gates in the same circuit."
+                    f"Invalid gate '{instr.get('gate')}'. "
+                    "Cannot mix native and QIS gates in the same circuit."
                 )
 
         return GateSet.NATIVE if first_gate_native else GateSet.QIS

--- a/qbraid/runtime/aws/job.py
+++ b/qbraid/runtime/aws/job.py
@@ -123,7 +123,7 @@ class BraketQuantumTask(QuantumJob):
         try:
             task.cancel()
         except RuntimeError:
-            task._aws_session.cancel_quantum_task(task.arn)
+            task._aws_session.cancel_quantum_task(self.id)
 
     @staticmethod
     def _get_cost(task_arn: str, aws_session: Optional[AwsSession] = None) -> Decimal:
@@ -132,5 +132,5 @@ class BraketQuantumTask(QuantumJob):
 
     def get_cost(self) -> float:
         """Return the cost of the job."""
-        decimal_cost = self._get_cost(self._task.arn)
+        decimal_cost = self._get_cost(self.id)
         return float(decimal_cost)

--- a/qbraid/runtime/ionq/device.py
+++ b/qbraid/runtime/ionq/device.py
@@ -110,6 +110,7 @@ class IonQDevice(QuantumDevice):
             program._module.unroll()
             program._program = pyqasm.dumps(program._module)
             program.transform(device=self, gate_mappings=IONQ_GATE_MAP)
+
         return program.program
 
     @staticmethod

--- a/qbraid/runtime/ionq/provider.py
+++ b/qbraid/runtime/ionq/provider.py
@@ -108,7 +108,7 @@ class IonQProvider(QuantumProvider):
                 IONQ_NATIVE_GATES_BASE,
             )
 
-        basis_gates = IONQ_QIS_GATES.copy() + native_gates
+        basis_gates = list(set(IONQ_QIS_GATES.copy() + native_gates))
 
         return basis_gates
 

--- a/qbraid/transpiler/conversions/openqasm3/openqasm3_to_ionq.py
+++ b/qbraid/transpiler/conversions/openqasm3/openqasm3_to_ionq.py
@@ -230,14 +230,27 @@ def _parse_gates(program: Union[OpenQasm2Program, OpenQasm3Program]) -> list[dic
                             f"Angle parameter is required for the '{name}' "
                             "gate but was not provided."
                         ) from err
-                    angle = _parse_angle(angle, ionq_name)
-                    gates.append(
-                        {
-                            "gate": ionq_name,
-                            "angle": angle,
-                            "targets": qubit_values,
-                        }
-                    )
+                    try:
+                        angle = _parse_angle(angle, ionq_name)
+                    except ValueError as err:
+                        if ionq_name == "zz":
+                            gates.append(
+                                {
+                                    "gate": ionq_name,
+                                    "rotation": float(angle),
+                                    "targets": qubit_values,
+                                }
+                            )
+                        else:
+                            raise err
+                    else:
+                        gates.append(
+                            {
+                                "gate": ionq_name,
+                                "angle": angle,
+                                "targets": qubit_values,
+                            }
+                        )
 
                 elif ionq_name in TWO_QUBIT_PARAM_ANGLE_PHASE:
                     params = extract_params(statement)

--- a/qbraid/transpiler/conversions/openqasm3/openqasm3_to_ionq.py
+++ b/qbraid/transpiler/conversions/openqasm3/openqasm3_to_ionq.py
@@ -25,7 +25,6 @@ from qbraid.programs import load_program
 from qbraid.programs.gate_model.ionq import IONQ_NATIVE_GATES, IonQProgram
 from qbraid.programs.gate_model.qasm2 import OpenQasm2Program
 from qbraid.programs.gate_model.qasm3 import OpenQasm3Program
-from qbraid.runtime.enums import ValidationLevel
 from qbraid.transpiler.annotations import weight
 from qbraid.transpiler.exceptions import ProgramConversionError
 
@@ -235,7 +234,6 @@ def _parse_gates(program: Union[OpenQasm2Program, OpenQasm3Program]) -> list[dic
                     )
 
                 if ionq_name in TWO_QUBIT_PARAM_ANGLE:
-                    # TODO:
                     try:
                         angle = extract_params(statement)[0]
                     except IndexError as err:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,10 +3,10 @@ amazon-braket-sdk>=1.83.0,<1.91.0
 cirq-core>=1.3,<1.5
 pennylane<0.41
 pyquil>=4.4; python_version < "3.13"
-qcs-sdk-python>=0.21.12; python_version < "3.13"
+qcs-sdk-python>=0.21.12,<0.21.13; python_version < "3.13"
 pytket>=1.31
 qiskit>=1.0,<1.5
-cudaq>=0.9.0; python_version < "3.13"
+# cudaq>=0.9.0; python_version < "3.13"
 
 # transpiler extras
 ply>=3.6

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ pyquil>=4.4; python_version < "3.13"
 qcs-sdk-python>=0.21.12,<0.21.13; python_version < "3.13"
 pytket>=1.31
 qiskit>=1.0,<1.5
-# cudaq>=0.9.0; python_version < "3.13"
+cudaq>=0.9.0; python_version < "3.13"
 
 # transpiler extras
 ply>=3.6

--- a/tests/runtime/azure/test_azure_runtime.py
+++ b/tests/runtime/azure/test_azure_runtime.py
@@ -15,6 +15,7 @@ Unit tests for the Azure Quantum runtime module.
 
 """
 import json
+import os
 from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
@@ -272,14 +273,22 @@ def test_azure_provider_init_with_credential():
 
 def test_init_without_credential():
     """Test initializing an AzureQuantumProvider without a credential."""
-    workspace = Workspace(
-        subscription_id="something",
-        resource_group="something",
-        name="something",
-        location="something",
-    )
-    with pytest.warns(Warning):
-        AzureQuantumProvider(workspace)
+    original_connection_string = os.environ.pop("AZURE_QUANTUM_CONNECTION_STRING", None)
+
+    try:
+        assert "AZURE_QUANTUM_CONNECTION_STRING" not in os.environ
+
+        workspace = Workspace(
+            subscription_id="something",
+            resource_group="something",
+            name="something",
+            location="something",
+        )
+        with pytest.warns(Warning):
+            AzureQuantumProvider(workspace)
+    finally:
+        if original_connection_string is not None:
+            os.environ["AZURE_QUANTUM_CONNECTION_STRING"] = original_connection_string
 
 
 def test_azure_provider_workspace_property(azure_provider, mock_workspace):

--- a/tests/runtime/native/test_ionq_runtime_remote.py
+++ b/tests/runtime/native/test_ionq_runtime_remote.py
@@ -18,7 +18,6 @@ import warnings
 import pytest
 
 from qbraid import GateModelResultData, QbraidProvider
-from qbraid.runtime import ValidationLevel
 
 
 @pytest.mark.remote
@@ -46,7 +45,6 @@ def test_qiskit_ionq_workflow():
 
         provider = QbraidProvider()
         device = provider.get_device("ionq_simulator")
-        device.set_options(validate=ValidationLevel.WARN)
 
         shots = 10
         job = device.run(qiskit_circuit_transpiled, shots=shots)

--- a/tests/runtime/native/test_quera_aquila_runtime.py
+++ b/tests/runtime/native/test_quera_aquila_runtime.py
@@ -100,6 +100,7 @@ def test_prepare_ahs_program(mock_device, braket_ahs, ahs_dict):
     assert mock_device.prepare(braket_ahs) == {"ahs": json.dumps(ahs_dict)}
 
 
+@pytest.mark.filterwarnings("ignore:Device is not online*:UserWarning")
 def test_submit_ahs_job_to_aquila(braket_ahs, mock_device, mock_job_id):
     """Test submitting AHS job to QuEra Aquila device."""
     job = mock_device.run(braket_ahs)

--- a/tests/transpiler/qasm/test_qasm_to_ionq.py
+++ b/tests/transpiler/qasm/test_qasm_to_ionq.py
@@ -349,25 +349,36 @@ def test_qasm3_to_ionq_zz_native_gate():
             """
     OPENQASM 3.0;
     qubit[2] q;
-    zz(0.45) q[0], q[1];
-    """,
-            "Invalid angle value",
-        ),
-        (
-            """
-    OPENQASM 3.0;
-    qubit[2] q;
-    zz(-0.9) q[0], q[1];
-    """,
-            "Invalid angle value",
-        ),
-        (
-            """
-    OPENQASM 3.0;
-    qubit[2] q;
     zz(abc) q[0], q[1];
     """,
             "Invalid angle value 'abc'",
+        ),
+        (
+            """
+    OPENQASM 3.0;
+    qubit[2] q;
+    gpi(0) q[1];
+    zz(2*pi) q[0], q[1];
+    """,
+            "Invalid angle value '2 * pi'",
+        ),
+        (
+            """
+    OPENQASM 3.0;
+    qubit[2] q;
+    cgpi2(0) q[0], q[1];
+    zz(2*pi) q[0], q[1];
+    """,
+            "Invalid angle value '2 * pi'",
+        ),
+        (
+            """
+    OPENQASM 3.0;
+    qubit[2] q;
+    zz(0.15) q[0], q[1];
+    zz(3.0) q[0], q[1];
+    """,
+            "Invalid angle value '3.0'",
         ),
     ],
 )
@@ -376,6 +387,72 @@ def test_qasm3_to_ionq_invalid_params(qasm_code, error_message):
     with pytest.raises(ProgramConversionError) as excinfo:
         qasm3_to_ionq(qasm_code)
     assert error_message in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "qasm_code, ionq_dict",
+    [
+        (
+            """
+    OPENQASM 3.0;
+    qubit[2] q;
+    zz(0.45) q[0], q[1];
+    """,
+            {
+                "qubits": 2,
+                "circuit": [{"gate": "zz", "rotation": 0.45, "targets": [0, 1]}],
+                "gateset": "qis",
+                "format": "ionq.circuit.v0",
+            },
+        ),
+        (
+            """
+    OPENQASM 3.0;
+    qubit[2] q;
+    zz(-0.9) q[0], q[1];
+    """,
+            {
+                "qubits": 2,
+                "circuit": [{"gate": "zz", "rotation": -0.9, "targets": [0, 1]}],
+                "gateset": "qis",
+                "format": "ionq.circuit.v0",
+            },
+        ),
+        (
+            """
+    OPENQASM 3.0;
+    qubit[2] q;
+    zz(0.1) q[0], q[1];
+    """,
+            {
+                "qubits": 2,
+                "circuit": [{"gate": "zz", "angle": 0.1, "targets": [0, 1]}],
+                "gateset": "native",
+                "format": "ionq.circuit.v0",
+            },
+        ),
+        (
+            """
+    OPENQASM 3.0;
+    qubit[2] q;
+    h q[0];
+    zz(pi/16) q[0], q[1];
+    """,
+            {
+                "qubits": 2,
+                "circuit": [
+                    {"gate": "h", "target": 0},
+                    {"gate": "zz", "rotation": 0.19634954084936207, "targets": [0, 1]},
+                ],
+                "gateset": "qis",
+                "format": "ionq.circuit.v0",
+            },
+        ),
+    ],
+)
+def test_qasm3_to_ionq_zz_context(qasm_code, ionq_dict):
+    """Test that qasm3_to_ionq correctly labels the gate parameter based on the value."""
+    assert qasm3_to_ionq(qasm_code) == ionq_dict
 
 
 @pytest.mark.parametrize(

--- a/tests/transpiler/qasm/test_qasm_to_ionq.py
+++ b/tests/transpiler/qasm/test_qasm_to_ionq.py
@@ -106,7 +106,7 @@ def test_ionq_device_extract_gate_data():
 
 
 def test_qasm2_to_ionq_measurements_raises():
-    """Test that qasm2_to_ionq raises an error when the circuit contains measurements."""
+    """Test that qasm2_to_ionq emits warning when the circuit contains measurements."""
     qasm = """
     OPENQASM 2.0;
     include "qelib1.inc";
@@ -115,9 +115,14 @@ def test_qasm2_to_ionq_measurements_raises():
     x q[0];
     measure q[0] -> c[0];
     """
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.warns(
+        UserWarning,
+        match=(
+            "Circuit contains measurement gates, which will be ignored "
+            "during conversion to the IonQDictType"
+        ),
+    ):
         qasm2_to_ionq(qasm)
-    assert "Circuits with measurements are not supported by the IonQDictType" in str(excinfo.value)
 
 
 @pytest.fixture

--- a/tests/transpiler/test_transpiler.py
+++ b/tests/transpiler/test_transpiler.py
@@ -28,6 +28,7 @@ from qiskit.circuit.quantumregister import Qubit as QiskitQubit
 from qbraid.interface import assert_allclose_up_to_global_phase
 from qbraid.programs import QPROGRAM_ALIASES, load_program
 from qbraid.programs.exceptions import ProgramLoaderError, ProgramTypeError
+from qbraid.programs.registry import is_registered_alias_native
 from qbraid.transpiler.converter import transpile
 from qbraid.transpiler.exceptions import NodeNotFoundError
 from qbraid.transpiler.graph import ConversionGraph
@@ -87,8 +88,10 @@ def test_cirq_round_trip(bell_circuit, to_type, conversion_graph: ConversionGrap
     ):
         pytest.skip(f"cirq to {to_type} round-trip not yet supported")
     circuit_in, _ = bell_circuit
-    circuit_mid = transpile(circuit_in, to_type, require_native=True)
-    circuit_out = transpile(circuit_mid, "cirq", require_native=True)
+
+    require_native = is_registered_alias_native(to_type)
+    circuit_mid = transpile(circuit_in, to_type, require_native=require_native)
+    circuit_out = transpile(circuit_mid, "cirq", require_native=require_native)
     assert _equal(circuit_in, circuit_out), f"Failed round-trip from cirq to {to_type}"
 
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

- Added a workflow for deploying to GitHub Pages on release publication or manual dispatch.
- Updated `bump-version.yml` to track `qbraid/_version.py` instead of `pyproject.toml`.
- Adjusted docs side navigation search styling for better alignment.
- Added support for interpreting `zz` as a QIS gate in `openqasm3_to_ionq` and refactored `determine_gateset` accordingly
- Modified `openqasm3_to_ionq` to emit warning instead of raise error when circuits contains measurements.
- Fixed bug where `BraketQuantumTask._task.arn` undefined if instaniated without `AwsQuantumTask` object
