### PR TITLE
Update qiskit runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ pyqubo = ["pyqubo>=1.4.0"]
 pyquil = ["pyquil>=4.4", "qcs-sdk-python>=0.21.12,<0.21.19"]
 pytket = ["pytket>=1.31"]
 qir = ["qbraid-qir>=0.2.0,<=0.4.0", "qbraid-core[runner]>=0.1.39"]
-qiskit = ["qiskit>=1.0,<3.0", "qiskit-ibm-runtime>=0.25.0,<0.42", "qiskit-qasm3-import>=0.5.1", "packaging>=20.0"]
+qiskit = ["qiskit>=1.0,<3.0", "qiskit-ibm-runtime>=0.39.0,<0.42", "qiskit-qasm3-import>=0.5.1", "packaging>=20.0"]
 quera = ["flair-visual[vis]>=0.5.3", "pandas"]
 visualization = ["ipython", "matplotlib", "pylatexenc", "ipympl", "pyqasm[visualization]"]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,7 +22,7 @@ pyqpanda3>=0.2.0; python_version < "3.13"
 autoqasm>=0.1.2,<0.2
 
 # optional runtime dependencies
-qiskit-ibm-runtime>=0.25.0,<0.42
+qiskit-ibm-runtime>=0.39.0,<0.42
 oqc-qcaas-client>=3.11.0; python_version < "3.13"
 azure-quantum>=2.0,<2.3
 azure-storage-blob>=12.20,<13.0


### PR DESCRIPTION

## Summary of changes
This update is required to adhere to the changes introduced in authentication for IBM Quantum REST API

* Increased the minimum version of `qiskit-ibm-runtime` from `0.25.0` to `0.39.0` in the `qiskit` extra within `pyproject.toml`, while keeping the upper bound at `<0.42`.
* Updated the `qiskit-ibm-runtime` version in `requirements-dev.txt` to match the new minimum requirement (`>=0.39.0,<0.42`).