### PR TITLE
Queue position, timestamps, pulser versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,14 +19,18 @@ Types of changes:
 - Added `CudaQKernel.serialize` method that converts cudaq program to QIR string for `run_input` compatible format for `QbraidDevice.submit`. ([#972](https://github.com/qBraid/qBraid/pull/972))
 
 ### Improved / Modified
+- Updated `TimeStamps` schema to auto-compute `executionDuration` from `createdAt` and `endedAt` if not explicitly provided. ([#983](https://github.com/qBraid/qBraid/pull/983))
+- Enhanced `TimeStamps` to accept both `datetime.datetime` objects for `createdAt` and `endedAt` (previously only accepted ISO-formatted strings). ([#983](https://github.com/qBraid/qBraid/pull/983))
 
 ### Deprecated
 
 ### Removed
+- Removed `queue_position` from result details, as it is always `None` and not applicable. ([#983](https://github.com/qBraid/qBraid/pull/983))
 
 ### Fixed
 - Fixed lazy importing bug in `plot_histogram` method ([#972](https://github.com/qBraid/qBraid/pull/972))
 - Fixed bug which caused all `braket` conversions to be unavailable if `cirq` was not installed due to an eager top-level import in `braket_to_cirq.py` which should have been done lazily ([#982](https://github.com/qBraid/qBraid/pull/982))
+- Made Pulser unit test version-agnostic to support any installed Pulser version. ([#983](https://github.com/qBraid/qBraid/pull/983))
 
 ### Dependencies
 - Migrated to `setuptools>=77` due to TOML-table based `project.license` deprecation in favor of SPDX expression in compliance with [PEP 639](https://peps.python.org/pep-0639) ([#973](https://github.com/qBraid/qBraid/pull/973))

--- a/qbraid/runtime/native/job.py
+++ b/qbraid/runtime/native/job.py
@@ -150,7 +150,9 @@ class QbraidJob(QuantumJob):
             else {"measurement_counts", "measurements"}
         )
         metadata_dump = model.metadata.model_dump(by_alias=True, exclude=exclude)
-        model_dump = model.model_dump(by_alias=True, exclude={"job_id", "device_id", "metadata"})
+        model_dump = model.model_dump(
+            by_alias=True, exclude={"job_id", "device_id", "metadata", "queue_position"}
+        )
         experiment_type: ExperimentType = model_dump["experimentType"]
         status_text = (
             model.status_text or model.status.status_message or model.status.default_message

--- a/tests/runtime/azure/test_azure_runtime.py
+++ b/tests/runtime/azure/test_azure_runtime.py
@@ -16,6 +16,7 @@ Unit tests for the Azure Quantum runtime module.
 """
 import json
 import os
+import re
 from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
@@ -1439,6 +1440,12 @@ def test_serialize_pulser_input():
     pulser_input = serialize_pulser_input(sequence)
 
     expected_input = '{"sequence_builder": {"version": "1", "name": "pulser-exported", "register": [{"name": "q0", "x": 0.0, "y": 0.0}], "channels": {}, "variables": {}, "operations": [], "measurement": null, "device": {"name": "AnalogDevice", "dimensions": 2, "rydberg_level": 60, "min_atom_distance": 5, "max_atom_num": 80, "max_radial_distance": 38, "interaction_coeff_xy": null, "supports_slm_mask": false, "max_layout_filling": 0.5, "optimal_layout_filling": 0.45, "max_sequence_duration": 6000, "max_runs": 2000, "reusable_channels": false, "pre_calibrated_layouts": [{"coordinates": [[-20.0, 0.0], [-17.5, -4.330127], [-17.5, 4.330127], [-15.0, -8.660254], [-15.0, 0.0], [-15.0, 8.660254], [-12.5, -12.990381], [-12.5, -4.330127], [-12.5, 4.330127], [-12.5, 12.990381], [-10.0, -17.320508], [-10.0, -8.660254], [-10.0, 0.0], [-10.0, 8.660254], [-10.0, 17.320508], [-7.5, -12.990381], [-7.5, -4.330127], [-7.5, 4.330127], [-7.5, 12.990381], [-5.0, -17.320508], [-5.0, -8.660254], [-5.0, 0.0], [-5.0, 8.660254], [-5.0, 17.320508], [-2.5, -12.990381], [-2.5, -4.330127], [-2.5, 4.330127], [-2.5, 12.990381], [0.0, -17.320508], [0.0, -8.660254], [0.0, 0.0], [0.0, 8.660254], [0.0, 17.320508], [2.5, -12.990381], [2.5, -4.330127], [2.5, 4.330127], [2.5, 12.990381], [5.0, -17.320508], [5.0, -8.660254], [5.0, 0.0], [5.0, 8.660254], [5.0, 17.320508], [7.5, -12.990381], [7.5, -4.330127], [7.5, 4.330127], [7.5, 12.990381], [10.0, -17.320508], [10.0, -8.660254], [10.0, 0.0], [10.0, 8.660254], [10.0, 17.320508], [12.5, -12.990381], [12.5, -4.330127], [12.5, 4.330127], [12.5, 12.990381], [15.0, -8.660254], [15.0, 0.0], [15.0, 8.660254], [17.5, -4.330127], [17.5, 4.330127], [20.0, 0.0]], "slug": "TriangularLatticeLayout(61, 5.0\\u00b5m)"}], "version": "1", "pulser_version": "1.4.0", "channels": [{"id": "rydberg_global", "basis": "ground-rydberg", "addressing": "Global", "max_abs_detuning": 125.66370614359172, "max_amp": 12.566370614359172, "min_retarget_interval": null, "fixed_retarget_t": null, "max_targets": null, "clock_period": 4, "min_duration": 16, "max_duration": 100000000, "mod_bandwidth": 8, "eom_config": {"limiting_beam": "RED", "max_limiting_amp": 188.49555921538757, "intermediate_detuning": 2827.4333882308138, "controlled_beams": ["BLUE"], "mod_bandwidth": 40, "custom_buffer_time": 240}}], "is_virtual": false}}}'
+
+    expected_input = re.sub(
+        r'"pulser_version"\s*:\s*"\d+\.\d+\.\d+"',
+        f'"pulser_version": "{pulser.__version__}"',
+        expected_input,
+    )
 
     assert pulser_input == expected_input
 

--- a/tests/runtime/test_schemas.py
+++ b/tests/runtime/test_schemas.py
@@ -143,6 +143,28 @@ def test_timestamps():
         )  # Invalid executionDuration
 
 
+def test_execution_duration_auto_calculation():
+    """Test execution duration auto-calculation."""
+    created = datetime(2025, 5, 22, 15, 8, 57)
+    ended = datetime(2025, 5, 22, 15, 8, 58)
+    ts = TimeStamps(createdAt=created, endedAt=ended)
+    assert ts.executionDuration == 1000  # 1 second in milliseconds
+
+
+def test_execution_duration_none_if_endedAt_missing():
+    """Test execution duration is None if endedAt is missing."""
+    created = datetime(2025, 5, 22, 15, 8, 57)
+    ts = TimeStamps(createdAt=created)
+    assert ts.executionDuration is None  # Not enough data to compute
+
+
+def test_execution_duration_zero_if_same_time():
+    """Test execution duration is zero if createdAt and endedAt are the same."""
+    t = datetime(2025, 5, 22, 15, 8, 57)
+    ts = TimeStamps(createdAt=t, endedAt=t)
+    assert ts.executionDuration == 0
+
+
 def test_runtime_job_model(mock_job_data):
     """Test RuntimeJobModel class."""
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

- Removed `queue_position` from result details, as it is always `None` and not applicable.
- Updated `TimeStamps` schema to auto-compute `executionDuration` from `createdAt` and `endedAt` if not explicitly provided.
- Enhanced `TimeStamps` to accept both `datetime.datetime` objects for `createdAt` and `endedAt` (previously only accepted ISO-formatted strings).
- Made Pulser unit test version-agnostic to support any installed Pulser version.
