### PR TITLE
Pad measurement to non-contiguous qubits for IonQ device

### DIFF
--- a/qbraid/programs/gate_model/braket.py
+++ b/qbraid/programs/gate_model/braket.py
@@ -134,9 +134,10 @@ class BraketCircuit(GateModelProgram):
         (e.g., IonQ devices).
 
         This method identifies qubits that already have measurement instructions (partial
-        measurements) and adds measurement instructions to all remaining qubits. It stores
-        the list of originally measured qubits as an attribute for later use in result
-        processing.
+        measurements) and adds measurement instructions to all remaining qubits from qubit 0
+        to qubit N, where N is the highest qubit index. A measurement is added even if a
+        qubit has no gate. The list of originally measured qubits is stored as an attribute
+        for later use in the result processing.
 
         The method modifies the circuit in-place and sets the `partial_measurement_qubits`
         attribute on the program object to track which qubits were originally measured
@@ -154,8 +155,9 @@ class BraketCircuit(GateModelProgram):
         if len(partial_measurement_qubits) == 0:
             return
 
-        # Add measurements to all qubits that don't already have them
-        for qubit in self._program.qubits:
+        # Add measurements on qubit 0 to N if any of them doesn't already have a
+        # measurement. N is the highest qubit index in the circuit.
+        for qubit in range(max(self._program.qubits)+1):
             if qubit not in partial_measurement_qubits:
                 self._program.measure(qubit)
 

--- a/qbraid/programs/gate_model/braket.py
+++ b/qbraid/programs/gate_model/braket.py
@@ -151,8 +151,11 @@ class BraketCircuit(GateModelProgram):
             if isinstance(instruction.operator, Measure):
                 partial_measurement_qubits.append(int(instruction.target[0]))
 
-        # Only apply padding when there is partial measurement
-        if len(partial_measurement_qubits) == 0:
+        # Only apply padding when there is partial measurement or there is non-continguous qubits
+        if (
+            len(partial_measurement_qubits) == 0
+            and max(self._program.qubits) + 1 == self._program.qubit_count
+        ):
             return
 
         # Add measurements on qubit 0 to N if any of them doesn't already have a

--- a/qbraid/programs/gate_model/braket.py
+++ b/qbraid/programs/gate_model/braket.py
@@ -157,7 +157,7 @@ class BraketCircuit(GateModelProgram):
 
         # Add measurements on qubit 0 to N if any of them doesn't already have a
         # measurement. N is the highest qubit index in the circuit.
-        for qubit in range(max(self._program.qubits)+1):
+        for qubit in range(max(self._program.qubits) + 1):
             if qubit not in partial_measurement_qubits:
                 self._program.measure(qubit)
 

--- a/qbraid/runtime/aws/device.py
+++ b/qbraid/runtime/aws/device.py
@@ -114,13 +114,20 @@ class BraketDevice(QuantumDevice):
             )
 
         # Use Tket to transform circuits for IonQ to support a bigger gateset. The transformation
-        # only applies when no measurement is presented in the circuit.
+        # only applies when no measurement is presented and the circuit only use contiguous qubits.
+        has_contiguous_qubits = False
         includes_measurement = False
         if isinstance(run_input, Circuit):
             includes_measurement = any(
                 isinstance(instruction.operator, Measure) for instruction in run_input.instructions
             )
-        if provider == "IONQ" and isinstance(run_input, Circuit) and not includes_measurement:
+            has_contiguous_qubits = max(run_input.qubits) + 1 == run_input.qubit_count
+        if (
+            provider == "IONQ"
+            and isinstance(run_input, Circuit)
+            and not includes_measurement
+            and has_contiguous_qubits
+        ):
             graph = self.scheme.conversion_graph
             if (
                 graph is not None


### PR DESCRIPTION
## Summary of changes
This PR improves the measurement handling for circuits when running on IonQ devices and Braket simulators by ensuring all qubits in the range [0, N] are measured, where N is the highest qubit index used in the circuit. This is to satisfy the device's requirement that all qubit from [0, N] must be measured. (That is, even if qubit 0 and qubit 2 have gates, qubit 1 needs to be measured too).

