### PR TITLE
Skip OQC remote tests - QCaaS servers offline

### DIFF
--- a/.github/workflows/pr-compliance.yml
+++ b/.github/workflows/pr-compliance.yml
@@ -19,7 +19,7 @@ jobs:
   remind:
     name: Changelog
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]' && github.event.pull_request.draft == false }}
+    if: ${{ github.actor != 'dependabot' && github.actor != 'dependabot[bot]' && github.actor != 'github-actions' && github.actor != 'github-actions[bot]' && github.event.pull_request.draft == false }}
     steps:
     - uses: actions/checkout@v4
     - name: Changelog Reminder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Types of changes:
 - Added support for interpreting `zz` as a QIS gate in `openqasm3_to_ionq` and refactored `determine_gateset` accordingly ([#917](https://github.com/qBraid/qBraid/pull/917))
 - Modified `openqasm3_to_ionq` to emit warning instead of raise error when circuits contains measurements. ([#917](https://github.com/qBraid/qBraid/pull/917))
 - Set 20 minute timeout for daily github actions workflow ([#919](https://github.com/qBraid/qBraid/pull/919))
+- Temporarily skip remote OQC tests because the QCaaS servers will be offline until March 17, 2025. ([#931](https://github.com/qBraid/qBraid/pull/931))
 
 ### Deprecated
 

--- a/tests/runtime/oqc/test_oqc_runtime.py
+++ b/tests/runtime/oqc/test_oqc_runtime.py
@@ -612,6 +612,7 @@ def test_cancel_job(oqc_device, program):
     assert job.cancel() is None
 
 
+@pytest.mark.skip(reason="QCaaS servers offline until March 17, 2025")
 @pytest.mark.remote
 def test_oqc_runtime_remote_execution(program, optimized_program):
     """Test OQC runtime with remote execution."""


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

- Temporarily skip remote OQC tests because the QCaaS servers will be offline until March 17, 2025.

