### PR TITLE
Drop reset case from qasm3_to_braket error-detail test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Types of changes:
 - Added credential validation check in Azure Quantum test workspace fixture to skip tests when `resource_id` or `credential` are not fully configured ([#1135](https://github.com/qBraid/qBraid/pull/1135))
 - Added skip marker to `test_submit_qasm2_to_quantinuum` due to Quantinuum emulator usage quota exceeded ([#1136](https://github.com/qBraid/qBraid/pull/1136))
 - Added device status checks to QIR simulator remote tests (`test_qir_simulator_qasm_circuit` and `test_qir_simulator_qir_module`) to skip when device is not `ONLINE` ([#1150](https://github.com/qBraid/qBraid/pull/1150))
+- Simplified `test_qasm3_to_braket_error_includes_detail` test by removing reset case and converting from parametrized test to single case testing only the `c3x` undefined gate error ([#1161](https://github.com/qBraid/qBraid/pull/1161))
 
 ### Deprecated
 - `AzureQuantumJob._make_estimator_result` and `OutputDataFormat.RESOURCE_ESTIMATOR` are deprecated; the `microsoft.resource-estimates.v1` output format is no longer emitted by azure-quantum >= 3.x. These will be removed in v0.12 ([#1125](https://github.com/qBraid/qBraid/pull/1125))

--- a/tests/transpiler/braket/test_braket_qasm3.py
+++ b/tests/transpiler/braket/test_braket_qasm3.py
@@ -226,39 +226,16 @@ def test_qasm3_to_braket_prior_errors_included_in_final_error(match_substring):
         qasm3_to_braket(invalid_qasm)
 
 
-@pytest.mark.parametrize(
-    "qasm_input, expected_detail",
-    [
-        (
-            textwrap.dedent(
-                """
-                OPENQASM 3.0;
-                include "stdgates.inc";
-                qubit[4] q;
-                h q[0];
-                c3x q[0], q[1], q[2], q[3];
-            """
-            ).strip(),
-            "c3x is not defined",
-        ),
-        (
-            textwrap.dedent(
-                """
-                OPENQASM 3.0;
-                include "stdgates.inc";
-                bit[1] b;
-                qubit[1] q;
-                h q[0];
-                reset q[0];
-                b[0] = measure q[0];
-            """
-            ).strip(),
-            "Reset not supported",
-        ),
-    ],
-    ids=["undefined_gate_c3x", "unsupported_reset"],
-)
-def test_qasm3_to_braket_error_includes_detail(qasm_input, expected_detail):
+def test_qasm3_to_braket_error_includes_detail():
     """Verify that QasmError includes the specific failure reason from the Braket parser."""
-    with pytest.raises(QasmError, match=expected_detail):
+    qasm_input = textwrap.dedent(
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        qubit[4] q;
+        h q[0];
+        c3x q[0], q[1], q[2], q[3];
+        """
+    ).strip()
+    with pytest.raises(QasmError, match="c3x is not defined"):
         qasm3_to_braket(qasm_input)


### PR DESCRIPTION
## Summary

- Removes the `unsupported_reset` parametrize case from `test_qasm3_to_braket_error_includes_detail`, which was failing intermittently in CI depending on the resolved version of `amazon-braket-default-simulator`.
- The `undefined_gate_c3x` case alone already covers the test's intent (verifying that Braket parser error detail propagates into `QasmError`), so the test is inlined as a non-parametrized function.

## Root cause

The `NotImplementedError: Reset not supported` error isn't raised by `amazon-braket-sdk` — it originates from `amazon-braket-default-simulator`, a transitive dependency that qBraid doesn't pin. Binary-searching versions against `amazon-braket-sdk==1.110.1`:

| `amazon-braket-default-simulator` | `Circuit.from_ir` with `reset` |
|---|---|
| 1.32.0 – 1.34.x | raises `NotImplementedError: Reset not supported` |
| 1.35.0+ | silently parses (reset dropped from circuit) |

CI installs the latest (1.37.0), so the test fails. Dev environments with an older simulator pass. Bumping `amazon-braket-sdk` wouldn't help — the raise was removed upstream in the maintained simulator, and reset is arguably a valid QASM op that shouldn't be rejected. Pinning the simulator backward would preserve behavior the maintainers deliberately dropped, so dropping the case is the cleaner fix.

Failing job: https://github.com/qBraid/qBraid/actions/runs/24351883913/job/71108242471

## Test plan

- [x] `pytest tests/transpiler/braket/test_braket_qasm3.py::test_qasm3_to_braket_error_includes_detail` passes locally
- [x] `tox -e format-check` clean
- [ ] CI passes on Python 3.13