### PR TITLE
Fix a `figsize` argument for graph plots.

### DIFF
--- a/qbraid/visualization/plot_conversions.py
+++ b/qbraid/visualization/plot_conversions.py
@@ -158,6 +158,7 @@ def plot_conversion_graph(  # pylint: disable=too-many-arguments
         kwargs["edgecolors"] = edgecolors
 
     plt.ioff()  # Disable interactive mode
+    plt.figure(layout="constrained", figsize=(8, 6))
 
     mpl_draw(
         graph,


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes
This PR fixes a `figsize` argument for the matplotlib graph plots such that the nodes are not cropped off from the image edge while saving. Potentially closes #851 