### PR TITLE
Remove `pkg_resources` from entrypoints logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Types of changes:
 ### Added
 
 ### Improved / Modified
+- Removed legacy `pkg_resources` logic for loading entry points (`qbraid._entrypoints`), as support for Python 3.9 has been dropped and the project now requires Python 3.10 or higher. ([#1002](https://github.com/qBraid/qBraid/issues/1002))
 
 ### Deprecated
 

--- a/qbraid/_entrypoints.py
+++ b/qbraid/_entrypoints.py
@@ -13,13 +13,7 @@ Module used for loading entry points and other dynamic imports.
 
 """
 import importlib.metadata
-import sys
 from typing import Optional, Type
-
-try:
-    import pkg_resources
-except ImportError:  # pragma: no cover
-    pkg_resources = None
 
 from .exceptions import QbraidError
 
@@ -36,10 +30,7 @@ def get_entrypoints(module: str) -> dict[str, object]:
     """
     group = f"qbraid.{module}"
 
-    if sys.version_info >= (3, 10):
-        entry_points = importlib.metadata.entry_points().select(group=group)
-    else:
-        entry_points = pkg_resources.iter_entry_points(group=group)
+    entry_points = importlib.metadata.entry_points().select(group=group)
 
     return {ep.name: ep for ep in entry_points}
 

--- a/qbraid/_version.py
+++ b/qbraid/_version.py
@@ -15,4 +15,4 @@ Version number (major.minor.patch[-label])
 
 """
 
-__version__ = "0.9.7"
+__version__ = "0.9.8.dev"

--- a/qbraid/programs/loader.py
+++ b/qbraid/programs/loader.py
@@ -10,8 +10,7 @@
 
 """
 Module containing top-level qbraid program loader functionality
-utilizing entrypoints via ``importlib`` for Python >= 3.10 or
-``pkg_resources`` for Python 3.9.
+utilizing entrypoints via ``importlib``.
 
 """
 from __future__ import annotations

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ rustworkx>=0.15.0
 numpy>=1.17
 openqasm3[parser]>=0.4.0
 qbraid-core>=0.1.39
-pydantic>2.0.0,<=2.11.1
+pydantic>2.0.0
 pydantic-core
 typing-extensions>=4.0.0
 pyqasm>=0.3.2, <0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ rustworkx>=0.15.0
 numpy>=1.17
 openqasm3[parser]>=0.4.0
 qbraid-core>=0.1.39
-pydantic>2.0.0
+pydantic>2.0.0,<=2.11.1
 pydantic-core
 typing-extensions>=4.0.0
 pyqasm>=0.3.2, <0.4.0


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

- Removed legacy `pkg_resources` logic for loading entry points, as support for Python 3.9 has been dropped and the project now requires Python 3.10 or higher.


