### PR TITLE
skip azure remote test(s) if device is offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Types of changes:
 
 - Added bin script + logic in version bump workflow to automatically update `CITATION.ff` ([#915](https://github.com/qBraid/qBraid/pull/915))
 - Added a workflow for deploying to GitHub Pages on release publication or manual dispatch. ([#917](https://github.com/qBraid/qBraid/pull/917))
+- Added `pytest.skip` statements to Azure remote tests to skip them when the relevant device is not online. ([#934](https://github.com/qBraid/qBraid/pull/934))
 
 ### Improved / Modified
 - Disabled validation step in remote (native) IonQ runtime test when constructing `IonQDict` via `qiskit-ionq` ([#915](https://github.com/qBraid/qBraid/pull/915))

--- a/tests/runtime/azure/test_azure_remote.py
+++ b/tests/runtime/azure/test_azure_remote.py
@@ -42,7 +42,10 @@ if TYPE_CHECKING:
 def test_submit_qasm2_to_quantinuum(provider: AzureQuantumProvider):
     """Test submitting an OpenQASM 2 string to run on the Quantinuum simulator."""
     device = provider.get_device("quantinuum.sim.h1-1sc")
-    assert device.status() == DeviceStatus.ONLINE
+    status = device.status()
+
+    if status != DeviceStatus.ONLINE:
+        pytest.skip(f"{device.id} is {status.value}")
 
     circuit = """
     OPENQASM 2.0;
@@ -71,7 +74,10 @@ def test_submit_qasm2_to_quantinuum(provider: AzureQuantumProvider):
 def test_submit_json_to_ionq(provider: AzureQuantumProvider):
     """Test submitting a circuit JSON to run on the IonQ simulator."""
     device = provider.get_device("ionq.simulator")
-    assert device.status() == DeviceStatus.ONLINE
+    status = device.status()
+
+    if status != DeviceStatus.ONLINE:
+        pytest.skip(f"{device.id} is {status.value}")
 
     circuit = {
         "qubits": 3,


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

- Added pytest.skip statements to Azure remote tests to skip them when the relevant device is not online.
