### PR TITLE
Fix classical bit collisions in Braket pad_measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Types of changes:
 ### Fixed
 - Fixed pyqpanda3-to-QASM2 conversion emitting invalid `creg c[0]` declarations, which caused downstream parsers to reject the output and broke round-trip conversions (e.g. `cirq → pyqpanda3 → cirq`)
 - Fixed azure-quantum version mismatch in development requirements to align with package optional dependency constraints ([#1135](https://github.com/qBraid/qBraid/pull/1135))
+- Fixed classical bit collisions in Braket `pad_measurements` method by detecting internal collisions, padding collisions, and out-of-range indices; rebases existing measures to sequential indices when necessary to ensure valid QASM output ([#1160](https://github.com/qBraid/qBraid/pull/1160))
+- Fixed `BraketQuantumTask._get_partial_measurement_qubits_from_tags` to return `None` and log warning when tag qubits are missing from result measurements, preventing crashes during result processing ([#1160](https://github.com/qBraid/qBraid/pull/1160))
 
 ### Dependencies
 - Updated `azure-quantum` optional dependency from `>=2.0,<2.3` to `>=3.6.0,<4.0`; removed `azure-identity` from the `azure` extra ([#1125](https://github.com/qBraid/qBraid/pull/1125))

--- a/qbraid/programs/gate_model/braket.py
+++ b/qbraid/programs/gate_model/braket.py
@@ -151,10 +151,14 @@ class BraketCircuit(GateModelProgram):
         all qubits and no padding is applied.
         """
         # Track qubits that already have measurement instructions
-        partial_measurement_qubits: list[int] = []
-        for instruction in self._program.instructions:
-            if isinstance(instruction.operator, Measure):
-                partial_measurement_qubits.append(int(instruction.target[0]))
+        existing_measures = [
+            instruction
+            for instruction in self._program.instructions
+            if isinstance(instruction.operator, Measure)
+        ]
+        partial_measurement_qubits: list[int] = [
+            int(instruction.target[0]) for instruction in existing_measures
+        ]
 
         # Only apply padding when there is partial measurement or there is non-continguous qubits
         if (
@@ -163,11 +167,51 @@ class BraketCircuit(GateModelProgram):
         ):
             return
 
+        qubits_to_pad = [
+            qubit
+            for qubit in range(max(self._program.qubits) + 1)
+            if qubit not in partial_measurement_qubits
+        ]
+
+        # A Braket ``Measure`` carries a ``_target_index`` that becomes the classical bit slot
+        # when the circuit is serialized back to QASM. Three failure modes can silently corrupt
+        # the emitted program, and we need to detect all of them before adding padded measures:
+        #
+        # 1. Internal collision. ``Circuit.from_ir`` reads each measure's target index literally
+        #    from the source, so a program using multiple classical registers (e.g.
+        #    ``a[0] = measure q[0]`` and ``b[0] = measure q[2]``) lands with two measures sharing
+        #    ``_target_index == 0`` and one will clobber the other on serialization.
+        # 2. Padding collision. ``Circuit.measure(q)`` does not use ``q`` as the bit index; it
+        #    assigns ``_target_index = len(_measure_targets)``, a running counter. The padded
+        #    measures we are about to add will therefore land on indices
+        #    ``[k, k+1, ..., k+m-1]`` where ``k`` is the current measure count and ``m`` is the
+        #    number of qubits to pad. If any existing measure already sits in that range, it
+        #    collides with a padded measure.
+        # 3. Out-of-range index. Braket emits ``bit[qubit_count] b`` regardless of the target
+        #    indices, so any existing measure with ``_target_index >= qubit_count`` produces
+        #    invalid QASM.
+        #
+        # When any of these would corrupt the output, rebase every existing measure to a
+        # sequential ``[0, 1, ..., k-1]`` in instruction order. That leaves ``[k, k+m-1]`` free
+        # for the padded measures (matching Braket's counter) and keeps every index under
+        # ``qubit_count``. Circuits whose user-supplied bit labels are already safe are left
+        # untouched so ``b[5] = measure q[0]`` round-trips as written.
+        existing_indices = [m.operator._target_index for m in existing_measures]
+        qubit_count = self._program.qubit_count
+        padded_index_range = range(
+            len(existing_measures), len(existing_measures) + len(qubits_to_pad)
+        )
+        has_internal_collision = len(set(existing_indices)) != len(existing_indices)
+        has_padding_collision = any(idx in padded_index_range for idx in existing_indices)
+        has_out_of_range = any(idx >= qubit_count for idx in existing_indices)
+        if has_internal_collision or has_padding_collision or has_out_of_range:
+            for new_index, measure in enumerate(existing_measures):
+                measure.operator._target_index = new_index
+
         # Add measurements on qubit 0 to N if any of them doesn't already have a
         # measurement. N is the highest qubit index in the circuit.
-        for qubit in range(max(self._program.qubits) + 1):
-            if qubit not in partial_measurement_qubits:
-                self._program.measure(qubit)
+        for qubit in qubits_to_pad:
+            self._program.measure(qubit)
 
         # Store the original partial measurement qubits for result processing
         self._program.partial_measurement_qubits = partial_measurement_qubits

--- a/qbraid/runtime/aws/job.py
+++ b/qbraid/runtime/aws/job.py
@@ -185,8 +185,16 @@ class BraketQuantumTask(QuantumJob):
         partial_measurement_qubits_str = response["tags"]["partial_measurement_qubits"]
         partial_measurement_qubits = [int(q) for q in partial_measurement_qubits_str.split("/")]
 
+        missing = [q for q in partial_measurement_qubits if q not in all_measurement_qubits]
+        if missing:
+            logger.warning(
+                "Partial measurement qubits %s from task tag are not present in the result's "
+                "measured qubits %s; skipping partial-measurement filtering. This usually means "
+                "the submitted circuit lost measurements during transpilation.",
+                missing,
+                all_measurement_qubits,
+            )
+            return None
+
         # Map the original qubit indices to their positions in the measurement results array
-        partial_measurement_qubit_indices = [
-            all_measurement_qubits.index(q) for q in partial_measurement_qubits
-        ]
-        return partial_measurement_qubit_indices
+        return [all_measurement_qubits.index(q) for q in partial_measurement_qubits]

--- a/qbraid/runtime/aws/job.py
+++ b/qbraid/runtime/aws/job.py
@@ -183,7 +183,13 @@ class BraketQuantumTask(QuantumJob):
 
         # Parse the partial measurement qubit indices from the tag string (e.g., "0/2/3")
         partial_measurement_qubits_str = response["tags"]["partial_measurement_qubits"]
-        partial_measurement_qubits = [int(q) for q in partial_measurement_qubits_str.split("/")]
+        if not partial_measurement_qubits_str:
+            return None
+        partial_measurement_qubits = [
+            int(q) for q in partial_measurement_qubits_str.split("/") if q
+        ]
+        if not partial_measurement_qubits:
+            return None
 
         missing = [q for q in partial_measurement_qubits if q not in all_measurement_qubits]
         if missing:

--- a/tests/programs/test_program_circuits_braket.py
+++ b/tests/programs/test_program_circuits_braket.py
@@ -16,6 +16,7 @@
 Unit tests for qbraid.programs.braket.BraketCircuit
 
 """
+import re
 from itertools import chain, combinations
 from unittest.mock import Mock
 
@@ -23,6 +24,7 @@ import numpy as np
 import pytest
 from braket.circuits import Circuit, Instruction, gates
 from braket.circuits.measure import Measure
+from braket.circuits.serialization import IRType
 
 from qbraid.programs import ProgramTypeError
 from qbraid.programs.gate_model.braket import BraketCircuit
@@ -298,6 +300,18 @@ def _measure_target_indices(circuit: Circuit) -> list[int]:
     ]
 
 
+def _assert_serialized_qasm_has_unique_bits(
+    qprogram: BraketCircuit, expected_measures: int
+) -> None:
+    """Emit OpenQASM from the Braket Circuit and verify the measurement declarations
+    map to unique classical bit indices, one per measure, all within ``qubit_count``."""
+    source = qprogram.program.to_ir(IRType.OPENQASM).source
+    bit_indices = [int(m) for m in re.findall(r"b\[(\d+)\]\s*=\s*measure\b", source)]
+    assert len(bit_indices) == expected_measures
+    assert len(set(bit_indices)) == expected_measures
+    assert all(idx < qprogram.program.qubit_count for idx in bit_indices)
+
+
 def _force_measure_target_index(circuit: Circuit, qubit: int, target_index: int) -> None:
     # Simulate what ``Circuit.from_ir`` does when the source QASM uses a literal bit index
     # that does not match Braket's own counter-based convention for ``Measure._target_index``.
@@ -325,6 +339,7 @@ def test_pad_measurements_rebases_multi_register_collision():
 
     assert _measure_target_indices(qprogram.program) == [0, 1, 2, 3]
     assert qprogram.program.partial_measurement_qubits == [0, 1, 2, 3]
+    _assert_serialized_qasm_has_unique_bits(qprogram, expected_measures=4)
 
 
 def test_pad_measurements_rebases_when_padding_would_collide():
@@ -343,6 +358,9 @@ def test_pad_measurements_rebases_when_padding_would_collide():
     assert len(target_indices) == len(set(target_indices))
     assert max(target_indices) < qprogram.program.qubit_count
     assert qprogram.program.partial_measurement_qubits == [0]
+    _assert_serialized_qasm_has_unique_bits(
+        qprogram, expected_measures=qprogram.program.qubit_count
+    )
 
 
 def test_pad_measurements_rebases_out_of_range_target_index():
@@ -359,6 +377,9 @@ def test_pad_measurements_rebases_out_of_range_target_index():
     target_indices = _measure_target_indices(qprogram.program)
     assert all(idx < qprogram.program.qubit_count for idx in target_indices)
     assert len(target_indices) == len(set(target_indices))
+    _assert_serialized_qasm_has_unique_bits(
+        qprogram, expected_measures=qprogram.program.qubit_count
+    )
 
 
 def test_pad_measurements_preserves_safe_user_labels():
@@ -378,6 +399,7 @@ def test_pad_measurements_preserves_safe_user_labels():
     assert target_indices[:2] == [0, 1]  # preserved, not rebased
     assert len(target_indices) == 4
     assert len(set(target_indices)) == 4
+    _assert_serialized_qasm_has_unique_bits(qprogram, expected_measures=4)
 
 
 def test_replace_i_with_rz_zero():

--- a/tests/programs/test_program_circuits_braket.py
+++ b/tests/programs/test_program_circuits_braket.py
@@ -22,6 +22,7 @@ from unittest.mock import Mock
 import numpy as np
 import pytest
 from braket.circuits import Circuit, Instruction, gates
+from braket.circuits.measure import Measure
 
 from qbraid.programs import ProgramTypeError
 from qbraid.programs.gate_model.braket import BraketCircuit
@@ -287,6 +288,96 @@ def test_transform_with_other_provider():
     )
     assert measurement_count == 1
     assert not hasattr(qprogram.program, "partial_measurement_qubits")
+
+
+def _measure_target_indices(circuit: Circuit) -> list[int]:
+    return [
+        instr.operator._target_index
+        for instr in circuit.instructions
+        if isinstance(instr.operator, Measure)
+    ]
+
+
+def _force_measure_target_index(circuit: Circuit, qubit: int, target_index: int) -> None:
+    # Simulate what ``Circuit.from_ir`` does when the source QASM uses a literal bit index
+    # that does not match Braket's own counter-based convention for ``Measure._target_index``.
+    for instr in circuit.instructions:
+        if isinstance(instr.operator, Measure) and int(instr.target[0]) == qubit:
+            instr.operator._target_index = target_index
+            return
+    raise AssertionError(f"no measure instruction targeting qubit {qubit}")
+
+
+def test_pad_measurements_rebases_multi_register_collision():
+    """Multiple classical registers in the source QASM collapse into colliding
+    ``_target_index`` values after ``Circuit.from_ir``. ``pad_measurements`` must detect
+    the internal collision and rebase every existing measure so the final QASM emits a
+    unique classical bit per measurement."""
+    circuit = Circuit().h(0).h(1).h(2).h(3).measure(0).measure(1).measure(2).measure(3)
+    # Emulate: a[0]=q[0], a[1]=q[1], b[0]=q[2], b[1]=q[3] — indices collide across registers
+    _force_measure_target_index(circuit, 0, 0)
+    _force_measure_target_index(circuit, 1, 1)
+    _force_measure_target_index(circuit, 2, 0)
+    _force_measure_target_index(circuit, 3, 1)
+
+    qprogram = BraketCircuit(circuit)
+    qprogram.pad_measurements()
+
+    assert _measure_target_indices(qprogram.program) == [0, 1, 2, 3]
+    assert qprogram.program.partial_measurement_qubits == [0, 1, 2, 3]
+
+
+def test_pad_measurements_rebases_when_padding_would_collide():
+    """When an existing measure's ``_target_index`` lies within the range that Braket's
+    counter-based ``.measure()`` will assign to padded measures, those indices collide.
+    ``pad_measurements`` must rebase the existing measure before padding."""
+    circuit = Circuit().h(0).h(5).measure(0)
+    # User wrote ``c[5] = measure q[0]`` — target_index 5 will clash with the padded
+    # measure for qubit 5, which Braket's counter assigns to index 5 as well.
+    _force_measure_target_index(circuit, 0, 5)
+
+    qprogram = BraketCircuit(circuit)
+    qprogram.pad_measurements()
+
+    target_indices = _measure_target_indices(qprogram.program)
+    assert len(target_indices) == len(set(target_indices))
+    assert max(target_indices) < qprogram.program.qubit_count
+    assert qprogram.program.partial_measurement_qubits == [0]
+
+
+def test_pad_measurements_rebases_out_of_range_target_index():
+    """A user-written ``_target_index`` greater than or equal to ``qubit_count`` produces
+    invalid QASM, because Braket emits ``bit[qubit_count] b``. ``pad_measurements`` must
+    rebase such measures even when there is no direct collision."""
+    circuit = Circuit().h(0).h(1).h(2).h(3).measure(0)
+    # User wrote ``c[10] = measure q[0]`` on a 4-qubit circuit — out of Braket's emission range.
+    _force_measure_target_index(circuit, 0, 10)
+
+    qprogram = BraketCircuit(circuit)
+    qprogram.pad_measurements()
+
+    target_indices = _measure_target_indices(qprogram.program)
+    assert all(idx < qprogram.program.qubit_count for idx in target_indices)
+    assert len(target_indices) == len(set(target_indices))
+
+
+def test_pad_measurements_preserves_safe_user_labels():
+    """When the existing measures' ``_target_index`` values are unique, in range, and
+    do not overlap with the slots Braket's counter will assign to padded measures,
+    ``pad_measurements`` must leave them untouched so user-chosen bit labels round-trip
+    through serialization unchanged."""
+    circuit = Circuit().h(0).h(1).h(2).h(3).measure(0).measure(1)
+    # Sequential, in-range, no overlap with padded range [2, 3] — safe to preserve.
+    _force_measure_target_index(circuit, 0, 0)
+    _force_measure_target_index(circuit, 1, 1)
+
+    qprogram = BraketCircuit(circuit)
+    qprogram.pad_measurements()
+
+    target_indices = _measure_target_indices(qprogram.program)
+    assert target_indices[:2] == [0, 1]  # preserved, not rebased
+    assert len(target_indices) == 4
+    assert len(set(target_indices)) == 4
 
 
 def test_replace_i_with_rz_zero():

--- a/tests/runtime/aws/test_braket_runtime.py
+++ b/tests/runtime/aws/test_braket_runtime.py
@@ -21,6 +21,7 @@ Unit tests for BraketProvider class
 import datetime
 import importlib.util
 import json
+import logging
 import warnings
 from unittest.mock import MagicMock, Mock, patch
 
@@ -867,6 +868,33 @@ def test_get_partial_measurement_qubits_from_tags_without_partial_measurements(m
     assert result is None
 
     mock_client.get_quantum_task.assert_called_once_with(quantumTaskArn="task1")
+
+
+@patch("boto3.client")
+def test_get_partial_measurement_qubits_from_tags_mismatch_returns_none(mock_boto_client, caplog):
+    """If the tag's qubits are not all present in the result's measured qubits, the method
+    must log a warning and return ``None`` instead of crashing with ``ValueError``. This
+    degraded-but-inspectable path lets users still load results from tasks whose submitted
+    QASM dropped measurements upstream (e.g. the multi-register collision bug in
+    ``pad_measurements``)."""
+    mock_client = MagicMock()
+    mock_boto_client.return_value = mock_client
+    mock_client.get_quantum_task.return_value = {
+        "tags": {"partial_measurement_qubits": "0/1/2/3/4/5/6/7/8/9"}
+    }
+
+    task = MockTask("task1")
+    braket_task = BraketQuantumTask("task1", task)
+
+    # Mimics the corrupted task the bug was reported on: tag says 0..9 are partial,
+    # but Braket's ``measured_qubits`` only contains the qubits that survived submission.
+    all_measurement_qubits = [6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+
+    with caplog.at_level(logging.WARNING, logger="qbraid"):
+        result = braket_task._get_partial_measurement_qubits_from_tags(all_measurement_qubits)
+
+    assert result is None
+    assert any("partial measurement" in record.message.lower() for record in caplog.records)
 
 
 @patch("boto3.client")

--- a/tests/runtime/aws/test_braket_runtime.py
+++ b/tests/runtime/aws/test_braket_runtime.py
@@ -897,6 +897,29 @@ def test_get_partial_measurement_qubits_from_tags_mismatch_returns_none(mock_bot
     assert any("partial measurement" in record.message.lower() for record in caplog.records)
 
 
+@pytest.mark.parametrize(
+    "tag_value",
+    ["", "/", "//"],
+    ids=["empty_string", "single_separator", "double_separator"],
+)
+@patch("boto3.client")
+def test_get_partial_measurement_qubits_from_tags_empty_tag_returns_none(
+    mock_boto_client, tag_value
+):
+    """An empty or separator-only ``partial_measurement_qubits`` tag must be treated as
+    absent rather than crashing with ``ValueError`` from ``int("")``."""
+    mock_client = MagicMock()
+    mock_boto_client.return_value = mock_client
+    mock_client.get_quantum_task.return_value = {"tags": {"partial_measurement_qubits": tag_value}}
+
+    task = MockTask("task1")
+    braket_task = BraketQuantumTask("task1", task)
+
+    result = braket_task._get_partial_measurement_qubits_from_tags([0, 1, 2])
+
+    assert result is None
+
+
 @patch("boto3.client")
 def test_get_partial_measurement_qubits_from_tags_complex_mapping(mock_boto_client):
     """Test partial measurement qubit mapping with non-contiguous qubits."""


### PR DESCRIPTION
# Summary of Changes

## Problem

qBraid submits OpenQASM 3 programs to Braket via `Circuit.from_ir → pad_measurements → Circuit.to_ir`. Two flaws in that round trip can silently drop measurements:

**1. `Circuit.from_ir` reads classical bit indices literally from the source.** When a user's program uses multiple classical registers, Braket stores the literal bit index in each `Measure._target_index`. Two registers sharing index `0` produce two measures with `_target_index == 0`, and on re-serialization they overwrite the same bit.

**2. `Circuit.measure(q)` assigns `_target_index` from a running counter**, not from `q`. So padded measures occupy slots `[k, k+m-1]` — and if an existing measure already sits in that range, padding collides with it.

### Concrete example

Input from a real task (trimmed):

```qasm
OPENQASM 3.0;
qubit[16] q;
bit[2] sel;
bit[2] reg_A;
bit[2] reg_B;
bit[4] reg_P;
// ... gates ...
sel[0]   = measure q[0];
sel[1]   = measure q[1];
reg_A[0] = measure q[2];
reg_A[1] = measure q[3];
reg_B[0] = measure q[4];
reg_B[1] = measure q[5];
reg_P[0] = measure q[6];
reg_P[1] = measure q[7];
reg_P[2] = measure q[8];
reg_P[3] = measure q[9];
```

After `Circuit.from_ir`, the ten measures land with `_target_index = [0, 1, 0, 1, 0, 1, 0, 1, 2, 3]` — four collisions on slot `0`, four on slot `1`. `pad_measurements` then adds measurements for `q[10..15]` via `Circuit.measure()`, which assigns indices starting at `len(_measure_targets) == 10`, i.e. `[10, 11, 12, 13, 14, 15]`.

The QASM that Braket actually submits to IonQ Forte-1:

```qasm
bit[16] b;
...
b[0] = measure q[0];
b[1] = measure q[1];
b[0] = measure q[2];   // clobbers b[0]
b[1] = measure q[3];   // clobbers b[1]
b[0] = measure q[4];   // clobbers b[0]
b[1] = measure q[5];   // clobbers b[1]
b[0] = measure q[6];   // clobbers b[0] — survives
b[1] = measure q[7];   // clobbers b[1] — survives
b[2] = measure q[8];
b[3] = measure q[9];
b[10] = measure q[10];
b[11] = measure q[11];
b[12] = measure q[12];
b[13] = measure q[13];
b[14] = measure q[14];
b[15] = measure q[15];
```

Only the **last** write to each bit survives. The task runs and returns `measured_qubits = [6, 7, 8, 9, 10, 11, 12, 13, 14, 15]` — the original measurements of `q[0..5]` are silently lost, and the 10-bit result has nothing to do with what the user wrote.

On top of that, loading the corrupted task crashes:

```
File "qbraid/runtime/aws/job.py", line 190, in <listcomp>
    all_measurement_qubits.index(q) for q in partial_measurement_qubits
ValueError: 0 is not in list
```

because `_get_partial_measurement_qubits_from_tags` assumes the task tag `partial_measurement_qubits=0/1/2/3/4/5/6/7/8/9` is a subset of the result's `measured_qubits`, and raises on `list.index` when it is not.

## Fix

**`pad_measurements` (`qbraid/programs/gate_model/braket.py`)** — before adding padded measures, detect three failure modes:

1. **Internal collision** — two existing measures share `_target_index`.
2. **Padding collision** — an existing `_target_index` lies in `[k, k+m-1]`, the range Braket's counter will assign to padded measures.
3. **Out-of-range** — an existing `_target_index >= qubit_count`, which breaks Braket's `bit[qubit_count] b` emission.

When any of the three is present, rebase existing measures to sequential slots `[0..k-1]` in instruction order. Circuits with unique, in-range, non-overlapping labels are left untouched so user-chosen bit labels round-trip unchanged (e.g. `b[5] = measure q[0]` stays `b[5] = measure q[0]`).

**`_get_partial_measurement_qubits_from_tags` (`qbraid/runtime/aws/job.py`)** — when the tag's qubits are not all present in `bk_result.measured_qubits`, log a warning and return `None` (skipping partial-measurement filtering) instead of crashing. This lets users still load and inspect results from tasks that were submitted before this fix landed.

## Tests

Five new tests cover the edge cases:

- `test_pad_measurements_rebases_multi_register_collision` — reproduces the original bug via colliding `_target_index` values.
- `test_pad_measurements_rebases_when_padding_would_collide` — existing label lands in the counter's padded range.
- `test_pad_measurements_rebases_out_of_range_target_index` — existing label ≥ `qubit_count`.
- `test_pad_measurements_preserves_safe_user_labels` — unique, in-range, no-overlap labels are not rebased.
- `test_get_partial_measurement_qubits_from_tags_mismatch_returns_none` — exercises the `measured_qubits=[6..15]` vs tag `0..9` shape from the real failing task and asserts graceful `None` + warning instead of `ValueError`.

Four of the five fail on `main`; the preservation test passes both before and after (it's the "do nothing" path).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed measurement padding logic to detect and mitigate classical-bit collisions and index conflicts, ensuring valid quantum assembly output with properly sequential measurement indices.
  * Fixed partial measurement result processing to gracefully handle missing or inconsistent measurement tag data by returning appropriate null values and emitting diagnostic warnings instead of crashing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->