### PR TITLE
Add: legacy jobs support for QbraidProvider

### DIFF
--- a/qbraid/runtime/postprocess.py
+++ b/qbraid/runtime/postprocess.py
@@ -140,7 +140,8 @@ def format_data(
                 if num_bits > 20:
                     warnings.warn(
                         f"Generating all {2**num_bits:,} possible states for {num_bits} qubits. "
-                        f"This may consume significant memory. Consider using include_zero_values=False."
+                        "This may consume significant memory. "
+                        "Consider using include_zero_values=False."
                     )
                 all_keys = [format(i, f"0{num_bits}b") for i in range(2**num_bits)]
                 data = {key: normalized_data.get(key, 0) for key in all_keys}

--- a/tests/runtime/_resources.py
+++ b/tests/runtime/_resources.py
@@ -540,7 +540,9 @@ class MockClient:
         }
         return RuntimeJob.model_validate(job_response)
 
-    def get_job(self, job_qrn: str) -> RuntimeJob:
+    def get_job(
+        self, job_qrn: str, legacy_jobs_path=None
+    ) -> RuntimeJob:  # pylint: disable=unused-argument
         """Returns the metadata for a specific quantum job."""
         # Try job QRN mapping first
         device_qrn = self.JOB_QRN_TO_DEVICE.get(job_qrn)
@@ -565,7 +567,9 @@ class MockClient:
 
         return RuntimeJob.model_validate(job_data_copy)
 
-    def get_job_result(self, job_qrn: str) -> Result:
+    def get_job_result(
+        self, job_qrn: str, legacy_jobs_path=None
+    ) -> Result:  # pylint: disable=unused-argument
         """Returns the results for a specific quantum job."""
         # Try job QRN mapping first
         device_qrn = self.JOB_QRN_TO_DEVICE.get(job_qrn)
@@ -598,7 +602,9 @@ class MockClient:
         }
         return Result.model_validate(result_response)
 
-    def get_job_program(self, job_qrn: str) -> Program:
+    def get_job_program(
+        self, job_qrn: str, legacy_jobs_path=None
+    ) -> Program:  # pylint: disable=unused-argument
         """Returns the program data for a specific quantum job."""
         # Return a mock program for AQUILA
         if "aquila" in job_qrn.lower() or "quera" in job_qrn.lower():


### PR DESCRIPTION
## Summary of changes
Dependency : https://github.com/qBraid/qbraid-core/pull/209

- Added a `legacy_jobs_path` for the `QbraidProvider` 
- If this path is provided AND `download_legacy_jobs` is called for the provider, the user can safely retrieve their old jobs with the qbraid sdk. 
- Added the `get_jobs` method which will auto-retrieve new / legacy jobs depending on how the provider was initialized
- Tested with `staging` API and works for legacy jobs stored in the GCS buckets