### PR TITLE
Add changes for workspace filtering in `QbraidProvider`

### DIFF
--- a/qbraid/runtime/native/provider.py
+++ b/qbraid/runtime/native/provider.py
@@ -223,6 +223,9 @@ class QbraidProvider(QuantumProvider):
                 and device["provider"] in {"Azure", "IonQ", "Quantinuum", "Rigetti", "Pasqal"}
             )
         ]
+        # filter the devices based on the workspace for aws byot
+        if self.client.session.workspace == "aws":
+            filtered_devices = [device for device in filtered_devices if device["vendor"] == "AWS"]
 
         if not filtered_devices:
             raise ResourceNotFoundError("No devices found matching given criteria.")
@@ -244,6 +247,11 @@ class QbraidProvider(QuantumProvider):
             device_data = self.client.get_device(qbraid_id=device_id)
         except (ValueError, QuantumServiceRequestError) as err:
             raise ResourceNotFoundError(f"Device '{device_id}' not found.") from err
+
+        if self.client.session.workspace == "aws" and device_data["vendor"] != "AWS":
+            raise ResourceNotFoundError(
+                f"Device '{device_id}' is not available in the current AWS workspace."
+            )
 
         profile = self._build_runtime_profile(device_data)
         return QbraidDevice(profile, client=self.client)

--- a/tests/runtime/_resources.py
+++ b/tests/runtime/_resources.py
@@ -314,6 +314,7 @@ class MockClient:
         """Mock session property."""
         session = MagicMock()
         session.api_key = "abc123"
+        session.workspace = "qbraid"
         return session
 
     @property

--- a/tests/runtime/test_device.py
+++ b/tests/runtime/test_device.py
@@ -295,6 +295,18 @@ def test_provider_get_devices_raises_for_no_results(mock_client):
         provider.get_devices(provider="IBM")
 
 
+def test_provider_get_device_workspace_allows_aws(mock_client):
+    """Test that get_device works for AWS device in AWS workspace."""
+    provider = QbraidProvider(client=mock_client)
+    aws_device_id = "quera_aquila"
+
+    # Set workspace to 'aws'
+    provider.client.session.workspace = "aws"
+    device = provider.get_device(aws_device_id)
+    assert device.profile.device_id == aws_device_id
+    assert device.profile.provider_name
+
+
 def test_provider_get_cached_devices(mock_client, device_data_qir, monkeypatch):
     """Test getting devices from the cache."""
     monkeypatch.setenv("DISABLE_CACHE", "0")


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

* [`qbraid/runtime/native/provider.py`](diffhunk://#diff-6f361948043f3272388d09bc56766913777e1264542ac8051de61649872ed083R226-R228): Added logic in the `get_devices` method to filter devices by the `AWS` vendor when the workspace is set to `aws`.
* [`qbraid/runtime/native/provider.py`](diffhunk://#diff-6f361948043f3272388d09bc56766913777e1264542ac8051de61649872ed083R251-R255): Updated the `get_device` method to raise a `ResourceNotFoundError` if the requested device is not available in the current `AWS` workspace.
