### PR TITLE
Equal1: decode compiled output in result details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Types of changes:
 ```python
 result = job.result()
 
-compiled_output = result.details['compiledOutput']
+compiled_output = result.details['metadata']['compiledOutput']
 ```
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ Types of changes:
 - Skip remote Azure provider tests that now require payed plan ([#1024](https://github.com/qBraid/qBraid/pull/1024))
 - Adds support for partial measurements on IonQ and Amazon Braket devices by automatically padding circuits with measurements on all qubits while tracking and filtering results to show only the originally measured qubits. ([#1028](https://github.com/qBraid/qBraid/pull/1028))
 - Replaced `execution_mode` and `device_name` fields in the `Equal1SimulationMetadata` class with `ir_type` and `noise_model` to match data returned by Equal1 simulator v0.3.0 ([#1035](https://github.com/qBraid/qBraid/pull/1035))
+- Moved decoding logic from `Equal1SimulatorResultData` class to the `Equal1SimulationMetadata` schema, ensuring that compiled outputs are automatically decoded when metadata is instantiated. For `equal1_simulator` jobs, the `base64` decoded compiled output will now be accessible from a `Result` object as follows:
+
+```python
+result = job.result()
+
+compiled_output = result.details['compiledOutput']
+```
 
 ### Deprecated
 

--- a/qbraid/runtime/native/result.py
+++ b/qbraid/runtime/native/result.py
@@ -15,11 +15,9 @@ managed natively through qBraid.
 """
 from __future__ import annotations
 
-import base64
 from typing import TYPE_CHECKING, Any, Optional
 
 from qbraid.exceptions import QbraidError
-from qbraid.programs.typer import Qasm2StringType
 from qbraid.runtime.result_data import AnnealingResultData, GateModelResultData
 
 if TYPE_CHECKING:
@@ -108,20 +106,6 @@ class QbraidQirSimulatorResultData(GateModelResultData):
 
 class Equal1SimulatorResultData(GateModelResultData):
     """Class for storing and accessing the results of an Equal1 simulator job."""
-
-    def __init__(self, compiled_output: str, **kwargs):
-        """Create a new Equal1SimulatorResultData instance."""
-        super().__init__(**kwargs)
-        self._compiled_output = self._decode_base64(compiled_output)
-
-    @staticmethod
-    def _decode_base64(value: str) -> str:
-        return base64.b64decode(value.encode("utf-8")).decode("utf-8")
-
-    @property
-    def compiled_output(self) -> Qasm2StringType:
-        """Returns the compiled output of the simulation."""
-        return self._compiled_output
 
 
 class NECVectorAnnealerResultData(AnnealingResultData):

--- a/qbraid/runtime/schemas/experiment.py
+++ b/qbraid/runtime/schemas/experiment.py
@@ -14,6 +14,7 @@ Module defining qBraid runtime experiment schemas.
 """
 from __future__ import annotations
 
+import base64
 from collections import Counter
 from typing import TYPE_CHECKING, Any, Optional, Union
 
@@ -134,7 +135,8 @@ class Equal1SimulationMetadata(GateModelExperimentMetadata):
     """Metadata specific to jobs submitted to the Equal1 simulator.
 
     Attributes:
-        compiled_output (str, optional): The compiled output of the job.
+        compiled_output (str, optional): The compiled output of the job
+            (automatically base64 decoded).
         ir_type (str, optional): The type of intermediate representation used for the job.
         noise_model (str, optional): The name of the noise model used for the job.
         simulation_platform (str, optional): The platform used for the simulation.
@@ -146,6 +148,19 @@ class Equal1SimulationMetadata(GateModelExperimentMetadata):
     noise_model: Optional[str] = Field(None, alias="noiseModel")
     simulation_platform: Optional[str] = Field(None, alias="simulationPlatform")
     execution_options: Optional[dict[str, Any]] = Field(None, alias="executionOptions")
+
+    @field_validator("compiled_output")
+    @classmethod
+    def decode_compiled_output(cls, value: Optional[str]) -> Optional[str]:
+        """Automatically decode base64 compiled output."""
+        if value is None:
+            return None
+        return cls._decode_base64(value)
+
+    @staticmethod
+    def _decode_base64(value: str) -> str:
+        """Decode base64 encoded string."""
+        return base64.b64decode(value.encode("utf-8")).decode("utf-8")
 
 
 class AhsExperimentMetadata(BaseModel):

--- a/qbraid/runtime/schemas/job.py
+++ b/qbraid/runtime/schemas/job.py
@@ -104,6 +104,7 @@ class RuntimeJobModel(QbraidSchemaBase):
     queue_position: Optional[int] = Field(None, ge=0, alias="queuePosition")
     metadata: Union[
         QbraidQirSimulationMetadata,
+        Equal1SimulationMetadata,
         QuEraQasmSimulationMetadata,
         GateModelExperimentMetadata,
         AnnealingExperimentMetadata,

--- a/tests/runtime/native/test_equal1_runtime.py
+++ b/tests/runtime/native/test_equal1_runtime.py
@@ -14,20 +14,38 @@ Unit tests for Equal1 simulator runtime through native provider.
 """
 import pytest
 
+from qbraid.runtime import Result
 from qbraid.runtime.native.result import Equal1SimulatorResultData
 from qbraid.runtime.schemas.experiment import Equal1SimulationMetadata
 
+@pytest.fixture
+def equal1_partial_base64_data():
+    """Fixture providing the partial base64 encoded compiled output."""
+    return "T1BFTlFBU00gMi4wOwppbmNsdWRlICJxZWxpYjEuaW5jIjsKcXJlZyBxWzZdOwpjcmVnIG1lYXNbMl07"
 
-def test_equal1_simulator_result_data():
-    """Test the Equal1SimulatorResultData class."""
-    compiled_output = (
+
+@pytest.fixture
+def equal1_full_base64_data():
+    """Fixture providing the complete base64 encoded compiled output."""
+    return (
         "T1BFTlFBU00gMi4wOwppbmNsdWRlICJxZWxpYjEuaW5jIjsKcXJlZyBxWzZdOwpjcmVnIG1lYXNbMl07"
         "CnJ6KHBpLzIpIHFbMl07CnJ4KHBpLzIpIHFbMl07CnJ6KHBpLzIpIHFbMl07CnJ6KHBpLzIpIHFbM107"
         "CnJ4KHBpLzIpIHFbM107CnJ6KHBpKSBxWzNdOwpjeiBxWzJdLHFbM107CnJ4KHBpLzIpIHFbM107"
         "CnJ6KHBpLzIpIHFbM107CmJhcnJpZXIgcVsyXSxxWzNdOwptZWFzdXJlIHFbMl0gLT4gbWVhc1swXTsK"
         "bWVhc3VyZSBxWzNdIC0+IG1lYXNbMV07"
     )
-    qasm_expected = """OPENQASM 2.0;
+
+
+@pytest.fixture
+def equal1_partial_decoded_qasm():
+    """Fixture providing the expected decoded partial compiled output."""
+    return 'OPENQASM 2.0;\ninclude "qelib1.inc";\nqreg q[6];\ncreg meas[2];'
+
+
+@pytest.fixture
+def equal1_full_decoded_qasm():
+    """Fixture providing the expected decoded complete compiled output."""
+    return """OPENQASM 2.0;
 include "qelib1.inc";
 qreg q[6];
 creg meas[2];
@@ -43,17 +61,13 @@ rz(pi/2) q[3];
 barrier q[2],q[3];
 measure q[2] -> meas[0];
 measure q[3] -> meas[1];"""
-    result_data = Equal1SimulatorResultData(compiled_output)
-    assert result_data.compiled_output == qasm_expected
 
 
 @pytest.fixture
-def equal1_partial_data():
+def equal1_partial_data(equal1_partial_base64_data):
     """Fixture providing partial Equal1 simulation metadata fields."""
     return {
-        "compiledOutput": (
-            "T1BFTlFBU00gMi4wOwppbmNsdWRlICJxZWxpYjEuaW5jIjsKcXJlZyBxWzZdOwpjcmVnIG1lYXNbMl07"
-        ),
+        "compiledOutput": equal1_partial_base64_data,
         "irType": "qasm2",
         "noiseModel": "bell1-6",
     }
@@ -89,13 +103,31 @@ measure q[1] -> c[1];
     }
 
 
-def test_equal1_simulation_metadata(equal1_full_data):
+@pytest.fixture
+def equal1_expected_decoded(equal1_partial_decoded_qasm):
+    """Fixture providing the expected decoded compiled output."""
+    return equal1_partial_decoded_qasm
+
+
+def test_equal1_simulation_metadata_base64_decoding(
+    equal1_full_base64_data, equal1_full_decoded_qasm
+):
+    """Test that compiled_output is automatically decoded from base64."""
+    # Use the correct alias name to match the field definition
+    metadata = Equal1SimulationMetadata(compiledOutput=equal1_full_base64_data)
+    assert metadata.compiled_output == equal1_full_decoded_qasm
+
+    # Test with None value
+    metadata_none = Equal1SimulationMetadata(compiledOutput=None)
+    assert metadata_none.compiled_output is None
+
+
+def test_equal1_simulation_metadata(equal1_full_data, equal1_expected_decoded):
     """Test the Equal1SimulationMetadata class with complete example data."""
-    # Create metadata instance
     metadata = Equal1SimulationMetadata(**equal1_full_data)
 
-    # Test that all fields are correctly set
-    assert metadata.compiled_output == equal1_full_data["compiledOutput"]
+    # compiled_output should be automatically decoded from base64
+    assert metadata.compiled_output == equal1_expected_decoded
     assert metadata.ir_type == equal1_full_data["irType"]
     assert metadata.noise_model == equal1_full_data["noiseModel"]
     assert metadata.simulation_platform == equal1_full_data["simulationPlatform"]
@@ -109,12 +141,13 @@ def test_equal1_simulation_metadata(equal1_full_data):
     assert metadata.gate_depth is None
 
 
-def test_equal1_simulation_metadata_partial(equal1_partial_data):
+def test_equal1_simulation_metadata_partial(equal1_partial_data, equal1_expected_decoded):
     """Test Equal1SimulationMetadata with partial data."""
     metadata = Equal1SimulationMetadata(**equal1_partial_data)
 
     # Test that provided fields are set
-    assert metadata.compiled_output == equal1_partial_data["compiledOutput"]
+    # compiled_output should be automatically decoded from base64
+    assert metadata.compiled_output == equal1_expected_decoded
     assert metadata.ir_type == equal1_partial_data["irType"]
     assert metadata.noise_model == equal1_partial_data["noiseModel"]
 
@@ -135,12 +168,13 @@ def test_equal1_simulation_metadata_empty():
     assert metadata.execution_options is None
 
 
-def test_equal1_simulation_metadata_with_qasm(equal1_data_with_qasm):
+def test_equal1_simulation_metadata_with_qasm(equal1_data_with_qasm, equal1_expected_decoded):
     """Test Equal1SimulationMetadata with QASM data to test inheritance."""
     metadata = Equal1SimulationMetadata(**equal1_data_with_qasm)
 
     # Test Equal1 specific fields
-    assert metadata.compiled_output == equal1_data_with_qasm["compiledOutput"]
+    # compiled_output should be automatically decoded from base64
+    assert metadata.compiled_output == equal1_expected_decoded
     assert metadata.ir_type == equal1_data_with_qasm["irType"]
     assert metadata.noise_model == equal1_data_with_qasm["noiseModel"]
 
@@ -149,3 +183,37 @@ def test_equal1_simulation_metadata_with_qasm(equal1_data_with_qasm):
     assert metadata.measurement_counts is not None
     assert metadata.measurement_counts["00"] == 100
     assert metadata.measurement_counts["11"] == 100
+
+
+def test_equal1_result_with_metadata_and_data(
+    equal1_full_data, equal1_full_base64_data, equal1_expected_decoded
+):
+    """Test getting a Result object with Equal1SimulationMetadata and Equal1SimulatorResultData."""
+    result_data = Equal1SimulatorResultData(compiled_output=equal1_full_base64_data)
+
+    device_id = "equal1_simulator"
+    test_job_id = "equal1_simulator-jovyan-qjob-0cwn6yvl3pmv4osvponu"
+
+    result = Result(
+        device_id=device_id, job_id=test_job_id, success=True, data=result_data, **equal1_full_data
+    )
+
+    # Test the Result object
+    assert result.device_id == device_id
+    assert result.job_id == test_job_id
+    assert result.success is True
+
+    # Test that metadata fields are accessible via details
+    assert result.details["compiledOutput"] == equal1_full_data["compiledOutput"]
+    assert result.details["irType"] == equal1_full_data["irType"]
+    assert result.details["noiseModel"] == equal1_full_data["noiseModel"]
+    assert result.details["simulationPlatform"] == equal1_full_data["simulationPlatform"]
+    assert result.details["executionOptions"] == equal1_full_data["executionOptions"]
+
+    # Test that we can create metadata from the details and it decodes correctly
+    metadata_from_details = Equal1SimulationMetadata(**result.details)
+    assert metadata_from_details.compiled_output == equal1_expected_decoded
+    assert metadata_from_details.ir_type == equal1_full_data["irType"]
+    assert metadata_from_details.noise_model == equal1_full_data["noiseModel"]
+    assert metadata_from_details.simulation_platform == equal1_full_data["simulationPlatform"]
+    assert metadata_from_details.execution_options == equal1_full_data["executionOptions"]


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

- This pull request refactors how base64 decoding is handled for the `compiled_output` field in Equal1 simulation results and metadata. The decoding logic is moved from the `Equal1SimulatorResultData` class to the `Equal1SimulationMetadata` schema, ensuring that compiled outputs are automatically decoded when metadata is instantiated. Associated tests have been updated and expanded to verify this behavior and to improve coverage for result/metadata interactions.
- For `equal1_simulator` jobs, the `base64` decoded compiled output will now be accessible from a `Result` object as follows:

```python
result = job.result()

compiled_output = result.details['metadata']['compiledOutput']
```
