### PR TITLE
Add async support for waiting on QuantumJob completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Types of changes:
 ## [Unreleased]
 
 ### Added
+- Added asynchronous method `QuantumJob._wait_for_final_state()` for non-blocking polling.
+- Added `QbraidJob.async_result()` to support async result retrieval using `await`.
 - Added `qbraid.runtime.get_providers()` and corresponding `qbraid.runtime.PROVIDERS` which is a list of the provider aliases that can be passed to the `qbraid.runtime.load_job()`function. ([#887](https://github.com/qBraid/qBraid/pull/887))
 
 ```python

--- a/qbraid/runtime/job.py
+++ b/qbraid/runtime/job.py
@@ -96,12 +96,11 @@ class QuantumJob(ABC):
         asynchronous applications where blocking the event loop is undesirable.
 
         Args:
-            timeout: Seconds to wait for the job. If ``None``, wait indefinitely.
-            poll_interval: Seconds between queries. Defaults to 5 seconds.
+            timeout (Optional[int]): Maximum number of seconds to wait for the job. If None, waits indefinitely.
+            poll_interval (int): Seconds between queries. Defaults to 5.
 
         Raises:
-            JobStateError: If the job does not reach a final state before the specified timeout.
-
+            TimeoutError: If the job does not reach a terminal state before the specified timeout.
         """
         start_time = time()
         while not self.is_terminal_state():
@@ -113,30 +112,21 @@ class QuantumJob(ABC):
     async def async_result(
             self, timeout: Optional[int] = None, poll_interval: int = 5
     ) -> qbraid.runtime.Result[ResultDataType]:
-        """
-        Asynchronously wait for the job to reach a final state and return the result.
+        """Asynchronously wait for the job to reach a final state and return the result.
 
         This method provides a non-blocking way to poll the job status using asyncio.
         It allows developers to `await` the job without blocking the event loop,
         making it suitable for integration in async applications and pipelines.
 
-        Parameters
-        ----------
-        timeout : int, optional
-            Maximum number of seconds to wait for the job. If ``None``, waits indefinitely.
+        Args:
+            timeout (Optional[int]): Maximum number of seconds to wait for the job. If None, waits indefinitely.
+            poll_interval (int): Seconds between status checks. Defaults to 5.
 
-        poll_interval : int, default=5
-            Number of seconds between status checks while waiting.
+        Returns:
+            Result[ResultDataType]: The result object associated with the job, if successfully completed.
 
-        Raises
-        ------
-        JobStateError
-            If the job does not reach a final (terminal) state before the timeout expires.
-
-        Returns
-        -------
-        Result[ResultDataType]
-            The result object associated with the job, if successfully completed.
+        Raises:
+            TimeoutError: If the job does not reach a terminal state before the timeout expires.
         """
         await self._wait_for_final_state(timeout, poll_interval)
         return self.result()

--- a/qbraid/runtime/job.py
+++ b/qbraid/runtime/job.py
@@ -96,7 +96,8 @@ class QuantumJob(ABC):
         asynchronous applications where blocking the event loop is undesirable.
 
         Args:
-            timeout (Optional[int]): Maximum number of seconds to wait for the job. If None, waits indefinitely.
+            timeout (Optional[int]): Maximum number of seconds to wait for the job.
+                If None, waits indefinitely.
             poll_interval (int): Seconds between queries. Defaults to 5.
 
         Raises:
@@ -119,11 +120,13 @@ class QuantumJob(ABC):
         making it suitable for integration in async applications and pipelines.
 
         Args:
-            timeout (Optional[int]): Maximum number of seconds to wait for the job. If None, waits indefinitely.
+            timeout (Optional[int]): Maximum number of seconds to wait for the job.
+                If None, waits indefinitely.
             poll_interval (int): Seconds between status checks. Defaults to 5.
 
         Returns:
-            Result[ResultDataType]: The result object associated with the job, if successfully completed.
+            Result[ResultDataType]: The result object associated with the job,
+            if successfully completed.
 
         Raises:
             TimeoutError: If the job does not reach a terminal state before the timeout expires.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 # optional program types
 amazon-braket-sdk>=1.83.0,<1.92.0
 cirq-core>=1.3,<1.5
+cudaq>=0.9.0; python_version < "3.13"
 pennylane<0.41
 pyquil>=4.4; python_version < "3.13"
 qcs-sdk-python>=0.21.12,<0.21.13; python_version < "3.13"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 # optional program types
 amazon-braket-sdk>=1.83.0,<1.92.0
 cirq-core>=1.3,<1.5
-cudaq>=0.9.0; python_version < "3.13"
 pennylane<0.41
 pyquil>=4.4; python_version < "3.13"
 qcs-sdk-python>=0.21.12,<0.21.13; python_version < "3.13"
@@ -38,3 +37,4 @@ sympy
 packaging>=20.0
 pytest
 pytest-cov
+pytest-asyncio>=0.21


### PR DESCRIPTION
### Summary

This PR introduces asynchronous support for job completion:

- `QuantumJob._wait_for_final_state()` - an `async` version of `wait_for_final_state()` using `asyncio.sleep`.
- `QbraidJob.async_result()` - an async wrapper that waits for job completion and returns the result.
- Associated tests using `pytest.mark.asyncio` for both success and timeout scenarios.
- All functions include proper docstrings and type hints.

### Motivation

The async variant allows non-blocking job monitoring in event-loop-driven applications such as async pipelines and UIs.

### Checklist
- [x] Unit tests added for async methods.
- [x] Existing tests pass via `tox -e unit-tests`.
- [x] Documentation builds via `tox -e docs`.
- [x] Code style verified via `tox -e format-check`.

Closes #942 