### PR TITLE
Add margins for conv graph plot 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Types of changes:
 ### Added
 - Added `CudaQKernel.serialize` method that converts cudaq program to QIR string for `run_input` compatible format for `QbraidDevice.submit`. ([#972](https://github.com/qBraid/qBraid/pull/972))
 - Added support for batch jobs for devices from Azure provider. The `AzureQuantumDevice.submit` method now accepts single and batched `qbraid.programs.QPROGRAM` inputs. ([#953](https://github.com/qBraid/qBraid/issues/953))
-- Added the "margin" argument to plot_conversion_graph to prevent possible clipping. ([#993](https://github.com/qBraid/qBraid/pull/993))
+- Added the 'margin' argument to 'plot_conversion_graph' to prevent possible clipping. ([#993](https://github.com/qBraid/qBraid/pull/993))
 
 ### Improved / Modified
 - Updated `TimeStamps` schema to auto-compute `executionDuration` from `createdAt` and `endedAt` if not explicitly provided. ([#983](https://github.com/qBraid/qBraid/pull/983))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Types of changes:
 ### Added
 - Added `CudaQKernel.serialize` method that converts cudaq program to QIR string for `run_input` compatible format for `QbraidDevice.submit`. ([#972](https://github.com/qBraid/qBraid/pull/972))
 - Added support for batch jobs for devices from Azure provider. The `AzureQuantumDevice.submit` method now accepts single and batched `qbraid.programs.QPROGRAM` inputs. ([#953](https://github.com/qBraid/qBraid/issues/953))
-- Added the "margin" argument to plot_conversion_graph to prevent possible clipping. ([#993] (https://github.com/qBraid/qBraid/pull/993))
+- Added the "margin" argument to plot_conversion_graph to prevent possible clipping. ([#993](https://github.com/qBraid/qBraid/pull/993))
 
 ### Improved / Modified
 - Updated `TimeStamps` schema to auto-compute `executionDuration` from `createdAt` and `endedAt` if not explicitly provided. ([#983](https://github.com/qBraid/qBraid/pull/983))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Types of changes:
 ### Added
 - Added `CudaQKernel.serialize` method that converts cudaq program to QIR string for `run_input` compatible format for `QbraidDevice.submit`. ([#972](https://github.com/qBraid/qBraid/pull/972))
 - Added support for batch jobs for devices from Azure provider. The `AzureQuantumDevice.submit` method now accepts single and batched `qbraid.programs.QPROGRAM` inputs. ([#953](https://github.com/qBraid/qBraid/issues/953))
-- Added the 'margin' argument to 'plot_conversion_graph' to prevent possible clipping. ([#993](https://github.com/qBraid/qBraid/pull/993))
+- Added the `margin` argument to `plot_conversion_graph` to prevent possible clipping. ([#993](https://github.com/qBraid/qBraid/pull/993))
 
 ### Improved / Modified
 - Updated `TimeStamps` schema to auto-compute `executionDuration` from `createdAt` and `endedAt` if not explicitly provided. ([#983](https://github.com/qBraid/qBraid/pull/983))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Types of changes:
 ### Added
 - Added `CudaQKernel.serialize` method that converts cudaq program to QIR string for `run_input` compatible format for `QbraidDevice.submit`. ([#972](https://github.com/qBraid/qBraid/pull/972))
 - Added support for batch jobs for devices from Azure provider. The `AzureQuantumDevice.submit` method now accepts single and batched `qbraid.programs.QPROGRAM` inputs. ([#953](https://github.com/qBraid/qBraid/issues/953))
-- Added `margin` argument to `plot_conversion_graph` to prevent possible clipping. ([#993](https://github.com/qBraid/qBraid/pull/993))
+- Added `ax_margins` argument to `plot_conversion_graph` to prevent possible clipping. ([#993](https://github.com/qBraid/qBraid/pull/993))
 
 ### Improved / Modified
 - Updated `TimeStamps` schema to auto-compute `executionDuration` from `createdAt` and `endedAt` if not explicitly provided. ([#983](https://github.com/qBraid/qBraid/pull/983))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Types of changes:
 ### Added
 - Added `CudaQKernel.serialize` method that converts cudaq program to QIR string for `run_input` compatible format for `QbraidDevice.submit`. ([#972](https://github.com/qBraid/qBraid/pull/972))
 - Added support for batch jobs for devices from Azure provider. The `AzureQuantumDevice.submit` method now accepts single and batched `qbraid.programs.QPROGRAM` inputs. ([#953](https://github.com/qBraid/qBraid/issues/953))
+- Added the "margin" argument to plot_conversion_graph to prevent possible clipping. ([#993] (https://github.com/qBraid/qBraid/pull/993))
 
 ### Improved / Modified
 - Updated `TimeStamps` schema to auto-compute `executionDuration` from `createdAt` and `endedAt` if not explicitly provided. ([#983](https://github.com/qBraid/qBraid/pull/983))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Types of changes:
 ### Added
 - Added `CudaQKernel.serialize` method that converts cudaq program to QIR string for `run_input` compatible format for `QbraidDevice.submit`. ([#972](https://github.com/qBraid/qBraid/pull/972))
 - Added support for batch jobs for devices from Azure provider. The `AzureQuantumDevice.submit` method now accepts single and batched `qbraid.programs.QPROGRAM` inputs. ([#953](https://github.com/qBraid/qBraid/issues/953))
-- Added the `margin` argument to `plot_conversion_graph` to prevent possible clipping. ([#993](https://github.com/qBraid/qBraid/pull/993))
+- Added `margin` argument to `plot_conversion_graph` to prevent possible clipping. ([#993](https://github.com/qBraid/qBraid/pull/993))
 
 ### Improved / Modified
 - Updated `TimeStamps` schema to auto-compute `executionDuration` from `createdAt` and `endedAt` if not explicitly provided. ([#983](https://github.com/qBraid/qBraid/pull/983))

--- a/qbraid/visualization/plot_conversions.py
+++ b/qbraid/visualization/plot_conversions.py
@@ -76,6 +76,7 @@ def plot_conversion_graph(  # pylint: disable=too-many-arguments
     edge_labels: bool = False,
     experiment_type: Optional[ExperimentType | Iterable[ExperimentType]] = None,
     target_nodes: Optional[Iterable[str]] = None,
+    margin: float = 0.1,
     **kwargs,
 ) -> None:
     """
@@ -99,6 +100,7 @@ def plot_conversion_graph(  # pylint: disable=too-many-arguments
         experiment_type (ExperimentType | Iterable[ExperimentType] | None): Filter the
             graph by experiment type. Defaults to None, meaning all experiment types are included.
         target_nodes (Iterable[str] | None): Nodes to be outlined in the plot. Defaults to None.
+        margin (float): Set margins around the data for autoscaling axis limits. Autoscaling determines the axis limits by adding margin times the data interval as padding around the data. Defaults to 0.1.
 
     Returns:
         None
@@ -175,7 +177,7 @@ def plot_conversion_graph(  # pylint: disable=too-many-arguments
         **kwargs,
     )
 
-    ax.margins(plot_margin, plot_margin)
+    ax.margins(margin, margin)
 
     if title:
         plt.title(title)

--- a/qbraid/visualization/plot_conversions.py
+++ b/qbraid/visualization/plot_conversions.py
@@ -159,9 +159,13 @@ def plot_conversion_graph(  # pylint: disable=too-many-arguments
 
     plt.ioff()  # Disable interactive mode
 
+    fig = plt.figure()
+    ax = fig.add_subplot(111)
+
     mpl_draw(
         graph,
         pos,
+        ax=ax,
         node_color=ncolors,
         edge_color=ecolors,
         node_size=node_size,
@@ -170,6 +174,8 @@ def plot_conversion_graph(  # pylint: disable=too-many-arguments
         min_target_margin=min_target_margin,
         **kwargs,
     )
+
+    ax.margins(0.15, 0.15)
 
     if title:
         plt.title(title)
@@ -240,6 +246,8 @@ def plot_conversion_graph(  # pylint: disable=too-many-arguments
             ha="left",
             va="bottom",
         )
+
+    fig.tight_layout()
 
     if save_path:
         plt.savefig(save_path, bbox_inches="tight", dpi=300)

--- a/qbraid/visualization/plot_conversions.py
+++ b/qbraid/visualization/plot_conversions.py
@@ -143,7 +143,6 @@ def plot_conversion_graph(  # pylint: disable=too-many-arguments
             "To avoid this issue, please upgrade to rustworkx>=0.16.0.",
             UserWarning,
         )
-    plot_margin = kwargs.pop("plot_margin", 0.1)
     seed = seed or random.randint(1, 999)
     k = kwargs.pop("k", max(1 / math.sqrt(len(graph.nodes())), 3))
     pos = rx.spring_layout(graph, seed=seed, k=k, **kwargs)

--- a/qbraid/visualization/plot_conversions.py
+++ b/qbraid/visualization/plot_conversions.py
@@ -70,13 +70,13 @@ def plot_conversion_graph(  # pylint: disable=too-many-arguments
     seed: Optional[int] = None,
     node_size: int = 1200,
     min_target_margin: int = 18,
+    ax_margins: float = 0.1,
     show: bool = True,
     save_path: Optional[str | Path] = None,
     colors: Optional[dict[str, str]] = None,
     edge_labels: bool = False,
     experiment_type: Optional[ExperimentType | Iterable[ExperimentType]] = None,
     target_nodes: Optional[Iterable[str]] = None,
-    margin: float = 0.1,
     **kwargs,
 ) -> None:
     """
@@ -92,6 +92,8 @@ def plot_conversion_graph(  # pylint: disable=too-many-arguments
             positioning. Defaults to None.
         node_size (int): Size of the nodes. Defaults to 1200.
         min_target_margin (int): Minimum target margin for edges. Defaults to 18.
+        ax_margins (float): Padding added (as a fraction of data range) to auto-scaled
+            axis limits. Defaults to 0.1.
         show (bool): If True, display the figure. Defaults to True.
         save_path (str | Path | None): Path to save the figure. If None, figure is not saved.
         colors (dict[str, str] | None): Node and edge colors with keys 'target_node_outline',
@@ -100,7 +102,6 @@ def plot_conversion_graph(  # pylint: disable=too-many-arguments
         experiment_type (ExperimentType | Iterable[ExperimentType] | None): Filter the
             graph by experiment type. Defaults to None, meaning all experiment types are included.
         target_nodes (Iterable[str] | None): Nodes to be outlined in the plot. Defaults to None.
-        margin (float): Set margins around the data for autoscaling axis limits. Autoscaling determines the axis limits by adding margin times the data interval as padding around the data. Defaults to 0.1.
 
     Returns:
         None
@@ -176,7 +177,7 @@ def plot_conversion_graph(  # pylint: disable=too-many-arguments
         **kwargs,
     )
 
-    ax.margins(margin, margin)
+    ax.margins(ax_margins, ax_margins)
 
     if title:
         plt.title(title)

--- a/qbraid/visualization/plot_conversions.py
+++ b/qbraid/visualization/plot_conversions.py
@@ -141,7 +141,7 @@ def plot_conversion_graph(  # pylint: disable=too-many-arguments
             "To avoid this issue, please upgrade to rustworkx>=0.16.0.",
             UserWarning,
         )
-
+    plot_margin = kwargs.pop("plot_margin", 0.1)
     seed = seed or random.randint(1, 999)
     k = kwargs.pop("k", max(1 / math.sqrt(len(graph.nodes())), 3))
     pos = rx.spring_layout(graph, seed=seed, k=k, **kwargs)
@@ -175,11 +175,11 @@ def plot_conversion_graph(  # pylint: disable=too-many-arguments
         **kwargs,
     )
 
-    ax.margins(0.15, 0.15)
+    ax.margins(plot_margin, plot_margin)
 
     if title:
         plt.title(title)
-    plt.axis("off")
+    plt.axis("on")
 
     if legend:
         legend_info = [


### PR DESCRIPTION
## Summary of changes

The autoscaling that matplotlib uses will sometimes cause the plot to be clipped. This is more likely to occur when using the "scatter" plot function with large symbols. This change does two things:

1) Explicitly creates a matplotlib figure object and associated Axes instance and passes the Axes instance to mpl_draw
2) After mpl_draw returns, a margin of 15% is added to the plot.

The margin around the plot allows the contents to be rendered without clipping.

Note that currently, the margin is hard coded at 15%. To make this more flexible it could be added as an extra keyword argument for the plot_conversion_graph function.

Potentially closes #851