### PR TITLE
fix braket cirq lazy import bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Types of changes:
 
 ### Fixed
 - Fixed lazy importing bug in `plot_histogram` method ([#972](https://github.com/qBraid/qBraid/pull/972))
+- Fixed bug which caused all `braket` conversions to be unavailable if `cirq` was not installed due to an eager top-level import in `braket_to_cirq.py` which should have been done lazily ([#982](https://github.com/qBraid/qBraid/pull/982))
 
 ### Dependencies
 - Migrated to `setuptools>=77` due to TOML-table based `project.license` deprecation in favor of SPDX expression in compliance with [PEP 639](https://peps.python.org/pep-0639) ([#973](https://github.com/qBraid/qBraid/pull/973))

--- a/qbraid/transpiler/conversions/braket/braket_to_cirq.py
+++ b/qbraid/transpiler/conversions/braket/braket_to_cirq.py
@@ -37,7 +37,6 @@ try:
 except ImportError:  # pragma: no cover
     cirq_ionq_ops = None
 
-from qbraid.programs.gate_model.cirq import CirqCircuit as QbraidCircuit
 from qbraid.transpiler.annotations import weight
 from qbraid.transpiler.exceptions import ProgramConversionError
 
@@ -85,6 +84,9 @@ def braket_to_cirq(circuit: BKCircuit) -> cirq_circuits.Circuit:
     Returns:
         Cirq circuit equivalent to the input Braket circuit.
     """
+    # pylint: disable-next=import-outside-toplevel
+    from qbraid.programs.gate_model.cirq import CirqCircuit as QbraidCircuit
+
     bk_qubits = [int(q) for q in circuit.qubits]
     cirq_qubits = [cirq.LineQubit(x) for x in bk_qubits]
     qubit_mapping = {q: cirq_qubits[i] for i, q in enumerate(bk_qubits)}


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

- Fix bug which caused all braket conversions to be unavailable if cirq was not installed due to top-level cirq import in `braket_to_cirq.py` which should have been done lazily. 
