### PR TITLE
BYOT AWS `BraketProvider` changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,22 @@ result.data.get_counts()  # {'100110': 1}
 
 ### Improved / Modified
 - Prepped tests for supporting `qiskit>=2.0` ([#955](https://github.com/qBraid/qBraid/pull/955))
+- Updated the `qbraid.runtime.aws.BraketProvider` to include an `aws_session_token` during initialization. Users can now choose to supply their temporary AWS credentials instead of permanent account secrets to access AWS - ([#968](https://github.com/qBraid/qBraid/pull/968))
+
+```python
+from qbraid.runtime.aws import BraketProvider
+
+aws_access_key = "YOUR_TEMP_ACCESS_KEY"
+aws_secret_key = "YOUR_TEMP_SECRET_KEY"
+aws_session_token = "YOUR_CURRENT_SESSION_TOKEN"
+
+provider = BraketProvider(aws_access_key, aws_secret_key, aws_session_token)
+print(provider.get_devices())
+
+# [<qbraid.runtime.aws.device.BraketDevice('arn:aws:braket:us-west-1::device/qpu/rigetti/Ankaa-3')>,
+#  <qbraid.runtime.aws.device.BraketDevice('arn:aws:braket:us-east-1::device/qpu/quera/Aquila')>,
+#  ...]
+```
 
 ### Deprecated
 

--- a/qbraid/runtime/aws/provider.py
+++ b/qbraid/runtime/aws/provider.py
@@ -47,14 +47,17 @@ class BraketProvider(QuantumProvider):
     Attributes:
         aws_access_key_id (str): AWS access key ID for authenticating with AWS services.
         aws_secret_access_key (str): AWS secret access key for authenticating with AWS services.
+        aws_session_token (str): AWS session token for authenticating with AWS services when using
+            temporary credentials.
     """
 
     REGIONS = ("us-east-1", "us-west-1", "us-west-2", "eu-west-2")
 
     def __init__(
-        self, aws_access_key_id: Optional[str] = None, 
+        self,
+        aws_access_key_id: Optional[str] = None,
         aws_secret_access_key: Optional[str] = None,
-        aws_session_token: Optional[str] = None
+        aws_session_token: Optional[str] = None,
     ):
         """
         Initializes the QbraidProvider object with optional AWS credentials.
@@ -62,10 +65,11 @@ class BraketProvider(QuantumProvider):
         Args:
             aws_access_key_id (str, optional): AWS access key ID. Defaults to None.
             aws_secret_access_key (str, optional): AWS secret access token. Defaults to None.
+            aws_session_token (str, optional): AWS session token. Defaults to None.
         """
         self.aws_access_key_id = aws_access_key_id or os.getenv("AWS_ACCESS_KEY_ID")
         self.aws_secret_access_key = aws_secret_access_key or os.getenv("AWS_SECRET_ACCESS_KEY")
-        self.aws_session_token = aws_session_token or os.getenv("AWS_SESSION_TOKEN")
+        self.aws_session_token = aws_session_token
 
     def save_config(
         self,
@@ -248,6 +252,8 @@ class BraketProvider(QuantumProvider):
     def __hash__(self):
         if not hasattr(self, "_hash"):
             object.__setattr__(
-                self, "_hash", hash((self.aws_access_key_id, self.aws_secret_access_key))
+                self,
+                "_hash",
+                hash((self.aws_access_key_id, self.aws_secret_access_key, self.aws_session_token)),
             )
         return self._hash  # pylint: disable=no-member

--- a/qbraid/runtime/aws/provider.py
+++ b/qbraid/runtime/aws/provider.py
@@ -52,7 +52,9 @@ class BraketProvider(QuantumProvider):
     REGIONS = ("us-east-1", "us-west-1", "us-west-2", "eu-west-2")
 
     def __init__(
-        self, aws_access_key_id: Optional[str] = None, aws_secret_access_key: Optional[str] = None
+        self, aws_access_key_id: Optional[str] = None, 
+        aws_secret_access_key: Optional[str] = None,
+        aws_session_token: Optional[str] = None
     ):
         """
         Initializes the QbraidProvider object with optional AWS credentials.
@@ -63,6 +65,7 @@ class BraketProvider(QuantumProvider):
         """
         self.aws_access_key_id = aws_access_key_id or os.getenv("AWS_ACCESS_KEY_ID")
         self.aws_secret_access_key = aws_secret_access_key or os.getenv("AWS_SECRET_ACCESS_KEY")
+        self.aws_session_token = aws_session_token or os.getenv("AWS_SESSION_TOKEN")
 
     def save_config(
         self,
@@ -108,6 +111,7 @@ class BraketProvider(QuantumProvider):
             region_name=region_name,
             aws_access_key_id=self.aws_access_key_id,
             aws_secret_access_key=self.aws_secret_access_key,
+            aws_session_token=self.aws_session_token,
         )
         braket_client = boto_session.client("braket", region_name=region_name)
         return AwsSession(

--- a/tests/runtime/aws/test_braket_runtime.py
+++ b/tests/runtime/aws/test_braket_runtime.py
@@ -214,6 +214,18 @@ def test_provider_get_aws_session():
         assert isinstance(aws_session, AwsSession)
 
 
+def test_provider_get_aws_session_with_session_token():
+    """Test getting an AWS session with session token."""
+    with patch("boto3.session.Session") as mock_boto_session:
+        mock_boto_session.aws_access_key_id.return_value = "aws_access_key_id"
+        mock_boto_session.aws_secret_access_key.return_value = "aws_secret_access_key"
+        mock_boto_session.get_credentials.return_value.token = "session_token"
+        aws_session = BraketProvider(aws_session_token="session_token")._get_aws_session()
+        assert aws_session.boto_session.region_name == "us-east-1"
+        assert isinstance(aws_session, AwsSession)
+        assert aws_session.boto_session.get_credentials().token == "session_token"
+
+
 def test_provider_get_devices_raises(braket_provider):
     """Test raising device wrapper error due to invalid device ID."""
     with pytest.raises(ValueError):

--- a/tests/runtime/aws/test_braket_runtime.py
+++ b/tests/runtime/aws/test_braket_runtime.py
@@ -678,7 +678,9 @@ def test_get_tasks_by_tag_qbraid_error():
 def mock_braket_provider_with_credentials():
     """Return a BraketProvider instance with mock credentials."""
     aws_provider = BraketProvider(
-        aws_access_key_id="mock_access_key_id", aws_secret_access_key="mock_secret_access_key"
+        aws_access_key_id="mock_access_key_id",
+        aws_secret_access_key="mock_secret_access_key",
+        aws_session_token="mock_session_token",
     )
     return aws_provider
 
@@ -689,7 +691,9 @@ def test_hash_method_creates_and_returns_hash(mock_hash, mock_braket_provider_wi
     mock_hash.return_value = 5555
     provider_instance = mock_braket_provider_with_credentials
     result = provider_instance.__hash__()  # pylint:disable=unnecessary-dunder-call
-    mock_hash.assert_called_once_with(("mock_access_key_id", "mock_secret_access_key"))
+    mock_hash.assert_called_once_with(
+        ("mock_access_key_id", "mock_secret_access_key", "mock_session_token")
+    )
     assert result == 5555
     assert provider_instance._hash == 5555
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->
Reference PR : [#1098 | api ](https://github.com/qBraid/api/pull/1098)

## Summary of changes

* Added support for `aws_session_token` in the `BraketProvider` class (`qbraid/runtime/aws/provider.py`)
* Updated the `_get_aws_session` method to include the `aws_session_token` parameter when creating an AWS session. (`qbraid/runtime/aws/provider.py`)
* Modified the `__hash__` method of `BraketProvider` to include `aws_session_token` in the hash computation, ensuring unique identification for instances with different session tokens. (`qbraid/runtime/aws/provider.py`)
