### PR TITLE
Populate basis gates in IBM Quantum provider backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Types of changes:
 ### Improved / Modified
 - Disabled validation step in remote (native) IonQ runtime test when constructing `IonQDict` via `qiskit-ionq` ([#915](https://github.com/qBraid/qBraid/pull/915))
 - Enabled loading `azure.quantum.Workspace` from `AZURE_QUANTUM_CONNECTION_STRING` environment variable in `AzureQuantumProvider` class ([#915](https://github.com/qBraid/qBraid/pull/915))
+- Populated basis gates property in profile of IBM Quantum provider backends ([#930](https://github.com/qBraid/qBraid/pull/930))
 - Adjusted docs side navigation search styling for better alignment. ([#917](https://github.com/qBraid/qBraid/pull/917))
 - Added support for interpreting `zz` as a QIS gate in `openqasm3_to_ionq` and refactored `determine_gateset` accordingly ([#917](https://github.com/qBraid/qBraid/pull/917))
 - Modified `openqasm3_to_ionq` to emit warning instead of raise error when circuits contains measurements. ([#917](https://github.com/qBraid/qBraid/pull/917))

--- a/qbraid/runtime/ibm/provider.py
+++ b/qbraid/runtime/ibm/provider.py
@@ -22,7 +22,7 @@ from qiskit_ibm_runtime import QiskitRuntimeService
 from qiskit_ibm_runtime.accounts import ChannelType
 
 from qbraid._caching import cached_method
-from qbraid.programs import ProgramSpec
+from qbraid.programs import ProgramSpec, ExperimentType
 from qbraid.runtime.profile import TargetProfile
 from qbraid.runtime.provider import QuantumProvider
 
@@ -97,6 +97,8 @@ class QiskitRuntimeProvider(QuantumProvider):
             instance=backend._instance,
             max_shots=config.max_shots,
             provider_name="IBM",
+            experiment_type=ExperimentType.GATE_MODEL,
+            basis_gates=config.basis_gates,
         )
 
     @cached_method

--- a/qbraid/runtime/ibm/provider.py
+++ b/qbraid/runtime/ibm/provider.py
@@ -22,7 +22,7 @@ from qiskit_ibm_runtime import QiskitRuntimeService
 from qiskit_ibm_runtime.accounts import ChannelType
 
 from qbraid._caching import cached_method
-from qbraid.programs import ProgramSpec, ExperimentType
+from qbraid.programs import ExperimentType, ProgramSpec
 from qbraid.runtime.profile import TargetProfile
 from qbraid.runtime.provider import QuantumProvider
 

--- a/tests/runtime/ibm/test_qiskit_runtime.py
+++ b/tests/runtime/ibm/test_qiskit_runtime.py
@@ -40,7 +40,7 @@ from qbraid.runtime.ibm.result_builder import QiskitGateModelResultBuilder
 
 FIXTURE_COUNT = sum(key in NATIVE_REGISTRY for key in ["qiskit", "braket", "cirq"])
 
-
+FAKE_BASIS_GATES = ["u1", "u2", "u3", "cx"]
 class FakeDevice(GenericBackendV2):
     """A test Qiskit device."""
 
@@ -78,7 +78,7 @@ class FakeDevice(GenericBackendV2):
             backend_name="fake_backend",
             backend_version="1.0",
             n_qubits=self._num_qubits,
-            basis_gates=["u1", "u2", "u3", "cx"],
+            basis_gates=FAKE_BASIS_GATES,
             gates=[],
             local=self._local,
             simulator=self._simulator,
@@ -194,6 +194,7 @@ def test_provider_build_runtime_profile(local, simulator, num_qubits):
         assert profile["local"] == local
         assert profile["num_qubits"] == num_qubits
         assert profile["max_shots"] == 8192
+        assert profile.basis_gates == set(FAKE_BASIS_GATES)
 
         qiskit_backend = QiskitBackend(profile, mock_runtime_service())
         assert isinstance(qiskit_backend, QiskitBackend)

--- a/tests/runtime/ibm/test_qiskit_runtime.py
+++ b/tests/runtime/ibm/test_qiskit_runtime.py
@@ -41,6 +41,8 @@ from qbraid.runtime.ibm.result_builder import QiskitGateModelResultBuilder
 FIXTURE_COUNT = sum(key in NATIVE_REGISTRY for key in ["qiskit", "braket", "cirq"])
 
 FAKE_BASIS_GATES = ["u1", "u2", "u3", "cx"]
+
+
 class FakeDevice(GenericBackendV2):
     """A test Qiskit device."""
 


### PR DESCRIPTION
Consider the following snippet instantiating an IBM Quantum provider backend.
```python3
provider = QiskitRuntimeProvider()
device = provider.get_device("ibm_sherbrooke")
print(device.profile.basis_gates)
```
Output before PR:
```
None
```
Output after PR:
```
{'x', 'ecr', 'id', 'rz', 'sx'}
```