### PR TITLE
Handle failed job results in native runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,6 @@ Types of changes:
 - Added pytest remote tests for QIR simulator device with fixtures for Bell state circuits as both QASM and QIR module formats ([#1136](https://github.com/qBraid/qBraid/pull/1136))
 - Added CodeRabbit configuration file (`.coderabbit.yaml`) to disable automatic code review functionality ([#1162](https://github.com/qBraid/qBraid/pull/1162))
 - Added `@overload` method signatures to `QbraidDevice.submit` method to provide type hints for single `Program` vs `list[Program]` input types ([#1164](https://github.com/qBraid/qBraid/pull/1164))
-- Added comprehensive test for failed job result handling with `MockClientWithFailedJob` and `test_job_result_failed` ([#1164](https://github.com/qBraid/qBraid/pull/1164))
 
 ### Improved / Modified
 - Updated Azure Quantum provider to be compatible with `azure-quantum>=3.6.0`: replaced private `_current_availability` attribute access with public `current_availability` property on `Target`; simplified `AzureQuantumProvider.__init__` to accept only an optional `Workspace` (removed `credential` parameter) ([#1125](https://github.com/qBraid/qBraid/pull/1125))
@@ -58,8 +57,7 @@ Types of changes:
 - Added skip marker to `test_submit_qasm2_to_quantinuum` due to Quantinuum emulator usage quota exceeded ([#1136](https://github.com/qBraid/qBraid/pull/1136))
 - Added device status checks to QIR simulator remote tests (`test_qir_simulator_qasm_circuit` and `test_qir_simulator_qir_module`) to skip when device is not `ONLINE` ([#1150](https://github.com/qBraid/qBraid/pull/1150))
 - Simplified `test_qasm3_to_braket_error_includes_detail` test by removing reset case and converting from parametrized test to single case testing only the `c3x` undefined gate error ([#1161](https://github.com/qBraid/qBraid/pull/1161))
-- Updated type annotations throughout `qbraid.runtime` to use modern union syntax (`|` instead of `Union`) and removed unnecessary imports ([#1164](https://github.com/qBraid/qBraid/pull/1164))
-- Enhanced `QuantumDevice.submit` docstring to clarify that run_input should match the device's accepted program spec ([#1164](https://github.com/qBraid/qBraid/pull/1164))
+- Modernized type annotations throughout `qbraid.runtime` by replacing `Optional[]` and `Union[]` with PEP 604 syntax using `|` operator ([#1164](https://github.com/qBraid/qBraid/pull/1164))
 
 ### Deprecated
 - `AzureQuantumJob._make_estimator_result` and `OutputDataFormat.RESOURCE_ESTIMATOR` are deprecated; the `microsoft.resource-estimates.v1` output format is no longer emitted by azure-quantum >= 3.x. These will be removed in v0.12 ([#1125](https://github.com/qBraid/qBraid/pull/1125))
@@ -71,7 +69,7 @@ Types of changes:
 - Fixed azure-quantum version mismatch in development requirements to align with package optional dependency constraints ([#1135](https://github.com/qBraid/qBraid/pull/1135))
 - Fixed classical bit collisions in Braket `pad_measurements` method by detecting internal collisions, padding collisions, and out-of-range indices; rebases existing measures to sequential indices when necessary to ensure valid QASM output ([#1160](https://github.com/qBraid/qBraid/pull/1160))
 - Fixed `BraketQuantumTask._get_partial_measurement_qubits_from_tags` to return `None` and log warning when tag qubits are missing from result measurements, preventing crashes during result processing ([#1160](https://github.com/qBraid/qBraid/pull/1160))
-- Fixed `QbraidJob.result` method to handle failed jobs by creating a `CoreResult` with empty `resultData` instead of calling `get_job_result`, preventing crashes when processing failed job results ([#1164](https://github.com/qBraid/qBraid/pull/1164))
+- Fixed `QbraidJob.result` method to handle failed jobs by creating a `qbraid_core.services.runtime.schemas.Result` with empty `resultData` instead of calling `get_job_result`, preventing crashes when processing failed job results ([#1164](https://github.com/qBraid/qBraid/pull/1164))
 
 ### Dependencies
 - Updated `azure-quantum` optional dependency from `>=2.0,<2.3` to `>=3.6.0,<4.0`; removed `azure-identity` from the `azure` extra ([#1125](https://github.com/qBraid/qBraid/pull/1125))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ Types of changes:
 - Added `remove_empty_registers` function to `qbraid.passes.qasm` for stripping zero-length register declarations (e.g. `creg c[0];`) from QASM strings
 - Added pytest remote tests for QIR simulator device with fixtures for Bell state circuits as both QASM and QIR module formats ([#1136](https://github.com/qBraid/qBraid/pull/1136))
 - Added CodeRabbit configuration file (`.coderabbit.yaml`) to disable automatic code review functionality ([#1162](https://github.com/qBraid/qBraid/pull/1162))
+- Added `@overload` method signatures to `QbraidDevice.submit` method to provide type hints for single `Program` vs `list[Program]` input types ([#1164](https://github.com/qBraid/qBraid/pull/1164))
+- Added comprehensive test for failed job result handling with `MockClientWithFailedJob` and `test_job_result_failed` ([#1164](https://github.com/qBraid/qBraid/pull/1164))
 
 ### Improved / Modified
 - Updated Azure Quantum provider to be compatible with `azure-quantum>=3.6.0`: replaced private `_current_availability` attribute access with public `current_availability` property on `Target`; simplified `AzureQuantumProvider.__init__` to accept only an optional `Workspace` (removed `credential` parameter) ([#1125](https://github.com/qBraid/qBraid/pull/1125))
@@ -56,6 +58,8 @@ Types of changes:
 - Added skip marker to `test_submit_qasm2_to_quantinuum` due to Quantinuum emulator usage quota exceeded ([#1136](https://github.com/qBraid/qBraid/pull/1136))
 - Added device status checks to QIR simulator remote tests (`test_qir_simulator_qasm_circuit` and `test_qir_simulator_qir_module`) to skip when device is not `ONLINE` ([#1150](https://github.com/qBraid/qBraid/pull/1150))
 - Simplified `test_qasm3_to_braket_error_includes_detail` test by removing reset case and converting from parametrized test to single case testing only the `c3x` undefined gate error ([#1161](https://github.com/qBraid/qBraid/pull/1161))
+- Updated type annotations throughout `qbraid.runtime` to use modern union syntax (`|` instead of `Union`) and removed unnecessary imports ([#1164](https://github.com/qBraid/qBraid/pull/1164))
+- Enhanced `QuantumDevice.submit` docstring to clarify that run_input should match the device's accepted program spec ([#1164](https://github.com/qBraid/qBraid/pull/1164))
 
 ### Deprecated
 - `AzureQuantumJob._make_estimator_result` and `OutputDataFormat.RESOURCE_ESTIMATOR` are deprecated; the `microsoft.resource-estimates.v1` output format is no longer emitted by azure-quantum >= 3.x. These will be removed in v0.12 ([#1125](https://github.com/qBraid/qBraid/pull/1125))
@@ -67,6 +71,7 @@ Types of changes:
 - Fixed azure-quantum version mismatch in development requirements to align with package optional dependency constraints ([#1135](https://github.com/qBraid/qBraid/pull/1135))
 - Fixed classical bit collisions in Braket `pad_measurements` method by detecting internal collisions, padding collisions, and out-of-range indices; rebases existing measures to sequential indices when necessary to ensure valid QASM output ([#1160](https://github.com/qBraid/qBraid/pull/1160))
 - Fixed `BraketQuantumTask._get_partial_measurement_qubits_from_tags` to return `None` and log warning when tag qubits are missing from result measurements, preventing crashes during result processing ([#1160](https://github.com/qBraid/qBraid/pull/1160))
+- Fixed `QbraidJob.result` method to handle failed jobs by creating a `CoreResult` with empty `resultData` instead of calling `get_job_result`, preventing crashes when processing failed job results ([#1164](https://github.com/qBraid/qBraid/pull/1164))
 
 ### Dependencies
 - Updated `azure-quantum` optional dependency from `>=2.0,<2.3` to `>=3.6.0,<4.0`; removed `azure-identity` from the `azure` extra ([#1125](https://github.com/qBraid/qBraid/pull/1125))

--- a/qbraid/runtime/device.py
+++ b/qbraid/runtime/device.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import warnings
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from qbraid._logging import logger
 from qbraid.programs import (
@@ -47,7 +47,6 @@ from .options import RuntimeOptions
 if TYPE_CHECKING:
     import qbraid.programs
     import qbraid.runtime
-    import qbraid.transpiler
 
 
 class QuantumDevice(ABC):
@@ -56,22 +55,22 @@ class QuantumDevice(ABC):
     def __init__(
         self,
         profile: qbraid.runtime.TargetProfile,
-        scheme: Optional[ConversionScheme] = None,
-        options: Optional[RuntimeOptions] = None,
+        scheme: ConversionScheme | None = None,
+        options: RuntimeOptions | None = None,
     ):
         """Create a ``QuantumDevice`` object.
 
         Args:
             profile (TargetProfile): The device runtime profile.
-            scheme (Optional[ConversionScheme]): The conversion graph and options passed
+            scheme (ConversionScheme | None): The conversion graph and options passed
                 to the transpiler at runtime.
-            options (Optional[RuntimeOptions]): Custom options to control the runtime
+            options (RuntimeOptions | None): Custom options to control the runtime
                 behavior. Adds fields or overrides default values for ``transpile``,
                 ``transform``, and ``validate``. Note that while you can modify these
                 values, their associated validators are fixed and cannot be changed.
         """
         self._profile = profile
-        self._target_spec: Optional[Union[ProgramSpec, list[ProgramSpec]]] = profile.program_spec
+        self._target_spec: ProgramSpec | list[ProgramSpec] | None = profile.program_spec
         self._scheme = scheme or ConversionScheme()
         self._options = self._default_options()
         if options:
@@ -88,7 +87,7 @@ class QuantumDevice(ABC):
         return self.profile.device_id
 
     @property
-    def num_qubits(self) -> Optional[int]:
+    def num_qubits(self) -> int | None:
         """The number of qubits supported by the device."""
         return self.profile.num_qubits
 
@@ -481,18 +480,21 @@ class QuantumDevice(ABC):
     @abstractmethod
     def submit(
         self,
-        run_input: Union[qbraid.programs.QPROGRAM, list[qbraid.programs.QPROGRAM]],
+        run_input: qbraid.programs.QPROGRAM | list[qbraid.programs.QPROGRAM],
         *args,
         **kwargs,
-    ) -> Union[qbraid.runtime.QuantumJob, list[qbraid.runtime.QuantumJob]]:
-        """Vendor run method. Should return dictionary with the following keys."""
+    ) -> qbraid.runtime.QuantumJob | list[qbraid.runtime.QuantumJob]:
+        """
+        Submit a job to the device, where run_input matches the quantum program type
+        accepted by the device API (i.e. QuantumDevice.profile.program_spec).
+        """
 
     def run(
         self,
-        run_input: Union[qbraid.programs.QPROGRAM, list[qbraid.programs.QPROGRAM]],
+        run_input: qbraid.programs.QPROGRAM | list[qbraid.programs.QPROGRAM],
         *args,
         **kwargs,
-    ) -> Union[qbraid.runtime.QuantumJob, list[qbraid.runtime.QuantumJob]]:
+    ) -> qbraid.runtime.QuantumJob | list[qbraid.runtime.QuantumJob]:
         """
         Run a quantum job or a list of quantum jobs on this quantum device.
 

--- a/qbraid/runtime/native/device.py
+++ b/qbraid/runtime/native/device.py
@@ -20,7 +20,7 @@ Module defining QbraidDevice class
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, overload
 
 from qbraid_core.services.runtime import QuantumRuntimeClient
 from qbraid_core.services.runtime.schemas import JobRequest, Program
@@ -84,6 +84,29 @@ class QbraidDevice(QuantumDevice):
             raise ValueError(f"Noise model '{noise_model}' not supported by device.")
 
         return self.profile.noise_models.get(noise_model).name
+
+    # pylint: disable=too-many-arguments
+    @overload
+    def submit(
+        self,
+        run_input: Program,
+        shots: int | None = None,
+        name: str | None = None,
+        tags: dict[str, str | int | bool] | None = None,
+        runtime_options: dict[str, Any] | None = None,
+    ) -> QbraidJob: ...
+
+    @overload
+    def submit(
+        self,
+        run_input: list[Program],
+        shots: int | None = None,
+        name: str | None = None,
+        tags: dict[str, str | int | bool] | None = None,
+        runtime_options: dict[str, Any] | None = None,
+    ) -> list[QbraidJob]: ...
+
+    # pylint: enable=too-many-arguments
 
     # pylint: disable-next=too-many-arguments
     def submit(

--- a/qbraid/runtime/native/job.py
+++ b/qbraid/runtime/native/job.py
@@ -18,9 +18,10 @@ Module defining QbraidJob class
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from qbraid_core.services.runtime import QuantumRuntimeClient
+from qbraid_core.services.runtime.schemas.result import Result as CoreResult
 
 from qbraid._logging import logger
 from qbraid.runtime.enums import JobStatus
@@ -41,8 +42,8 @@ class QbraidJob(QuantumJob):
     def __init__(
         self,
         job_id: str,
-        device: Optional[qbraid.runtime.QbraidDevice] = None,
-        client: Optional[qbraid_core.services.runtime.QuantumRuntimeClient] = None,
+        device: qbraid.runtime.QbraidDevice | None = None,
+        client: qbraid_core.services.runtime.QuantumRuntimeClient | None = None,
         **kwargs,
     ):
         super().__init__(job_id, device, **kwargs)
@@ -63,7 +64,7 @@ class QbraidJob(QuantumJob):
             self._client = self._device.client if self._device else QuantumRuntimeClient()
         return self._client
 
-    def queue_position(self) -> Optional[int]:
+    def queue_position(self) -> int | None:
         """Return the position of the job in the queue."""
         return self.metadata()["queuePosition"]
 
@@ -106,14 +107,22 @@ class QbraidJob(QuantumJob):
 
         logger.info("Success. Current status: %s", status.name)
 
-    def result(self, timeout: Optional[int] = None) -> Result[ResultDataType]:
+    def result(self, timeout: int | None = None) -> Result[ResultDataType]:
         """Return the results of the job."""
         self.wait_for_final_state(timeout=timeout)
         job_data = self.client.get_job(self.id)
         cost = job_data.cost
         time_stamps = job_data.timeStamps
         success = job_data.status == JobStatus.COMPLETED
-        job_result = self.client.get_job_result(self.id) if success else None
+        if success:
+            job_result = self.client.get_job_result(self.id)
+        else:
+            job_result = CoreResult(
+                status=job_data.status,
+                cost=cost,
+                timeStamps=time_stamps,
+                resultData={},
+            )
         data = ResultData.from_object(job_result, job_data.experimentType)
         return Result[ResultDataType](
             device_id=job_data.deviceQrn,
@@ -122,4 +131,5 @@ class QbraidJob(QuantumJob):
             data=data,
             time_stamps=time_stamps,
             cost=cost,
+            status=job_data.status,
         )

--- a/qbraid/runtime/native/provider.py
+++ b/qbraid/runtime/native/provider.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import base64
 import json
 import warnings
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable
 
 import pyqasm
 from qbraid_core.exceptions import AuthError
@@ -92,7 +92,7 @@ def validate_qasm_to_ionq(program: Qasm2StringType | Qasm3StringType, device_id:
 
 def get_program_spec_lambdas(
     program_type_alias: str, device_id: str
-) -> dict[str, Optional[Callable[[Any], None]]]:
+) -> dict[str, Callable[[Any], None] | None]:
     """Returns conversion and validation functions for the given program type and device."""
     if program_type_alias == "pyqir":
         return {"serialize": _serialize_pyqir, "validate": None}
@@ -127,9 +127,7 @@ class QbraidProvider(QuantumProvider):
             qBraid QuantumRuntimeClient object
     """
 
-    def __init__(
-        self, api_key: Optional[str] = None, client: Optional[QuantumRuntimeClient] = None
-    ):
+    def __init__(self, api_key: str | None = None, client: QuantumRuntimeClient | None = None):
         """
         Initializes the QbraidProvider object
 
@@ -157,7 +155,7 @@ class QbraidProvider(QuantumProvider):
         return self._client
 
     @staticmethod
-    def _get_program_spec(run_package: Optional[str], device_id: str) -> Optional[ProgramSpec]:
+    def _get_program_spec(run_package: str | None, device_id: str) -> ProgramSpec | None:
         """Return the program spec for the given run package and device."""
         if not run_package:
             return None
@@ -182,7 +180,7 @@ class QbraidProvider(QuantumProvider):
         ]
 
     @staticmethod
-    def _get_basis_gates(device_qrn: str) -> Optional[list[str]]:
+    def _get_basis_gates(device_qrn: str) -> list[str] | None:
         """Return the basis gates for the qBraid device."""
         _vendor, provider, device_type, name = device_qrn.split(":")
         if provider == "ionq":
@@ -218,7 +216,6 @@ class QbraidProvider(QuantumProvider):
     @cached_method(ttl=120)
     def get_devices(self) -> list[QbraidDevice]:
         """Return a list of devices matching the specified filtering."""
-        # query = kwargs or None
 
         try:
             # TODO: Implement support for device query

--- a/tests/runtime/native/test_runtime.py
+++ b/tests/runtime/native/test_runtime.py
@@ -17807,4 +17807,6 @@ def test_job_result_failed():
     assert result.job_id == FAILED_GET_JOB.jobQrn
     assert result.device_id == FAILED_GET_JOB.deviceQrn
     assert isinstance(result.data, GateModelResultData)
+    assert result.data.measurement_counts is None
+    assert result.data.measurements is None
     assert result.details.get("status") == JobStatus.FAILED

--- a/tests/runtime/native/test_runtime.py
+++ b/tests/runtime/native/test_runtime.py
@@ -17735,3 +17735,76 @@ def test_full_pipeline_multiple_devices(provider, sv1_program):
     for job in jobs:
         assert isinstance(job, QbraidJob)
         assert job.status() in [JobStatus.COMPLETED, JobStatus.QUEUED, JobStatus.INITIALIZING]
+
+
+# ============================================================================
+# Failed Job Result Tests
+# ============================================================================
+
+FAILED_GET_JOB_RESPONSE = {
+    "success": True,
+    "data": {
+        "_id": "69e7d2b3ae0f5ac2f46cb5db",
+        "jobQrn": "qbraid:qbraid:sim:qir-sv-8ce1-qjob-69e7d2b3ae0f5ac2f46cb5da",
+        "batchJobQrn": None,
+        "vendor": "qbraid",
+        "provider": "qbraid",
+        "status": "FAILED",
+        "statusMsg": 'Error: "Failed to link some declared functions: '
+        '__quantum__qis__barrier__body"\n',
+        "experimentType": "gate_model",
+        "queuePosition": None,
+        "timeStamps": {
+            "createdAt": "2026-04-21T19:40:37Z",
+            "endedAt": "2026-04-21T19:40:37Z",
+            "executionDuration": 2,
+        },
+        "cost": 0.0,
+        "estimatedCost": 0.0,
+        "metadata": {},
+        "name": None,
+        "shots": 100,
+        "deviceQrn": "qbraid:qbraid:sim:qir-sv",
+        "tags": {},
+        "runtimeOptions": {},
+        "jobVrn": None,
+        "organizationUserId": "68f94f8e0c6d3502fd4c37f5",
+        "deviceId": {
+            "_id": "689fa8990970e91064666bff",
+            "vrn": None,
+            "name": "QIR Sparse Simulator",
+            "pricing": {"perTask": 0, "perShot": 0, "perMinute": 0},
+            "status": "ONLINE",
+            "vendor": "qbraid",
+        },
+        "providerId": {"_id": "68cd83661650e905db02b1ff", "provider": "qBraid"},
+        "error": None,
+        "s3Destination": None,
+        "createdAt": "2026-04-21T19:40:37.000Z",
+        "updatedAt": "2026-04-21T19:40:37.000Z",
+    },
+}
+
+FAILED_GET_JOB = RuntimeJob.model_validate(FAILED_GET_JOB_RESPONSE["data"])
+
+
+class MockClientWithFailedJob(MockQuantumRuntimeClient):
+    """Mock client that returns a FAILED job for the failed job QRN."""
+
+    def get_job(self, job_qrn: str) -> RuntimeJob:
+        if job_qrn == FAILED_GET_JOB.jobQrn:
+            return FAILED_GET_JOB
+        return super().get_job(job_qrn)
+
+
+def test_job_result_failed():
+    """Test getting result for a FAILED job creates CoreResult with empty resultData."""
+    client = MockClientWithFailedJob()
+    job = QbraidJob(job_id=FAILED_GET_JOB.jobQrn, client=client)
+    result = job.result()
+    assert isinstance(result, RuntimeResult)
+    assert result.success is False
+    assert result.job_id == FAILED_GET_JOB.jobQrn
+    assert result.device_id == FAILED_GET_JOB.deviceQrn
+    assert isinstance(result.data, GateModelResultData)
+    assert result.details.get("status") == JobStatus.FAILED


### PR DESCRIPTION
## Summary
- Update `QbraidJob.result()` to construct a `CoreResult` with empty `resultData` for failed jobs instead of passing `None`, preventing errors when retrieving results for jobs that failed server-side (e.g. QIR linking failures)
- Include job `status` in `Result` details for downstream consumers
- Modernize type annotations to PEP 604 syntax (`X | None` instead of `Optional[X]`) and add `@overload` signatures to `QbraidDevice.submit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  - Enhanced type annotations for submit method to better distinguish between single program and batch submissions, improving IDE support and type safety.

* **Bug Fixes**
  - Fixed handling of failed job results to properly return result objects with status information instead of null values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->