### PR TITLE
Ensure braket device properties set when checking next available

### DIFF
--- a/qbraid/runtime/aws/availability.py
+++ b/qbraid/runtime/aws/availability.py
@@ -95,12 +95,14 @@ def _calculate_future_time(
 
 def next_available_time(device: AwsDevice) -> tuple[bool, str, Optional[str]]:
     """Returns hr/min/sec until device is next available, or empty string if device is offline."""
-
     is_available_result = False
     available_time = None
 
     if device.status != "ONLINE":
         return False, "", None
+
+    if not device.properties:
+        device.refresh_metadata()
 
     if device.is_available:
         return True, "", None

--- a/tests/runtime/aws/test_braket_availability.py
+++ b/tests/runtime/aws/test_braket_availability.py
@@ -71,7 +71,7 @@ class FakeAwsDevice(AwsDevice):
     def __init__(self, online, available):
         self._is_available = available
         self._status = "ONLINE" if online else "OFFLINE"
-        self._properties = TestProperties()
+        self._properties = None
 
     @property
     def is_available(self):
@@ -99,6 +99,10 @@ class FakeAwsDevice(AwsDevice):
     @properties.setter
     def properties(self, value):
         self._properties = value
+
+    def refresh_metadata(self):
+        """Refresh metadata of the device."""
+        self._properties = TestProperties()
 
 
 def test_next_available_time_offline():


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

This pull request improves the handling of AWS device metadata availability checks, particularly in scenarios where device properties may not be initialized. The changes ensure that device metadata is refreshed when necessary and update the test suite to reflect this behavior.

Enhancements to device availability logic:

* In `next_available_time` (`qbraid/runtime/aws/availability.py`), added a check to refresh device metadata if `device.properties` is not set, ensuring accurate availability calculations.

Updates to test mocks and metadata handling:

* Modified the `FakeAwsDevice` test mock to initialize `_properties` as `None` instead of a default value, better simulating uninitialized metadata. (`tests/runtime/aws/test_braket_availability.py`)
* Added a `refresh_metadata` method to `FakeAwsDevice` to allow refreshing device properties during tests, mirroring the real device behavior. (`tests/runtime/aws/test_braket_availability.py`)
