### PR TITLE
Add support for transpiling QASM2 to/from pyqpanda3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,10 @@ result = job.result()
 result.data.get_counts()  # {'100110': 1}
 ```
 
+- Added support for transpiling between [pyqpanda3](https://pyqpanda-toturial.readthedocs.io/) and QASM2 with `pyqpanda3` program type ([#963](https://github.com/qBraid/qBraid/pull/963))
+
+
+
 ### Improved / Modified
 - Prepped tests for supporting `qiskit>=2.0` ([#955](https://github.com/qBraid/qBraid/pull/955))
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,6 +64,7 @@ autodoc_mock_imports = [
     "flair_visual",
     "bloqade",
     "pandas",
+    "pyqpanda3",
 ]
 napoleon_numpy_docstring = False
 todo_include_todos = True

--- a/qbraid/programs/_import.py
+++ b/qbraid/programs/_import.py
@@ -110,6 +110,8 @@ def _get_class(module: str):
         return stim.Circuit  # type: ignore # noqa: F821
     if module == "pulser":
         return pulser.sequence.sequence.Sequence  # type: ignore # noqa: F821
+    if module == "pyqpanda3":  # pragma: no cover
+        return pyqpanda3.core.QProg  # type: ignore # noqa: F821
     raise ValueError(f"Unsupported module '{module}'")
 
 
@@ -131,7 +133,7 @@ dynamic_type_registry: dict[str, Type[Any]] = _dynamic_importer(
     ]
 )
 dynamic_non_native: dict[str, Type[Any]] = _dynamic_importer(
-    ["bloqade.analog.builder.assign", "qibo", "stim", "pyqir", "pulser"]
+    ["bloqade.analog.builder.assign", "qibo", "stim", "pyqir", "pulser", "pyqpanda3"]
 )
 static_type_registry: dict[str, Type[Any]] = {
     metatype.__alias__: metatype.__bound__ for metatype in BOUND_QBRAID_META_TYPES

--- a/qbraid/transpiler/conversions/qasm2/__init__.py
+++ b/qbraid/transpiler/conversions/qasm2/__init__.py
@@ -26,9 +26,12 @@ Functions
     qasm2_to_ionq
     qasm2_to_qibo
     qibo_to_qasm2
+    qasm2_to_pyqpanda3
+    pyqpanda3_to_qasm2
 
 """
-from .qasm2_extras import qasm2_to_qibo, qibo_to_qasm2
+
+from .qasm2_extras import pyqpanda3_to_qasm2, qasm2_to_pyqpanda3, qasm2_to_qibo, qibo_to_qasm2
 from .qasm2_to_cirq import qasm2_to_cirq
 from .qasm2_to_ionq import qasm2_to_ionq
 from .qasm2_to_pytket import qasm2_to_pytket
@@ -43,4 +46,6 @@ __all__ = [
     "qasm2_to_ionq",
     "qasm2_to_qibo",
     "qibo_to_qasm2",
+    "qasm2_to_pyqpanda3",
+    "pyqpanda3_to_qasm2",
 ]

--- a/qbraid/transpiler/conversions/qasm2/qasm2_extras.py
+++ b/qbraid/transpiler/conversions/qasm2/qasm2_extras.py
@@ -12,6 +12,7 @@
 Module containing OpenQASM 2 conversion extras.
 
 """
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -21,8 +22,10 @@ from qbraid_core._import import LazyLoader
 from qbraid.transpiler.annotations import requires_extras
 
 qibo = LazyLoader("qibo", globals(), "qibo")
+pyqpanda3 = LazyLoader("pyqpanda3", globals(), "pyqpanda3")
 
 if TYPE_CHECKING:
+    import pyqpanda3 as pyqpanda3_  # type: ignore
     import qibo as qibo_  # type: ignore
 
     from qbraid.programs.typer import Qasm2StringType
@@ -64,3 +67,29 @@ def qibo_to_qasm2(circuit: qibo_.Circuit) -> Qasm2StringType:
         OpenQASM 2 string equivalent to the input qibo.Circuit.
     """
     return circuit.to_qasm()
+
+
+@requires_extras("pyqpanda3")
+def qasm2_to_pyqpanda3(qasm: Qasm2StringType) -> pyqpanda3_.core.QProg:
+    """Returns a pyqpande3.core.QProg equivalent to the input OpenQASM 2 circuit.
+
+    Args:
+        qasm: OpenQASM 2 string to convert to a pyqpanda3.core.QProg
+
+    Returns:
+        pyqpanda3.core.QProg object equivalent to the input OpenQASM 2 string.
+    """
+    return pyqpanda3.intermediate_compiler.convert_qasm_string_to_qprog(qasm)
+
+
+@requires_extras("pyqpanda3")
+def pyqpanda3_to_qasm2(circuit: pyqpanda3_.core.QProg) -> Qasm2StringType:
+    """Returns an OpenQASM 2 string equivalent to the input pyqpanda3.core.QProg.
+
+    Args:
+        circuit: pyqpanda3.core.QProg object to convert to OpenQASM 2 string.
+
+    Returns:
+        OpenQASM 2 string equivalent to the input pyqpanda3.core.QProg.
+    """
+    return pyqpanda3.intermediate_compiler.convert_qprog_to_qasm(circuit)

--- a/qbraid/transpiler/converter.py
+++ b/qbraid/transpiler/converter.py
@@ -12,6 +12,7 @@
 Module for transpiling quantum programs between different quantum programming languages
 
 """
+
 from __future__ import annotations
 
 import warnings
@@ -22,9 +23,16 @@ from qbraid_core._import import LazyLoader
 
 from qbraid._logging import logger
 from qbraid.programs import QPROGRAM_ALIASES
-from qbraid.programs.alias_manager import _get_program_type_alias, get_program_type_alias
+from qbraid.programs.alias_manager import (
+    _get_program_type_alias,
+    get_program_type_alias,
+)
 
-from .exceptions import ConversionPathNotFoundError, NodeNotFoundError, ProgramConversionError
+from .exceptions import (
+    ConversionPathNotFoundError,
+    NodeNotFoundError,
+    ProgramConversionError,
+)
 from .graph import ConversionGraph, _get_path_from_bound_methods
 
 if TYPE_CHECKING:
@@ -112,7 +120,7 @@ def transpile(
         path_details = _get_path_from_bound_methods(path)
         try:
             temp_program = deepcopy(program)
-        except RecursionError as err:
+        except (RecursionError, TypeError) as err:
             logger.warning(
                 "Deepcopy failed due to a %s, likely caused by the internal structure of "
                 "the %s object. Continuing execution, but any subsequent errors during "

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,6 +18,7 @@ qiskit-qasm3-import>=0.5.1
 qiskit-aer>=0.15.0; python_version < "3.13"
 qiskit-qir
 qiskit-ionq>=0.5.12
+pyqpanda3>=0.2.0; python_version < "3.13"
 
 # optional runtime dependencies
 qiskit-ibm-runtime>=0.25.0,<0.39

--- a/tests/transpiler/qasm/test_conversions_pyqpanda3.py
+++ b/tests/transpiler/qasm/test_conversions_pyqpanda3.py
@@ -1,0 +1,96 @@
+# Copyright (C) 2024 qBraid
+#
+# This file is part of the qBraid-SDK
+#
+# The qBraid-SDK is free software released under the GNU General Public License v3
+# or later. You can redistribute and/or modify it under the terms of the GPL v3.
+# See the LICENSE file in the project root or <https://www.gnu.org/licenses/gpl-3.0.html>.
+#
+# THERE IS NO WARRANTY for the qBraid-SDK, as per Section 15 of the GPL v3.
+
+# pylint: disable=expression-not-assigned
+"""
+Unit tests for OpenQASM2 to pyqpanda3 transpilation.
+
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from qbraid import transpile
+from qbraid.interface import circuits_allclose
+
+pyqpanda3 = pytest.importorskip("pyqpanda3")
+
+
+def test_openqasm2_to_pyqpanda3():
+    """Test converting an OpenQASM2 program to a pyqpanda3 QProg"""
+
+    qasm2_str_in = """
+    OPENQASM 2.0;
+    include "stdgates.inc";
+    // comment
+    qubit[1] q;
+
+    h q[0];
+    x q[0];
+    y q[0];
+    """
+    qprog = transpile(qasm2_str_in, target="pyqpanda3")
+
+    expected = pyqpanda3.core.QProg()
+    expected << pyqpanda3.core.H(0) << pyqpanda3.core.X(0) << pyqpanda3.core.Y(0)
+
+    # pylint thinks .ndarray() has an extra argument, so disabling for the test
+    # pylint: disable=no-value-for-parameter
+    u_obs = pyqpanda3.quantum_info.Unitary(qprog.to_circuit()).ndarray()
+    u_expected = pyqpanda3.quantum_info.Unitary(expected.to_circuit()).ndarray()
+    assert np.allclose(u_obs, u_expected)
+
+
+# Skip test as pyqpanda3 generates qasm with a creg of size 0 even
+# though there are no classical bits in the circuit. pyqasm, which parses
+# this output for circuits_allclose, errors that creg size must be > 0.
+@pytest.mark.skip
+def test_pyqpanda3_to_openqasm2():
+    """Test converting a pyqpanda3 QProg to OpenQASM2"""
+
+    prog = pyqpanda3.core.QProg()
+    prog << pyqpanda3.core.RX(0, 3.1415926) << pyqpanda3.core.CNOT(0, 2)
+
+    expected = """
+    OPENQASM 2.0;
+    include "qelib1.inc";
+    qreg q[3];
+    rx(3.14159260) q[0];
+    cx q[0],q[2];
+    """
+
+    res = transpile(prog, target="qasm2")
+    assert circuits_allclose(res, expected)
+
+
+# Until the above is supported, compare the QASM strings directly
+def test_pyqpanda3_to_openqasm2_str_cmp():
+    """Test converting a pyqpanda3 QProg to OpenQASM2"""
+
+    prog = pyqpanda3.core.QProg()
+    prog << pyqpanda3.core.RX(0, 3.1415926) << pyqpanda3.core.CNOT(0, 2)
+
+    expected = """
+    OPENQASM 2.0;
+    include "qelib1.inc";
+    qreg q[3];
+    creg c[0];
+    rx(3.14159260) q[0];
+    cx q[0],q[2];
+    """
+
+    res = transpile(prog, target="qasm2")
+
+    # Normalize whitespace for comparison
+    res_normalized = "".join(res.split())
+    expected_normalized = "".join(expected.split())
+    assert res_normalized == expected_normalized


### PR DESCRIPTION
## Summary of changes
This PR adds support for transpiling between [`pyqpanda3`](https://qcloud.originqc.com.cn/document/qpanda-3/index.html) and QASM2.

The testing checking pyqpanda3 -> qasm2 is failing however, as pyqpanda3 is adding a `creg c[0];` to the QASM output, even though there are no classical bits involved in the circuit. The qasm2 parser that is testing for equivalence between two qasm 2 strings is raising an error that the `creg` size must be positive. 

Closes #961 

(TODO: Update changelog)