### PR TITLE
Add measurement_probabilties argument to GateModelResultData class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Types of changes:
 ### Improved / Modified
 - Updated `TimeStamps` schema to auto-compute `executionDuration` from `createdAt` and `endedAt` if not explicitly provided. ([#983](https://github.com/qBraid/qBraid/pull/983))
 - Enhanced `TimeStamps` to accept both `datetime.datetime` objects for `createdAt` and `endedAt` (previously only accepted ISO-formatted strings). ([#983](https://github.com/qBraid/qBraid/pull/983))
+- Added a `measurement_probabilties` argument to the `GateModelResultData` class. ([#785](https://github.com/qBraid/qBraid/issues/785))
 
 ### Deprecated
 

--- a/qbraid/runtime/azure/result_builder.py
+++ b/qbraid/runtime/azure/result_builder.py
@@ -31,7 +31,7 @@ import numpy as np
 from azure.quantum import Job
 
 from qbraid.runtime.ionq.job import IonQJob
-from qbraid.runtime.postprocess import counts_to_probabilities, normalize_counts
+from qbraid.runtime.postprocess import counts_to_probabilities, normalize_data
 
 from .io_format import OutputDataFormat
 
@@ -136,7 +136,7 @@ class AzureResultBuilder:
         }
 
         raw_counts = IonQJob._get_counts(data)
-        counts = normalize_counts(raw_counts)
+        counts = normalize_data(raw_counts)
         probabilities = counts_to_probabilities(counts)
 
         return {"counts": counts, "probabilities": probabilities}
@@ -231,7 +231,7 @@ class AzureResultBuilder:
 
         """
         histogram = self.job.get_results()
-        counts = normalize_counts(histogram)
+        counts = normalize_data(histogram)
         probabilities = counts_to_probabilities(counts)
         return {"counts": histogram, "probabilities": probabilities}
 

--- a/qbraid/runtime/ionq/job.py
+++ b/qbraid/runtime/ionq/job.py
@@ -23,7 +23,7 @@ from qbraid_core._import import LazyLoader
 from qbraid.runtime.enums import JobStatus
 from qbraid.runtime.exceptions import QbraidRuntimeError
 from qbraid.runtime.job import QuantumJob
-from qbraid.runtime.postprocess import distribute_counts, normalize_counts
+from qbraid.runtime.postprocess import distribute_counts, normalize_data
 from qbraid.runtime.result import Result
 from qbraid.runtime.result_data import GateModelResultData, MeasCount, MeasProb
 
@@ -96,7 +96,7 @@ class IonQJob(QuantumJob):
         def convert_to_counts(meas_prob: dict[str, float]) -> dict[str, int]:
             """Helper function to normalize probabilities and convert to counts."""
             probs_dec = {int(key): value for key, value in meas_prob.items()}
-            probs_normal = normalize_counts(probs_dec)
+            probs_normal = normalize_data(probs_dec)
             return distribute_counts(probs_normal, shots)
 
         if all(isinstance(value, dict) for value in probabilities.values()):

--- a/qbraid/runtime/postprocess.py
+++ b/qbraid/runtime/postprocess.py
@@ -76,8 +76,8 @@ def normalize_bit_lengths(measurement: dict[str, int]) -> dict[str, int]:
     return normalized_list[0] if normalized_list else measurement
 
 
-def format_counts(
-    counts: dict[Any, Union[int, float]],
+def format_data(
+    data: dict[Any, Union[int, float]],
     include_zero_values: bool = False,
     decimal: bool = False,
 ) -> dict[Any, Union[int, float]]:
@@ -85,7 +85,7 @@ def format_counts(
     Formats and sorts a counts dictionary with binary or integer keys.
 
     Args:
-        counts (dict[Any, Union[int, float]]): Dictionary with keys as binary strings
+        data (dict[Any, Union[int, float]]): Dictionary with keys as binary strings
             (e.g., '0 1') or integers (e.g., 3), and values as counts.
         include_zero_values (bool, optional): Include missing states with zero counts.
             Defaults to False.
@@ -99,83 +99,83 @@ def format_counts(
 
     Examples:
         Basic formatting with binary keys:
-        >>> counts = {'1 1': 13, '0 0': 46, '1 0': 79}
-        >>> format_counts(counts)
+        >>> data = {'1 1': 13, '0 0': 46, '1 0': 79}
+        >>> format_data(data)
         {'00': 46, '10': 79, '11': 13}
 
         Include zero values:
-        >>> format_counts(counts, include_zero_values=True)
+        >>> format_data(data,include_zero_values=True)
         {'00': 46, '01': 0, '10': 79, '11': 13}
 
         Convert binary keys to decimal:
-        >>> format_counts(counts, decimal=True)
+        >>> format_data(data,decimal=True)
         {0: 46, 1: 0, 2: 79, 3: 13}
     """
-    if not counts:
-        return counts
+    if not data:
+        return data
 
     input_is_dec = False
     input_is_bin = False
 
-    if all(isinstance(key, str) for key in counts.keys()):
+    if all(isinstance(key, str) for key in data.keys()):
         if all(
             (key.startswith("0b") and set(key[2:]).issubset({"0", "1", " "}))
             or set(key).issubset({"0", "1", " "})
-            for key in counts.keys()
+            for key in data.keys()
         ):
-            key_str_counts = {
+            key_str_data = {
                 (key.replace(" ", "")[2:] if key.startswith("0b") else key.replace(" ", "")): value
-                for key, value in counts.items()
+                for key, value in data.items()
             }
-            normalized_counts = normalize_bit_lengths(key_str_counts)
-            num_bits = max(len(key) for key in normalized_counts)
+            normalized_data = normalize_bit_lengths(key_str_data)
+            num_bits = max(len(key) for key in normalized_data)
             all_keys = [format(i, f"0{num_bits}b") for i in range(2**num_bits)]
-            counts = {key: normalized_counts.get(key, 0) for key in all_keys}
+            data = {key: normalized_data.get(key, 0) for key in all_keys}
             input_is_bin = True
-        elif all(key.isdigit() for key in counts.keys()):
-            counts = {int(key): value for key, value in counts.items()}
+        elif all(key.isdigit() for key in data.keys()):
+            data = {int(key): value for key, value in data.items()}
             input_is_dec = True
 
     if decimal:
         if input_is_bin:
-            counts = {int(key, 2): value for key, value in counts.items()}
+            data = {int(key, 2): value for key, value in data.items()}
         elif input_is_dec:
-            counts = {int(key): value for key, value in counts.items()}
+            data = {int(key): value for key, value in data.items()}
 
         if include_zero_values:
-            max_key = max(counts)
+            max_key = max(data)
             for i in range(max_key + 1):
-                if i not in counts:
-                    counts[i] = 0
+                if i not in data:
+                    data[i] = 0
 
-    elif input_is_dec or all(isinstance(key, int) for key in counts.keys()):
-        counts = {bin(key): value for key, value in counts.items()}
-        return format_counts(counts, include_zero_values=include_zero_values, decimal=False)
+    elif input_is_dec or all(isinstance(key, int) for key in data.keys()):
+        data = {bin(key): value for key, value in data.items()}
+        return format_data(data, include_zero_values=include_zero_values, decimal=False)
 
     if not include_zero_values:
-        counts = {key: value for key, value in counts.items() if value != 0}
+        data = {key: value for key, value in data.items() if value != 0}
 
-    return dict(sorted(counts.items()))
+    return dict(sorted(data.items()))
 
 
-def normalize_counts(
-    counts: Union[dict[str, int], list[dict[str, int]]],
+def normalize_data(
+    data: Union[dict[str, int], list[dict[str, int]]],
     include_zero_values: bool = False,
     decimal: bool = False,
 ) -> Union[dict[str, int], list[dict[str, int]]]:
     """Returns the sorted histogram data of the run"""
-    if isinstance(counts, dict):
-        return format_counts(counts, include_zero_values=include_zero_values, decimal=decimal)
+    if isinstance(data, dict):
+        return format_data(data, include_zero_values=include_zero_values, decimal=decimal)
 
-    batch_counts = [
-        format_counts(counts, include_zero_values=include_zero_values, decimal=decimal)
-        for counts in counts
+    batch_data = [
+        format_data(datum, include_zero_values=include_zero_values, decimal=decimal)
+        for datum in data
     ]
 
     if decimal:
-        return batch_counts
+        return batch_data
 
-    return normalize_batch_bit_lengths(batch_counts)
+    return normalize_batch_bit_lengths(batch_data)
 
 
 def _counts_to_probabilities(counts: dict[str, int]) -> dict[str, float]:

--- a/qbraid/runtime/result_data.py
+++ b/qbraid/runtime/result_data.py
@@ -22,7 +22,7 @@ import numpy as np
 
 from qbraid.programs import ExperimentType
 
-from .postprocess import counts_to_probabilities, normalize_counts, format_counts
+from .postprocess import counts_to_probabilities, format_counts, normalize_counts
 from .schemas.experiment import (
     AhsExperimentMetadata,
     AnnealingExperimentMetadata,
@@ -182,7 +182,8 @@ class GateModelResultData(ResultData):
             Union[MeasProb, list[MeasProb]: Probabilities of measurement outcomes.
 
         Raises:
-            ValueError: If probabilities data is not available or if measurement_probabilities is not a dictionary.
+            ValueError: If probabilities data is not available or
+                        if measurement_probabilities is not a dictionary.
         """
         cache_key = f"prob_{'dec' if decimal else 'bin'}_{'wz' if include_zero_values else 'nz'}"
 
@@ -196,7 +197,7 @@ class GateModelResultData(ResultData):
             probabilities = format_counts(
                 self._measurement_probabilities,
                 include_zero_values=include_zero_values,
-                decimal=decimal
+                decimal=decimal,
             )
         else:
             counts = self.get_counts(include_zero_values=include_zero_values, decimal=decimal)

--- a/qbraid/runtime/result_data.py
+++ b/qbraid/runtime/result_data.py
@@ -22,7 +22,7 @@ import numpy as np
 
 from qbraid.programs import ExperimentType
 
-from .postprocess import counts_to_probabilities, format_counts, normalize_counts
+from .postprocess import counts_to_probabilities, normalize_data
 from .schemas.experiment import (
     AhsExperimentMetadata,
     AnnealingExperimentMetadata,
@@ -160,7 +160,7 @@ class GateModelResultData(ResultData):
 
         if self._cache[cache_key] is not None:
             return self._cache[cache_key]
-        counts = normalize_counts(
+        counts = normalize_data(
             self._measurement_counts, include_zero_values=include_zero_values, decimal=decimal
         )
 
@@ -194,7 +194,7 @@ class GateModelResultData(ResultData):
             if not isinstance(self._measurement_probabilities, dict):
                 raise ValueError("'measurement_probabilities' must be a dictionary.")
 
-            probabilities = format_counts(
+            probabilities = normalize_data(
                 self._measurement_probabilities,
                 include_zero_values=include_zero_values,
                 decimal=decimal,

--- a/tests/runtime/azure/test_azure_runtime.py
+++ b/tests/runtime/azure/test_azure_runtime.py
@@ -42,7 +42,7 @@ from qbraid.runtime.azure import AzureQuantumDevice, AzureQuantumJob
 from qbraid.runtime.azure.io_format import InputDataFormat, OutputDataFormat
 from qbraid.runtime.azure.provider import AzureQuantumProvider, serialize_pulser_input
 from qbraid.runtime.azure.result_builder import AzureResultBuilder
-from qbraid.runtime.postprocess import normalize_counts
+from qbraid.runtime.postprocess import normalize_data
 
 pytestmark = pytest.mark.filterwarnings("ignore:Unrecognized input data format:UserWarning")
 
@@ -847,7 +847,7 @@ def test_azure_quantum_result_counts(
         return_value=mock_builder_ionq_results["results"],
     ):
         raw_counts = azure_result_builder.get_counts()
-        formatted_counts = normalize_counts(raw_counts)
+        formatted_counts = normalize_data(raw_counts)
     assert raw_counts == formatted_counts == {"000": 50, "111": 50}
 
 

--- a/tests/runtime/test_result.py
+++ b/tests/runtime/test_result.py
@@ -657,7 +657,11 @@ def test_repr(result_instance):
         "  device_id=test_device,\n"
         "  job_id=test_job,\n"
         "  success=True,\n"
-        "  data=GateModelResultData(measurement_counts=None, measurements=None)"
+        "  data=GateModelResultData("
+        "measurement_counts=None, "
+        "measurements=None, "
+        "measurement_probabilities=None"
+        ")"
     )
     assert repr(result_instance).startswith(expected_repr)
 

--- a/tests/runtime/test_result.py
+++ b/tests/runtime/test_result.py
@@ -354,17 +354,24 @@ def test_get_probabilities_from_cache(gate_model_result_data):
     retrieved_probs = gate_model_result_data.get_probabilities(decimal=True)
     assert retrieved_probs == mock_cached_probs
 
-@pytest.mark.parametrize("precomputed_probs", ({"00": 0.4, "01": 0.6}, {"00": 0.25, "01": 0.25, "10": 0.25, "11": 0.25}))
+
+@pytest.mark.parametrize(
+    "precomputed_probs", ({"00": 0.4, "01": 0.6}, {"00": 0.25, "01": 0.25, "10": 0.25, "11": 0.25})
+)
 def test_precomputed_measurement_probs(precomputed_probs):
     """Tests that precomputed probabilities are returned from GateModelResultData"""
-    measurement_probs = GateModelResultData(measurement_probabilities=precomputed_probs).get_probabilities()
+    measurement_probs = GateModelResultData(
+        measurement_probabilities=precomputed_probs
+    ).get_probabilities()
     assert precomputed_probs == measurement_probs
+
 
 @pytest.mark.parametrize("precomputed_probs", ([0.1, 0.7, 0.2], True, False, 0.2, "probabilities"))
 def test_precomputed_measurement_probs_not_dict(precomputed_probs):
     """Tests that ValueError is raised if 'measurement_probabilities' is not a dictionary."""
     with pytest.raises(ValueError, match="'measurement_probabilities' must be a dictionary."):
         GateModelResultData(measurement_probabilities=precomputed_probs).get_probabilities()
+
 
 def test_to_dict_no_counts():
     """Test the to_dict method when measurement counts are not available."""

--- a/tests/runtime/test_result.py
+++ b/tests/runtime/test_result.py
@@ -354,6 +354,17 @@ def test_get_probabilities_from_cache(gate_model_result_data):
     retrieved_probs = gate_model_result_data.get_probabilities(decimal=True)
     assert retrieved_probs == mock_cached_probs
 
+@pytest.mark.parametrize("precomputed_probs", ({"00": 0.4, "01": 0.6}, {"00": 0.25, "01": 0.25, "10": 0.25, "11": 0.25}))
+def test_precomputed_measurement_probs(precomputed_probs):
+    """Tests that precomputed probabilities are returned from GateModelResultData"""
+    measurement_probs = GateModelResultData(measurement_probabilities=precomputed_probs).get_probabilities()
+    assert precomputed_probs == measurement_probs
+
+@pytest.mark.parametrize("precomputed_probs", ([0.1, 0.7, 0.2], True, False, 0.2, "probabilities"))
+def test_precomputed_measurement_probs_not_dict(precomputed_probs):
+    """Tests that ValueError is raised if 'measurement_probabilities' is not a dictionary."""
+    with pytest.raises(ValueError, match="'measurement_probabilities' must be a dictionary."):
+        GateModelResultData(measurement_probabilities=precomputed_probs).get_probabilities()
 
 def test_to_dict_no_counts():
     """Test the to_dict method when measurement counts are not available."""

--- a/tests/runtime/test_result.py
+++ b/tests/runtime/test_result.py
@@ -24,10 +24,10 @@ from qbraid.programs import ExperimentType
 from qbraid.runtime.native.result import NECVectorAnnealerResultData, QbraidQirSimulatorResultData
 from qbraid.runtime.postprocess import (
     distribute_counts,
-    format_counts,
+    format_data,
     normalize_batch_bit_lengths,
     normalize_bit_lengths,
-    normalize_counts,
+    normalize_data,
 )
 from qbraid.runtime.result import Result
 from qbraid.runtime.result_data import (
@@ -199,7 +199,7 @@ def result_instance():
 )
 def test_format_counts(counts_raw, expected_out, include_zero_values):
     """Test formatting of raw measurement counts."""
-    counts_out = format_counts(counts_raw, include_zero_values=include_zero_values)
+    counts_out = format_data(counts_raw, include_zero_values=include_zero_values)
     assert counts_out == expected_out  # check equivalance
     assert list(counts_out.items()) == list(expected_out.items())  # check ordering of keys
 
@@ -208,7 +208,7 @@ def test_format_counts_empty_input():
     """Test formatting of empty input."""
     counts = {}
     expected = {}
-    assert format_counts(counts) == expected
+    assert format_data(counts) == expected
 
 
 def test_normalize_different_key_lengths():
@@ -276,7 +276,7 @@ def test_batch_normalized_counts():
     """Test batch measurement counts."""
     result = MockBatchResult()
     raw_counts = result.get_counts()
-    counts = normalize_counts(raw_counts, include_zero_values=False)
+    counts = normalize_data(raw_counts, include_zero_values=False)
     expected = [{"0": 550}, {"0": 550, "1": 474}]
     assert counts == expected
 
@@ -603,7 +603,7 @@ def test_normalize_batch_decimal_counts():
     """Test normalization of batch measurement counts with decimal=True."""
     counts = [{"00": 10, "01": 15}, {"10": 20, "11": 25}]
     expected = [{0: 10, 1: 15}, {2: 20, 3: 25}]
-    result = normalize_counts(counts, decimal=True)
+    result = normalize_data(counts, decimal=True)
     assert result == expected
 
 
@@ -613,7 +613,7 @@ def test_normalize_batch_decimal_counts():
 def test_format_counts_include_zero_values_decimal(counts):
     """Test format counts include_zero_values option in decimal form."""
     expected = {0: 10, 1: 15, 2: 0, 3: 25}
-    result = format_counts(counts, include_zero_values=True, decimal=True)
+    result = format_data(counts, include_zero_values=True, decimal=True)
     assert result == expected
 
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

This PR adds a `measurement_probabilities` argument to the `GateModelResultData` class.

TODO:
- [x] Fix decimal for `measurement_probabilities` in the `get_probabilities` method
- [x] Type check `measurement_probabilities` in `get_probabilities` method.
- [x] Add test funtion(s) in `test_results.py`
- [x] Edit CHANGELOG.md
- [x] Change `normalize_counts` to `normalize_data` and `format_counts` to format_data`.

Closes #785 