### PR TITLE
Remove `strict` param from `pydantic_core` union schema calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,12 @@ Types of changes:
 ### Deprecated
 
 ### Removed
+- Removed the `strict=False` parameter from the `pydantic_core.core_schema.union_schema()` calls in the `__get_pydantic_core_schema__` method(s) in `qbraid.runtime.schemas.base`. `stric` parameter no longer included in the `pydantic-core` API for that method as of release [v0.2.30](https://github.com/pydantic/pydantic-core/releases/tag/v2.30.0), PR [#1638](https://github.com/pydantic/pydantic-core/pull/1638). ([#946](https://github.com/qBraid/qBraid/pull/946))
 
 ### Fixed
 
 ### Dependencies
+- Added `pydantic-core` to project requirements ([#946](https://github.com/qBraid/qBraid/pull/946))
 
 ## [0.9.5] - 2025-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,21 @@ Types of changes:
 ## [Unreleased]
 
 ### Added
-- Added asynchronous method `QuantumJob._wait_for_final_state()` for non-blocking polling.
-- Added `QbraidJob.async_result()` to support async result retrieval using `await`.
+- Added `QbraidJob.async_result()` to support async result retrieval using `await`. ([#945](https://github.com/qBraid/qBraid/pull/945))
+
+### Improved / Modified
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Dependencies
+
+## [0.9.5] - 2025-03-26
+
+### Added
 - Added `qbraid.runtime.get_providers()` and corresponding `qbraid.runtime.PROVIDERS` which is a list of the provider aliases that can be passed to the `qbraid.runtime.load_job()`function. ([#887](https://github.com/qBraid/qBraid/pull/887))
 
 ```python
@@ -43,8 +56,6 @@ Types of changes:
 - `QuantumJob.wait_for_final_state` now raises `TimeoutError` on timeout instead of `JobStateError` ([#943](https://github.com/qBraid/qBraid/pull/943))
 - Updated job ID type annotations to support both `str` and `int` (for compatibility with QUDORA) ([#943](https://github.com/qBraid/qBraid/pull/943))
 - Updated `qbraid._logging` so that `logging.basicConfig` is only set if `LOG_LEVEL` environment variable is defined. ([#943](https://github.com/qBraid/qBraid/pull/943))
-
-### Deprecated
 
 ### Removed
 - Removed `qasm3_drawer` function  in favor of `pyqasm.draw` ([#943](https://github.com/qBraid/qBraid/pull/943))

--- a/qbraid/runtime/job.py
+++ b/qbraid/runtime/job.py
@@ -87,7 +87,7 @@ class QuantumJob(ABC):
             sleep(poll_interval)
 
     async def _wait_for_final_state(
-            self, timeout: Optional[int] = None, poll_interval: int = 5
+        self, timeout: Optional[int] = None, poll_interval: int = 5
     ) -> None:
         """Asynchronously wait for the job to reach a terminal state (e.g., COMPLETED, FAILED).
 
@@ -111,7 +111,7 @@ class QuantumJob(ABC):
             await asyncio.sleep(poll_interval)
 
     async def async_result(
-            self, timeout: Optional[int] = None, poll_interval: int = 5
+        self, timeout: Optional[int] = None, poll_interval: int = 5
     ) -> qbraid.runtime.Result[ResultDataType]:
         """Asynchronously wait for the job to reach a final state and return the result.
 

--- a/qbraid/runtime/schemas/base.py
+++ b/qbraid/runtime/schemas/base.py
@@ -97,7 +97,6 @@ class Credits(qbraid_core.decimal.Credits):
                 core_schema.float_schema(),
                 handler(Decimal),
             ],
-            strict=False,
             custom_error_type="credits_type",
             custom_error_message="Input should be a number (int, float, or Decimal)",
         )
@@ -141,7 +140,6 @@ class USD(qbraid_core.decimal.USD):
                 core_schema.float_schema(),
                 handler(Decimal),
             ],
-            strict=False,
             custom_error_type="usd_type",
             custom_error_message="Input should be a number (int, float, or Decimal)",
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ numpy>=1.17
 openqasm3[parser]>=0.4.0
 qbraid-core>=0.1.25
 pydantic>2.0.0
+pydantic-core
 typing-extensions>=4.0.0
 pyqasm>=0.3.0,<0.4.0


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

- Removed the `strict=False` parameter from the `pydantic_core.core_schema.union_schema()` calls in the `__get_pydantic_core_schema__` method(s) in `qbraid.runtime.schemas.base`. `stric` parameter no longer included in the `pydantic-core` API for that method as of release [v0.2.30](https://github.com/pydantic/pydantic-core/releases/tag/v2.30.0), PR [#1638](https://github.com/pydantic/pydantic-core/pull/1638).
- Added `pydantic-core` to project requirements