### PR TITLE
Add set target program type method to QbraidDevice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,29 @@ Types of changes:
 
 ### Added
 - Added `QbraidJob.async_result()` to support async result retrieval using `await`. ([#945](https://github.com/qBraid/qBraid/pull/945))
+- Added `QbraidDevice.set_target_program_type`, allowing you to set a specific `ProgramSpec` (from `TargetProfile`) alias as the default ([#952](https://github.com/qBraid/qBraid/pull/952)). For example, if a device supports both "qasm2" and "qasm3", you can now restrict transpilation to one format:
+
+```python
+from qbraid.runtime import IonQProvider
+
+provider = IonQProvider()
+
+device = provider.get_device("simulator")
+
+device.metadata()["runtime_config"]["target_program_type"] # ['qasm2', 'qasm3']
+
+device.set_target_program_type("qasm2")
+
+device.metadata()["runtime_config"]["target_program_type"] # 'qasm2'
+```
+
+However the original `TargetProfile.program_spec` value remains frozen:
+
+```python
+device.profile.program_spec
+# [<ProgramSpec('builtins.str', 'qasm2')>,
+#  <ProgramSpec('builtins.str', 'qasm3')>]
+```
 
 ### Improved / Modified
 

--- a/qbraid/runtime/device.py
+++ b/qbraid/runtime/device.py
@@ -271,7 +271,8 @@ class QuantumDevice(ABC):
             alias = aliases[0]
             if alias != self.profile.program_spec.alias:
                 raise ValueError(
-                    f"Invalid alias: '{alias}'. Available aliases: '{self.profile.program_spec.alias}'"
+                    f"Invalid alias: '{alias}'. "
+                    f"Available aliases: '{self.profile.program_spec.alias}'"
                 )
             self._target_spec = [self.profile.program_spec] if as_lst else self.profile.program_spec
 

--- a/qbraid/runtime/device.py
+++ b/qbraid/runtime/device.py
@@ -203,7 +203,7 @@ class QuantumDevice(ABC):
             for key, value in dict(self._options).items()
         }
 
-        program_spec = self.profile.program_spec
+        program_spec = self._target_spec
 
         if not program_spec:
             target_program_type = None

--- a/qbraid/runtime/device.py
+++ b/qbraid/runtime/device.py
@@ -206,14 +206,14 @@ class QuantumDevice(ABC):
         program_spec = self.profile.program_spec
 
         if not program_spec:
-            target_ir = None
+            target_program_type = None
         elif isinstance(program_spec, list):
-            target_ir = [ps.alias for ps in program_spec]
+            target_program_type = [ps.alias for ps in program_spec]
         else:
-            target_ir = program_spec.alias
+            target_program_type = program_spec.alias
 
         runtime_config = {
-            "target_ir": target_ir,
+            "target_program_type": target_program_type,
             "conversion_scheme": self._scheme.to_dict(),
             "options": options,
         }
@@ -221,6 +221,62 @@ class QuantumDevice(ABC):
         metadata["runtime_config"] = runtime_config
 
         return metadata
+
+    def set_target_program_type(self, alias: str | list[str] | None) -> None:
+        """Set the program type to target during runtime transpile step.
+
+        Args:
+            alias: The alias(es) of the target program spec(s) to set.
+
+        Raises:
+            ValueError: If the given alias does not match any program spec in the target profile.
+        """
+        if alias is None:
+            self._target_spec = None
+            return
+
+        aliases = [alias] if isinstance(alias, str) else alias
+
+        if len(set(aliases)) != len(aliases):
+            raise ValueError("Duplicate aliases are not allowed.")
+
+        if isinstance(self.profile.program_spec, list):
+            spec_aliases = {spec.alias for spec in self.profile.program_spec}
+            if isinstance(alias, str):
+                if alias not in spec_aliases:
+                    raise ValueError(
+                        f"Invalid alias: '{alias}'. Available aliases: {', '.join(spec_aliases)}"
+                    )
+                self._target_spec = next(
+                    spec for spec in self.profile.program_spec if spec.alias == alias
+                )
+            else:
+                missing_aliases = [a for a in aliases if a not in spec_aliases]
+                if missing_aliases:
+                    raise ValueError(
+                        f"Invalid aliases: {', '.join(missing_aliases)}. "
+                        f"Available aliases: {', '.join(spec_aliases)}"
+                    )
+                self._target_spec = [
+                    spec for spec in self.profile.program_spec if spec.alias in aliases
+                ]
+
+        elif self.profile.program_spec is not None:
+            if len(aliases) != 1:
+                raise ValueError(
+                    "Alias list must contain exactly one alias when the target profile "
+                    "has a single program spec."
+                )
+            as_lst = isinstance(alias, list)
+            alias = aliases[0]
+            if alias != self.profile.program_spec.alias:
+                raise ValueError(
+                    f"Invalid alias: '{alias}'. Available aliases: '{self.profile.program_spec.alias}'"
+                )
+            self._target_spec = [self.profile.program_spec] if as_lst else self.profile.program_spec
+
+        else:
+            raise ValueError("Target profile has no program spec defined.")
 
     def _get_target_spec(self, run_input: qbraid.programs.QPROGRAM) -> ProgramSpec:
         run_input_alias = get_program_type_alias(run_input, safe=True)

--- a/tests/runtime/test_device.py
+++ b/tests/runtime/test_device.py
@@ -8,11 +8,10 @@
 #
 # THERE IS NO WARRANTY for the qBraid-SDK, as per Section 15 of the GPL v3.
 
-# pylint: disable=redefined-outer-name,unused-argument
+# pylint: disable=redefined-outer-name,unused-argument,too-many-lines
 
 """
-Unit tests for QbraidDevice, QbraidJob, and QbraidGateModelResultBuilder
-classes using the qbraid_qir_simulator and nec_vector_annealer devices.
+Unit tests for QbraidDevice and QbraidProvider classes.
 
 """
 import importlib.util
@@ -991,10 +990,28 @@ def test_set_target_program_type_raises_for_multiple(mock_qasm_device: QbraidDev
         mock_qasm_device.set_target_program_type("qasm4")
 
 
-def test_set_target_program_type_raises_for_single(mock_qbraid_device: QbraidDevice):
-    """Test setting target spec with multiple program specs."""
+def test_set_target_program_type_raises_for_single_invalid(mock_qbraid_device: QbraidDevice):
+    """Test setting target spec raises ValueError for invalid alias."""
     with pytest.raises(ValueError):
         mock_qbraid_device.set_target_program_type("qasm4")
+
+
+def test_set_target_program_type_raises_for_list_invalid(mock_qasm_device: QbraidDevice):
+    """Test setting target spec raises if any alias in list is not in original spec."""
+    with pytest.raises(ValueError):
+        mock_qasm_device.set_target_program_type(["qasm2", "qasm4"])
+
+
+def test_set_target_program_type_raises_for_list_if_spec_single(mock_qbraid_device: QbraidDevice):
+    """Test setting target spec raises if list is given but spec expects single alias."""
+    with pytest.raises(ValueError):
+        mock_qbraid_device.set_target_program_type(["qasm2", "qasm4"])
+
+
+def test_set_target_program_type_raises_for_duplicate(mock_qbraid_device: QbraidDevice):
+    """Test setting target spec raises ValueError for duplicate alias input."""
+    with pytest.raises(ValueError):
+        mock_qbraid_device.set_target_program_type(["qasm3", "qasm3"])
 
 
 @pytest.fixture
@@ -1008,8 +1025,13 @@ def mock_profile_program_spec_none():
     )
 
 
-# @pytest.fixture
-# def mock_device_program_spec_none(mock_profile_program_spec_none):
-#     return QbraidDevice(profile=mock_profile_program_spec_none, client)
-# def test_set_target_program_type_raises_for_none(mock_qasm_device: QbraidDevice):
-#     return QbraidDevice(profile=mock_qasm_profile, client=mock_client, scheme=mock_scheme)
+@pytest.fixture
+def mock_device_program_spec_none(mock_profile_program_spec_none, mock_client):
+    """Mock QbraidDevice for testing with target profile program_spec set to None."""
+    return QbraidDevice(profile=mock_profile_program_spec_none, client=mock_client)
+
+
+def test_set_target_spec_raises_if_none(mock_device_program_spec_none: QbraidDevice):
+    """Test setting target spec raises ValueError if program_spec is None."""
+    with pytest.raises(ValueError):
+        mock_device_program_spec_none.set_target_program_type("qasm2")


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

- Added `QbraidDevice.set_target_program_type`, allowing you to set a specific `ProgramSpec` (from `TargetProfile`) alias as the default. For example, if a device supports both "qasm2" and "qasm3", you can now restrict transpilation to one format:

```python
from qbraid.runtime import IonQProvider

provider = IonQProvider()

device = provider.get_device("simulator")

device.metadata()["runtime_config"]["target_program_type"] # ['qasm2', 'qasm3']

device.set_target_program_type("qasm2")

device.metadata()["runtime_config"]["target_program_type"] # 'qasm2'
```

However the original `TargetProfile.program_spec` value remains frozen:

```python
device.profile.program_spec
# [<ProgramSpec('builtins.str', 'qasm2')>,
#  <ProgramSpec('builtins.str', 'qasm3')>]
```