### PR TITLE
Circumvent constructing unregistered program type nodes in `ConversionGraph`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Types of changes:
 - Fixed lazy importing bug in `plot_histogram` method ([#972](https://github.com/qBraid/qBraid/pull/972))
 - Fixed bug which caused all `braket` conversions to be unavailable if `cirq` was not installed due to an eager top-level import in `braket_to_cirq.py` which should have been done lazily ([#982](https://github.com/qBraid/qBraid/pull/982))
 - Made Pulser unit test version-agnostic to support any installed Pulser version. ([#983](https://github.com/qBraid/qBraid/pull/983))
+- Fixed the bug that included unregistered program type in `ConversionGraph`. ([#986](SaashaJoshi:unregister))
 
 ### Dependencies
 - Migrated to `setuptools>=77` due to TOML-table based `project.license` deprecation in favor of SPDX expression in compliance with [PEP 639](https://peps.python.org/pep-0639) ([#973](https://github.com/qBraid/qBraid/pull/973))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Types of changes:
 - Fixed lazy importing bug in `plot_histogram` method ([#972](https://github.com/qBraid/qBraid/pull/972))
 - Fixed bug which caused all `braket` conversions to be unavailable if `cirq` was not installed due to an eager top-level import in `braket_to_cirq.py` which should have been done lazily ([#982](https://github.com/qBraid/qBraid/pull/982))
 - Made Pulser unit test version-agnostic to support any installed Pulser version. ([#983](https://github.com/qBraid/qBraid/pull/983))
-- Fixed the bug that included unregistered program type in `ConversionGraph`. ([#986](SaashaJoshi:unregister))
+- Fixed the bug that included unregistered program type in `ConversionGraph`. ([#986](https://github.com/qBraid/qBraid/pull/986))
 
 ### Dependencies
 - Migrated to `setuptools>=77` due to TOML-table based `project.license` deprecation in favor of SPDX expression in compliance with [PEP 639](https://peps.python.org/pep-0639) ([#973](https://github.com/qBraid/qBraid/pull/973))

--- a/qbraid/transpiler/graph.py
+++ b/qbraid/transpiler/graph.py
@@ -138,19 +138,19 @@ class ConversionGraph(rx.PyDiGraph):
         """
         transpiler = import_module("qbraid.transpiler.conversions")
         conversion_functions: list[str] = getattr(transpiler, "conversion_functions", [])
-        conversion_functions = [conversion.split("_to_") for conversion in conversion_functions]
-        conversion_functions = [
+        conversion_pairs: list[list[str, str]] = [conversion.split("_to_") for conversion in conversion_functions]
+        registered_conversion_pairs: list[list[str, str]] = [
             [source, target]
-            for source, target in conversion_functions
+            for source, target in conversion_pairs
             if source in QPROGRAM_ALIASES and target in QPROGRAM_ALIASES
         ]
 
-        def construct_conversion(name: str) -> Conversion:
+        def construct_conversion(name: list[str, str]) -> Conversion:
             source, target = name
             conversion_func = getattr(transpiler, f"{source}_to_{target}")
             return Conversion(source, target, conversion_func, bias=bias)
 
-        return [construct_conversion(conversion) for conversion in conversion_functions]
+        return [construct_conversion(conversion) for conversion in registered_conversion_pairs]
 
     def create_conversion_graph(self) -> None:
         """Create a directed graph from a list of conversion functions."""

--- a/qbraid/transpiler/graph.py
+++ b/qbraid/transpiler/graph.py
@@ -138,7 +138,9 @@ class ConversionGraph(rx.PyDiGraph):
         """
         transpiler = import_module("qbraid.transpiler.conversions")
         conversion_functions: list[str] = getattr(transpiler, "conversion_functions", [])
-        conversion_pairs: list[list[str, str]] = [conversion.split("_to_") for conversion in conversion_functions]
+        conversion_pairs: list[list[str, str]] = [
+            conversion.split("_to_") for conversion in conversion_functions
+        ]
         registered_conversion_pairs: list[list[str, str]] = [
             [source, target]
             for source, target in conversion_pairs

--- a/qbraid/transpiler/graph.py
+++ b/qbraid/transpiler/graph.py
@@ -138,10 +138,16 @@ class ConversionGraph(rx.PyDiGraph):
         """
         transpiler = import_module("qbraid.transpiler.conversions")
         conversion_functions: list[str] = getattr(transpiler, "conversion_functions", [])
+        conversion_functions = [conversion.split("_to_") for conversion in conversion_functions]
+        conversion_functions = [
+            [source, target]
+            for source, target in conversion_functions
+            if source in QPROGRAM_ALIASES and target in QPROGRAM_ALIASES
+        ]
 
         def construct_conversion(name: str) -> Conversion:
-            source, target = name.split("_to_")
-            conversion_func = getattr(transpiler, name)
+            source, target = name
+            conversion_func = getattr(transpiler, f"{source}_to_{target}")
             return Conversion(source, target, conversion_func, bias=bias)
 
         return [construct_conversion(conversion) for conversion in conversion_functions]

--- a/tests/transpiler/test_conversion_graph.py
+++ b/tests/transpiler/test_conversion_graph.py
@@ -194,6 +194,7 @@ def test_copy_conversion_graph():
     assert require_native_init == copy.require_native
     assert node_alias_id_map_init == copy._node_alias_id_map
 
+
 @pytest.mark.parametrize("program_type", ["qasm2", "qasm3", "pyquil", "braket", "cirq"])
 def test_unregistered_node_in_conversion_graph(program_type):
     """Test the unregistered nodes in ConversionGraph"""
@@ -214,6 +215,7 @@ def test_unregistered_node_in_conversion_graph(program_type):
     QPROGRAM_ALIASES.update(aliases_backup)
     QPROGRAM_REGISTRY.clear()
     QPROGRAM_REGISTRY.update(registry_backup)
+
 
 def test_get_path_from_bound_method():
     """Test formatted conversion path logging helper function."""

--- a/tests/transpiler/test_conversion_graph.py
+++ b/tests/transpiler/test_conversion_graph.py
@@ -198,7 +198,9 @@ def test_copy_conversion_graph():
 @pytest.mark.parametrize("program_type", ["qasm2", "qasm3", "pyquil", "braket", "cirq"])
 def test_unregistered_node_in_conversion_graph(program_type):
     """Test the unregistered nodes in ConversionGraph"""
-    assert program_type in QPROGRAM_ALIASES
+    if program_type not in QPROGRAM_ALIASES:
+        pytest.skip(f"{program_type} not installed")
+
     graph = ConversionGraph()
     assert graph.has_node(program_type) is True
 

--- a/tests/transpiler/test_conversion_graph.py
+++ b/tests/transpiler/test_conversion_graph.py
@@ -28,11 +28,11 @@ try:
 except ImportError:
     pyqir_installed = False
 
-from qbraid.programs import ExperimentType, register_program_type
+from qbraid.programs import ExperimentType, register_program_type, unregister_program_type
 from qbraid.programs.ahs import submodules as ahs_submodules
 from qbraid.programs.annealing import submodules as annealing_submodules
 from qbraid.programs.gate_model import submodules as gate_model_submodules
-from qbraid.programs.registry import QPROGRAM_ALIASES
+from qbraid.programs.registry import QPROGRAM_ALIASES, QPROGRAM_REGISTRY
 from qbraid.transpiler.conversions import conversion_functions
 from qbraid.transpiler.conversions.qiskit import qiskit_to_pyqir
 from qbraid.transpiler.converter import transpile
@@ -194,6 +194,26 @@ def test_copy_conversion_graph():
     assert require_native_init == copy.require_native
     assert node_alias_id_map_init == copy._node_alias_id_map
 
+@pytest.mark.parametrize("program_type", ["qasm2", "qasm3", "pyquil", "braket", "cirq"])
+def test_unregistered_node_in_conversion_graph(program_type):
+    """Test the unregistered nodes in ConversionGraph"""
+    assert program_type in QPROGRAM_ALIASES
+    graph = ConversionGraph()
+    assert graph.has_node(program_type) is True
+
+    # Backup QPROGRAM registry
+    aliases_backup = QPROGRAM_ALIASES.copy()
+    registry_backup = QPROGRAM_REGISTRY.copy()
+    unregister_program_type(program_type)
+
+    new_graph = ConversionGraph()
+    assert new_graph.has_node(program_type) is False
+
+    # Revert changes.
+    QPROGRAM_ALIASES.clear()
+    QPROGRAM_ALIASES.update(aliases_backup)
+    QPROGRAM_REGISTRY.clear()
+    QPROGRAM_REGISTRY.update(registry_backup)
 
 def test_get_path_from_bound_method():
     """Test formatted conversion path logging helper function."""


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

Okay, so I could figure out that the main error comes from loading the default conversions in this line,
https://github.com/qBraid/qBraid/blob/d3f6614b5ea3c58fe0fe1a0a79be68638673e26c/qbraid/transpiler/graph.py#L132-L147

This PR makes changes to only consider `source` and `target` in `conversion_functions` that are present/registered in `QPROGRAM_ALIASES`, hence solving the bug mentioned in #789. 

Closes #789. 
