### PR TITLE
fix: alter raise of warning instead of value error for probability sum.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Types of changes:
 ### Improved / Modified
 - Removed legacy `pkg_resources` logic for loading entry points (`qbraid._entrypoints`), as support for Python 3.9 has been dropped and the project now requires Python 3.10 or higher. ([#1002](https://github.com/qBraid/qBraid/issues/1002))
 
+- Throw a `UserWarning` instead of a `ValueError` when checking for the sum of result probabilities from job to be equal
+to 1 ([#1004](https://github.com/qBraid/qBraid/pull/1004)).
+
+
 ### Deprecated
 
 ### Removed

--- a/qbraid/runtime/postprocess.py
+++ b/qbraid/runtime/postprocess.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from math import isclose
 from typing import Any, Union
+import warnings
 
 
 def normalize_batch_bit_lengths(measurements: list[dict[str, int]]) -> list[dict[str, int]]:
@@ -255,7 +256,7 @@ def distribute_counts(probs: dict[Any, float], shots: int) -> dict[Any, int]:
         {0: 9, 1: 1}
     """
     if not isclose(sum(probs.values()), 1.0, rel_tol=1e-7):
-        raise ValueError("Probabilities must sum to 1.")
+        warnings.warn("Probabilities must sum to 1.")
 
     if not all(0 <= prob <= 1 for prob in probs.values()):
         raise ValueError("Probabilities must be between 0 and 1.")

--- a/tests/runtime/test_result.py
+++ b/tests/runtime/test_result.py
@@ -816,7 +816,7 @@ def test_distribute_counts_probabilities_not_sum_to_1():
     """Test distribute_counts with probabilities that do not sum to 1."""
     probs = {0: 0.9, 1: 0.2}
     shots = 10
-    with pytest.warns(UserWarning, match="Probabilities must sum to 1."):
+    with pytest.warns(UserWarning, match="Probabilities do not sum to 1."):
         distribute_counts(probs, shots)
 
 

--- a/tests/runtime/test_result.py
+++ b/tests/runtime/test_result.py
@@ -25,6 +25,7 @@ from qbraid.runtime.native.result import NECVectorAnnealerResultData, QbraidQirS
 from qbraid.runtime.postprocess import (
     distribute_counts,
     format_data,
+    normalize_batch_bit_lengths,
     normalize_bit_lengths,
     normalize_data,
 )
@@ -815,7 +816,7 @@ def test_distribute_counts_probabilities_not_sum_to_1():
     """Test distribute_counts with probabilities that do not sum to 1."""
     probs = {0: 0.9, 1: 0.2}
     shots = 10
-    with pytest.warns(UserWarning, match="Probabilities do not sum to 1."):
+    with pytest.warns(UserWarning, match="Probabilities must sum to 1."):
         distribute_counts(probs, shots)
 
 

--- a/tests/runtime/test_result.py
+++ b/tests/runtime/test_result.py
@@ -19,6 +19,7 @@ from collections import Counter
 
 import numpy as np
 import pytest
+import warnings
 
 from qbraid.programs import ExperimentType
 from qbraid.runtime.native.result import NECVectorAnnealerResultData, QbraidQirSimulatorResultData
@@ -816,7 +817,7 @@ def test_distribute_counts_probabilities_not_sum_to_1():
     """Test distribute_counts with probabilities that do not sum to 1."""
     probs = {0: 0.9, 1: 0.2}
     shots = 10
-    with pytest.raises(ValueError, match="Probabilities must sum to 1."):
+    with pytest.warns(UserWarning, match="Probabilities must sum to 1."):
         distribute_counts(probs, shots)
 
 

--- a/tests/runtime/test_result.py
+++ b/tests/runtime/test_result.py
@@ -19,14 +19,12 @@ from collections import Counter
 
 import numpy as np
 import pytest
-import warnings
 
 from qbraid.programs import ExperimentType
 from qbraid.runtime.native.result import NECVectorAnnealerResultData, QbraidQirSimulatorResultData
 from qbraid.runtime.postprocess import (
     distribute_counts,
     format_data,
-    normalize_batch_bit_lengths,
     normalize_bit_lengths,
     normalize_data,
 )


### PR DESCRIPTION
As discussed on the thread of [this issue](https://github.com/unitaryfoundation/metriq-gym/issues/386), we decided to demote the probability sum not being equal to 1 from a `ValueError` to a `UserWarning`.