### PR TITLE
QASM Parser and Related Transpilation Updated for Compatibility with Cirq v1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Types of changes:
 ### Added
 
 ### Improved / Modified
+- Updated the `QasmParser`and transpilation from Cirq to PyQuil to be compatible with Cirq 1.5. Also, added testing for new behavior in Cirq 1.5.([#1049](https://github.com/qBraid/qBraid/pull/1049)) 
 
 ### Deprecated
 
@@ -26,6 +27,7 @@ Types of changes:
 ### Fixed
 
 ### Dependencies
+- Updated `cirq-core` and `cirq-ionq` requirements from >=1.3,<1.5 to >=1.3,<1.6 ([#1049](https://github.com/qBraid/qBraid/pull/1049))
 
 ## [0.9.9] - 2025-09-01
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ Discord = "https://discord.gg/TPBU2sa8Et"
 azure = ["azure-quantum>=2.0,<2.3", "azure-storage-blob>=12.20,<13.0", "azure-identity>=1.17,<2.0"]
 bloqade = ["bloqade-analog>=0.16.1,<0.17.0"]
 braket = ["amazon-braket-sdk>=1.83.0,<1.101.0", "pytket-braket>=0.30,<0.45"]
-cirq = ["cirq-core>=1.3,<1.5", "cirq-ionq>=1.3,<1.5", "ply>=3.6", "attrs>=21.3.0"]
+cirq = ["cirq-core>=1.3,<1.6", "cirq-ionq>=1.3,<1.6", "ply>=3.6", "attrs>=21.3.0"]
 cudaq = ["cudaq>=0.9.0"]
 ionq = ["qiskit-ionq>=0.5.12"]
 oqc = ["oqc-qcaas-client>=3.11.0"]

--- a/qbraid/transpiler/conversions/cirq/cirq_quil_output.py
+++ b/qbraid/transpiler/conversions/cirq/cirq_quil_output.py
@@ -521,6 +521,7 @@ class QuilOutput:
         def on_stuck(bad_op):
             if not repr(bad_op).startswith("cirq.global_phase_operation"):
                 return ValueError(f"Cannot output operation as QUIL: {bad_op!r}")
+            return None
 
         for main_op in self.operations:
             decomposed = protocols.decompose(

--- a/qbraid/transpiler/conversions/cirq/cirq_quil_output.py
+++ b/qbraid/transpiler/conversions/cirq/cirq_quil_output.py
@@ -519,7 +519,8 @@ class QuilOutput:
             return QuilTwoQubitGate(mat).on(*op.qubits)  # pragma: no cover
 
         def on_stuck(bad_op):
-            return ValueError(f"Cannot output operation as QUIL: {bad_op!r}")
+            if not repr(bad_op).startswith("cirq.global_phase_operation"):
+                return ValueError(f"Cannot output operation as QUIL: {bad_op!r}")
 
         for main_op in self.operations:
             decomposed = protocols.decompose(
@@ -527,7 +528,8 @@ class QuilOutput:
             )
 
             for decomposed_op in decomposed:
-                output_func(self._op_to_quil(decomposed_op))
+                if not repr(decomposed_op).startswith("cirq.global_phase_operation"):
+                    output_func(self._op_to_quil(decomposed_op))
 
     def rename_defgates(self, output: str) -> str:
         """A function for renaming the DEFGATEs within the QUIL output. This

--- a/qbraid/transpiler/conversions/qasm2/cirq_qasm_parser.py
+++ b/qbraid/transpiler/conversions/qasm2/cirq_qasm_parser.py
@@ -498,9 +498,13 @@ class QasmParser:
 
     def p_term(self, p):
         """term : NUMBER
-        | NATURAL_NUMBER
-        | PI"""
+        | NATURAL_NUMBER"""
         p[0] = p[1]
+
+    def p_pi(self, p):
+        """term : PI"""
+        p[0] = np.pi
+
 
     # qargs : qarg ',' qargs
     #      | qarg ';'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 # optional program types
 amazon-braket-sdk>=1.83.0,<1.101.0
-cirq-core>=1.3,<1.5
-cudaq>=0.9.0; python_version < "3.13"
+cirq-core>=1.3,<1.6
+# cudaq>=0.9.0; python_version < "3.13"
 pennylane>=0.42.3,<0.43
 pyquil>=4.4; python_version < "3.13"
 qcs-sdk-python>=0.21.12,<0.21.19; python_version < "3.13"
@@ -11,9 +11,9 @@ qiskit>=1.0,<3.0
 # transpiler extras
 ply>=3.6
 bloqade-analog>=0.16.2,<0.17.0; python_version < "3.13"
-cirq-ionq>=1.3,<1.5
+cirq-ionq>=1.3,<1.6
 qbraid-qir>=0.2.0,<=0.4.0
-pytket-braket>=0.35.1,<0.45.0
+pytket-braket>=0.35.1,<0.44.0
 qiskit-qasm3-import>=0.5.1
 qiskit-aer>=0.15.0; python_version < "3.13"
 qiskit-qir

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 # optional program types
 amazon-braket-sdk>=1.83.0,<1.101.0
 cirq-core>=1.3,<1.6
-# cudaq>=0.9.0; python_version < "3.13"
+cudaq>=0.9.0; python_version < "3.13"
 pennylane>=0.42.3,<0.43
 pyquil>=4.4; python_version < "3.13"
 qcs-sdk-python>=0.21.12,<0.21.19; python_version < "3.13"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ ply>=3.6
 bloqade-analog>=0.16.2,<0.17.0; python_version < "3.13"
 cirq-ionq>=1.3,<1.6
 qbraid-qir>=0.2.0,<=0.4.0
-pytket-braket>=0.35.1,<0.44.0
+pytket-braket>=0.35.1,<0.45.0
 qiskit-qasm3-import>=0.5.1
 qiskit-aer>=0.15.0; python_version < "3.13"
 qiskit-qir

--- a/tests/transpiler/cirq/test_conversions_cirq.py
+++ b/tests/transpiler/cirq/test_conversions_cirq.py
@@ -18,11 +18,11 @@ import cirq
 import numpy as np
 import pytest
 
+from qbraid.interface.circuit_equality import circuits_allclose
 from qbraid.programs import NATIVE_REGISTRY, load_program
 from qbraid.transpiler.conversions import conversion_functions
 from qbraid.transpiler.converter import transpile
 from qbraid.transpiler.graph import ConversionGraph
-from qbraid.interface.circuit_equality import circuits_allclose
 
 
 def find_cirq_targets(skip: Optional[list[str]] = None):
@@ -38,6 +38,7 @@ def find_cirq_targets(skip: Optional[list[str]] = None):
 
 
 TARGETS = find_cirq_targets()
+
 
 @pytest.mark.parametrize("frontend", TARGETS)
 def test_convert_circuit_operation_from_cirq(frontend):
@@ -63,6 +64,7 @@ def test_convert_circuit_operation_from_cirq(frontend):
 
     assert np.allclose(cirq_unitary, test_unitary)
 
+
 @pytest.mark.parametrize("frontend", TARGETS)
 def test_convert_circuit_with_global_phase_from_cirq(frontend):
     """Test converting Cirq circuit with global phase to PyQuil"""
@@ -72,14 +74,13 @@ def test_convert_circuit_with_global_phase_from_cirq(frontend):
     graph = ConversionGraph()
 
     if not graph.has_path("cirq", frontend):
-        pytest.skip(f"conversion from cirq to {frontend} not yet supported")    
-    
+        pytest.skip(f"conversion from cirq to {frontend} not yet supported")
+
     test_circuit = transpile(cirq_circuit, frontend, conversion_graph=graph)
 
     try:
-        test_unitary = load_program(test_circuit).unitary()
+        load_program(test_circuit).unitary()
     except NotImplementedError:
         pytest.skip(f"Unitary calculation not implemented for {frontend}")
 
     assert circuits_allclose(cirq_circuit, test_circuit)
-

--- a/tests/transpiler/cirq/test_conversions_cirq.py
+++ b/tests/transpiler/cirq/test_conversions_cirq.py
@@ -36,28 +36,11 @@ def find_cirq_targets(skip: Optional[list[str]] = None):
                 cirq_targets.append(target_library)
     return cirq_targets
 
-def frozencircuit_operation_circuit():
-    q0 = cirq.NamedQubit("q0")
-    return cirq.Circuit(
-        cirq.Y(q0), cirq.CircuitOperation(cirq.FrozenCircuit(cirq.X(q0)), repetitions=5), cirq.Z(q0)
-    )       
-
-def global_phase_operation_circuit():
-    q0, q1 = cirq.NamedQubit("q0"), cirq.NamedQubit("q1")
-    return cirq.Circuit(
-        cirq.Y(q1).controlled_by(q0)
-    )
 
 TARGETS = find_cirq_targets()
 
-CIRCUITS = [
-    frozencircuit_operation_circuit(),
-    global_phase_operation_circuit()
-]
-
 @pytest.mark.parametrize("frontend", TARGETS)
-@pytest.mark.parametrize("cirq_circuit", CIRCUITS)
-def test_convert_circuit_operation_from_cirq(frontend, cirq_circuit):
+def test_convert_circuit_operation_from_cirq(frontend):
     """Test converting Cirq FrozenCircuit operation to OpenQASM"""
     q = cirq.NamedQubit("q")
     cirq_circuit = cirq.Circuit(
@@ -78,8 +61,25 @@ def test_convert_circuit_operation_from_cirq(frontend, cirq_circuit):
     except NotImplementedError:
         pytest.skip(f"Unitary calculation not implemented for {frontend}")
 
+    assert np.allclose(cirq_unitary, test_unitary)
+
+@pytest.mark.parametrize("frontend", TARGETS)
+def test_convert_circuit_with_global_phase_from_cirq(frontend):
+    """Test converting Cirq circuit with global phase to PyQuil"""
+    q0, q1 = cirq.NamedQubit("q0"), cirq.NamedQubit("q1")
+    cirq_circuit = cirq.Circuit(cirq.Y(q1).controlled_by(q0))
+
+    graph = ConversionGraph()
+
+    if not graph.has_path("cirq", frontend):
+        pytest.skip(f"conversion from cirq to {frontend} not yet supported")    
+    
+    test_circuit = transpile(cirq_circuit, frontend, conversion_graph=graph)
+
     try:
-        assert np.allclose(cirq_unitary, test_unitary)
-    except AssertionError:
-        # check if they are equivalent up to a global phase
-        assert circuits_allclose(cirq_circuit, test_circuit)
+        test_unitary = load_program(test_circuit).unitary()
+    except NotImplementedError:
+        pytest.skip(f"Unitary calculation not implemented for {frontend}")
+
+    assert circuits_allclose(cirq_circuit, test_circuit)
+


### PR DESCRIPTION
Fixes #977 

## Summary of changes
This PR updates the QASM Parser and related code for Cirq to PyQuil transpilation. 

The [Cirq v1.5 Parser](https://github.com/quantumlib/Cirq/blob/7fe741bfbce2a58f803ecb04d577bb45802fb2f4/cirq-core/cirq/contrib/qasm_import/_parser.py#L515) separated `pi` from `terms`, requiring a small addition to the `cirq_qasm_parser.py`.

This resolved all QASM Parser issues, except for the decomposition of some gates (like Controlled-Y) which now include a `cirq.global_phase_operation()`. Since the QASM Parser does not recognize this operation, the code around the decomposition was modified to **NOT** send the global phase to the QASM Parser. 

Tests were added for `cirq.global_phase_operation()` to ensure the transpilation use-case is handled properly.

> [!NOTE]
> The [Cirq v1.5 parser](https://github.com/quantumlib/Cirq/blob/v1.5.0/cirq-core/cirq/contrib/qasm_import/_parser.py) includes additional changes and the [parser tests](https://github.com/quantumlib/Cirq/blob/v1.5.0/cirq-core/cirq/contrib/qasm_import/_parser_test.py) include tests for reset and two qubit gate parameters. If the tests are added to `test_qasm_parser.py`, these new tests fail. However, all existing tests pass using `tox` command from the [CONTRIBUTING.md](github.com/qBraid/qBraid/blob/6c919f6d767d27f5b2009faa6d508cb9cbb52464/CONTRIBUTING.md#testing).