### PR TITLE
cudaq qir serialization + plt counts import fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ Types of changes:
 ## [Unreleased]
 
 ### Added
+- Added `CudaQKernel.serialize` method that converts cudaq program to QIR string for `run_input` compatible format for `QbraidDevice.submit`. ([#972](https://github.com/qBraid/qBraid/pull/972))
+
+### Improved / Modified
+
+### Deprecated
+
+### Removed
+
+### Fixed
+- Fixed lazy importing bug in `plot_histogram` method ([#972](https://github.com/qBraid/qBraid/pull/972))
+
+### Dependencies
+
+## [0.9.6] - 2025-05-02
+
+### Added
 - Added `QbraidJob.async_result()` to support async result retrieval using `await`. ([#945](https://github.com/qBraid/qBraid/pull/945))
 - Added `QbraidDevice.set_target_program_type`, allowing you to set a specific `ProgramSpec` (from `TargetProfile`) alias as the default ([#952](https://github.com/qBraid/qBraid/pull/952)). For example, if a device supports both "qasm2" and "qasm3", you can now restrict transpilation to one format:
 
@@ -89,8 +105,6 @@ result.data.get_counts()  # {'100110': 1}
 
 - Added support for transpiling between [pyqpanda3](https://pyqpanda-toturial.readthedocs.io/) and QASM2 with `pyqpanda3` program type ([#963](https://github.com/qBraid/qBraid/pull/963))
 
-
-
 ### Improved / Modified
 - Prepped tests for supporting `qiskit>=2.0` ([#955](https://github.com/qBraid/qBraid/pull/955))
 - Updated the `qbraid.runtime.aws.BraketProvider` to include an `aws_session_token` during initialization. Users can now choose to supply their temporary AWS credentials instead of permanent account secrets to access AWS - ([#968](https://github.com/qBraid/qBraid/pull/968))
@@ -109,8 +123,6 @@ print(provider.get_devices())
 #  <qbraid.runtime.aws.device.BraketDevice('arn:aws:braket:us-east-1::device/qpu/quera/Aquila')>,
 #  ...]
 ```
-
-### Deprecated
 
 ### Removed
 - Removed the `strict=False` parameter from the `pydantic_core.core_schema.union_schema()` calls in the `__get_pydantic_core_schema__` method(s) in `qbraid.runtime.schemas.base`. `strict` parameter no longer included in the `pydantic-core` API for that method as of release [v0.2.30](https://github.com/pydantic/pydantic-core/releases/tag/v2.30.0), PR [#1638](https://github.com/pydantic/pydantic-core/pull/1638). ([#946](https://github.com/qBraid/qBraid/pull/946))

--- a/qbraid/_version.py
+++ b/qbraid/_version.py
@@ -15,4 +15,4 @@ Version number (major.minor.patch[-label])
 
 """
 
-__version__ = "0.9.6.dev"
+__version__ = "0.9.7.dev"

--- a/qbraid/programs/gate_model/cudaq.py
+++ b/qbraid/programs/gate_model/cudaq.py
@@ -14,6 +14,8 @@ Module defining CudaQKernel Class
 """
 from __future__ import annotations
 
+import base64
+
 import cudaq
 
 from qbraid.programs.exceptions import ProgramTypeError
@@ -46,3 +48,8 @@ class CudaQKernel(GateModelProgram):
     def num_clbits(self) -> int:
         """Return the number of classical bits in the circuit."""
         return 0
+
+    def serialize(self) -> dict[str, str]:
+        """Return the program in a format suitable for submission to the qBraid API."""
+        qir: str = cudaq.translate(self.program, format="qir-base")
+        return {"qir": base64.b64encode(qir.encode("utf-8")).decode("utf-8")}

--- a/qbraid/runtime/native/provider.py
+++ b/qbraid/runtime/native/provider.py
@@ -14,6 +14,7 @@ Module defining QbraidProvider class.
 """
 from __future__ import annotations
 
+import base64
 import warnings
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
@@ -45,8 +46,11 @@ def _serialize_program(program) -> dict[str, str]:
     return qbraid_program.serialize()
 
 
-def _serialize_pyqir(program: pyqir.Module) -> dict[str, bytes]:
-    return {"bitcode": program.bitcode}
+def _serialize_pyqir(program: pyqir.Module) -> dict[str, bytes | str]:
+    return {
+        "bitcode": program.bitcode,
+        "qir": base64.b64encode(str(program).encode("utf-8")).decode("utf-8"),
+    }
 
 
 def _serialize_sequence(sequence: pulser.Sequence) -> dict[str, str]:

--- a/qbraid/runtime/native/provider.py
+++ b/qbraid/runtime/native/provider.py
@@ -14,7 +14,6 @@ Module defining QbraidProvider class.
 """
 from __future__ import annotations
 
-import base64
 import warnings
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
@@ -46,11 +45,8 @@ def _serialize_program(program) -> dict[str, str]:
     return qbraid_program.serialize()
 
 
-def _serialize_pyqir(program: pyqir.Module) -> dict[str, bytes | str]:
-    return {
-        "bitcode": program.bitcode,
-        "qir": base64.b64encode(str(program).encode("utf-8")).decode("utf-8"),
-    }
+def _serialize_pyqir(program: pyqir.Module) -> dict[str, bytes]:
+    return {"bitcode": program.bitcode}
 
 
 def _serialize_sequence(sequence: pulser.Sequence) -> dict[str, str]:

--- a/qbraid/visualization/plot_counts.py
+++ b/qbraid/visualization/plot_counts.py
@@ -18,7 +18,6 @@ from typing import Callable, Optional, Union
 from qbraid_core._import import LazyLoader
 
 plt = LazyLoader("plt", globals(), "matplotlib.pyplot")
-matplotlib = LazyLoader("matplotlib", globals(), "matplotlib")
 
 # pylint: disable=too-many-arguments,unnecessary-lambda
 
@@ -87,7 +86,7 @@ def _plot_data(
     x_positions = range(len(all_states))
 
     if colors is None:
-        cmap = matplotlib.pyplot.get_cmap("tab10")
+        cmap = plt.get_cmap("tab10")
         colors = [cmap(i / 10) for i in range(num_dicts)]
 
     if len(colors) != len(counts):

--- a/tests/fixtures/qir/bell.ll
+++ b/tests/fixtures/qir/bell.ll
@@ -1,0 +1,33 @@
+; ModuleID = 'LLVMDialectModule'
+source_filename = "LLVMDialectModule"
+
+%Qubit = type opaque
+%Result = type opaque
+
+@cstr.72303030303000 = private constant [7 x i8] c"r00000\00"
+@cstr.72303030303100 = private constant [7 x i8] c"r00001\00"
+
+define void @__nvqpp__mlirgen____nvqppBuilderKernel_JIG28W9O6V() local_unnamed_addr #0 {
+  tail call void @__quantum__qis__h__body(%Qubit* null)
+  tail call void @__quantum__qis__cnot__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+  tail call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
+  tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* nonnull inttoptr (i64 1 to %Result*))
+  tail call void @__quantum__rt__result_record_output(%Result* null, i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @cstr.72303030303000, i64 0, i64 0))
+  tail call void @__quantum__rt__result_record_output(%Result* nonnull inttoptr (i64 1 to %Result*), i8* nonnull getelementptr inbounds ([7 x i8], [7 x i8]* @cstr.72303030303100, i64 0, i64 0))
+  ret void
+}
+
+declare void @__quantum__qis__h__body(%Qubit*) local_unnamed_addr
+
+declare void @__quantum__qis__mz__body(%Qubit*, %Result*) local_unnamed_addr #1
+
+declare void @__quantum__rt__result_record_output(%Result*, i8*) local_unnamed_addr
+
+declare void @__quantum__qis__cnot__body(%Qubit*, %Qubit*) local_unnamed_addr
+
+attributes #0 = { "entry_point" "output_labeling_schema"="schema_id" "output_names"="[[[0,[0,\22r00000\22]],[1,[1,\22r00001\22]]]]" "qir_profiles"="base_profile" "requiredQubits"="2" "requiredResults"="2" }
+attributes #1 = { "irreversible" }
+
+!llvm.module.flags = !{!0}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}

--- a/tests/programs/test_program_cudaq.py
+++ b/tests/programs/test_program_cudaq.py
@@ -15,6 +15,7 @@ Tests for the CUDAQ program type.
 
 import base64
 import pathlib
+import re
 
 import pytest
 
@@ -86,4 +87,10 @@ def test_cudaq_program_serialize():
     with open(fixture_path, "r", encoding="utf-8") as file:
         expected_qir = file.read()
 
-    assert expected_qir == decoded_qir
+    def _normalize_qir(qir: str) -> str:
+        return re.sub(r"derKernel_[A-Z0-9]+\(\)", "derKernel_PLACEHOLDER()", qir)
+
+    normalized_expected_qir = _normalize_qir(expected_qir)
+    normalized_decoded_qir = _normalize_qir(decoded_qir)
+
+    assert normalized_expected_qir == normalized_decoded_qir


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

- Add `CudaQKernel.serialize` method that converts cudaq program to QIR string for `run_input` compatible format for `QbraidDevice.submit`.
- Fixed lazy importing bug in `plot_histogram` method