### PR TITLE
Catch validation errors in rt flow if option set to none/warn

### DIFF
--- a/qbraid/runtime/device.py
+++ b/qbraid/runtime/device.py
@@ -47,7 +47,6 @@ from .options import RuntimeOptions
 if TYPE_CHECKING:
     import qbraid.programs
     import qbraid.runtime
-    import qbraid.transpiler
 
 
 class QuantumDevice(ABC):
@@ -103,6 +102,11 @@ class QuantumDevice(ABC):
         if not self._scheme.conversion_graph:
             self._scheme.update_values(conversion_graph=ConversionGraph(include_isolated=True))
         return self._scheme
+
+    @property
+    def options(self) -> RuntimeOptions:
+        """Return the runtime options."""
+        return self._options
 
     def __repr__(self):
         """Return a string representation of the device."""


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

- Within the `QbraidDevice.run` pipeline, if `load_program` fails while constructing the auxillary payload and if the user has switched off program validation (i.e. `RuntimeOptions` "validate" option set to `ValidationLevel.WARN` or `ValidationLevel.NONE`) then return aux payload as empty dict instead of raising exception, and let job submission go through.
- Add public property `options` to `QbraidDevice` (returns `RuntimeOptions` so can inspect after setting via `QbraidDevice.set_options(...)`)
