### PR TITLE
Fixed braket remote test timeout error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Types of changes:
 - Removed the `strict=False` parameter from the `pydantic_core.core_schema.union_schema()` calls in the `__get_pydantic_core_schema__` method(s) in `qbraid.runtime.schemas.base`. `stric` parameter no longer included in the `pydantic-core` API for that method as of release [v0.2.30](https://github.com/pydantic/pydantic-core/releases/tag/v2.30.0), PR [#1638](https://github.com/pydantic/pydantic-core/pull/1638). ([#946](https://github.com/qBraid/qBraid/pull/946))
 
 ### Fixed
+- Fixed Amazon Braket remote test by changing catch `JobStateError` to `TimeoutError` ([#948](https://github.com/qBraid/qBraid/pull/948))
 
 ### Dependencies
 - Added `pydantic-core` to project requirements ([#946](https://github.com/qBraid/qBraid/pull/946))

--- a/tests/runtime/aws/test_braket_remote.py
+++ b/tests/runtime/aws/test_braket_remote.py
@@ -23,7 +23,6 @@ from braket.tracking.tracker import Tracker
 
 from qbraid.runtime.aws.provider import BraketProvider
 from qbraid.runtime.aws.tracker import get_quantum_task_cost
-from qbraid.runtime.exceptions import JobStateError
 
 
 @pytest.fixture
@@ -91,7 +90,7 @@ def test_get_quantum_task_cost_cancelled(braket_most_busy, braket_no_meas):
     try:
         qbraid_job.wait_for_final_state(timeout=30)
         final_state_reached = True
-    except JobStateError:
+    except TimeoutError:
         final_state_reached = False
 
     # Based on whether final state was reached or not, proceed to verify expected outcomes


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

- Changed catch `JobStateError` to `TimeoutError` in braket remote test
