### PR TITLE
Fix barrier removal for QIR simulator devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,8 +165,8 @@ Types of changes:
 - Added pytest remote tests for QIR simulator device with fixtures for Bell state circuits as both QASM and QIR module formats ([#1136](https://github.com/qBraid/qBraid/pull/1136))
 - Added CodeRabbit configuration file (`.coderabbit.yaml`) to disable automatic code review functionality ([#1162](https://github.com/qBraid/qBraid/pull/1162))
 - Added `@overload` method signatures to `QbraidDevice.submit` method to provide type hints for single `Program` vs `list[Program]` input types ([#1164](https://github.com/qBraid/qBraid/pull/1164))
-- Added `QbraidDevice.transform()` method and `_QIR_DEVICE_IDS` module-level set to `qbraid.runtime.native.device`; `transform()` uses `load_program()` + `pyqasm` to strip barrier operations from QASM programs before submission to QIR-based devices ([#PR_NUMBER](https://github.com/qBraid/qBraid/pull/PR_NUMBER))
-- Added 8 unit tests for `QbraidDevice.transform()` in `tests/runtime/native/test_qir_simulator_remote.py` covering barrier removal, no-barrier passthrough, non-QIR device preservation, non-QASM passthrough, multiple barriers, single-qubit barrier, barrier between gates/measurements, and barrier-only circuits ([#PR_NUMBER](https://github.com/qBraid/qBraid/pull/PR_NUMBER))
+- Added `QbraidDevice.transform()` method and `_QIR_DEVICE_IDS` module-level set to `qbraid.runtime.native.device`; `transform()` uses `load_program()` + `pyqasm` to strip barrier operations from QASM programs before submission to QIR-based devices ([#1170](https://github.com/qBraid/qBraid/pull/1170))
+- Added 8 unit tests for `QbraidDevice.transform()` in `tests/runtime/native/test_qir_simulator_remote.py` covering barrier removal, no-barrier passthrough, non-QIR device preservation, non-QASM passthrough, multiple barriers, single-qubit barrier, barrier between gates/measurements, and barrier-only circuits ([#1170](https://github.com/qBraid/qBraid/pull/1170))
 
 ### Improved / Modified
 - Updated Azure Quantum provider to be compatible with `azure-quantum>=3.6.0`: replaced private `_current_availability` attribute access with public `current_availability` property on `Target`; simplified `AzureQuantumProvider.__init__` to accept only an optional `Workspace` (removed `credential` parameter) ([#1125](https://github.com/qBraid/qBraid/pull/1125))
@@ -176,7 +176,7 @@ Types of changes:
 - Added skip marker to `test_submit_qasm2_to_quantinuum` due to Quantinuum emulator usage quota exceeded ([#1136](https://github.com/qBraid/qBraid/pull/1136))
 - Added device status checks to QIR simulator remote tests (`test_qir_simulator_qasm_circuit` and `test_qir_simulator_qir_module`) to skip when device is not `ONLINE` ([#1150](https://github.com/qBraid/qBraid/pull/1150))
 - Simplified `test_qasm3_to_braket_error_includes_detail` test by removing reset case and converting from parametrized test to single case testing only the `c3x` undefined gate error ([#1161](https://github.com/qBraid/qBraid/pull/1161))
-- Broadened exception catch in `tests/fixtures/__init__.py` `import_circuit_functions()` from `ImportError` to `Exception` to handle broken native library imports (e.g. `quil_rs` incompatibility with `pyquil`) gracefully during test collection ([#PR_NUMBER](https://github.com/qBraid/qBraid/pull/PR_NUMBER))
+- Broadened exception catch in `tests/fixtures/__init__.py` `import_circuit_functions()` from `ImportError` to `Exception` to handle broken native library imports (e.g. `quil_rs` incompatibility with `pyquil`) gracefully during test collection ([#1170](https://github.com/qBraid/qBraid/pull/1170))
 - Modernized type annotations throughout `qbraid.runtime` by replacing `Optional[]` and `Union[]` with PEP 604 syntax using `|` operator ([#1164](https://github.com/qBraid/qBraid/pull/1164))
 
 ### Deprecated
@@ -185,7 +185,7 @@ Types of changes:
 ### Removed
 
 ### Fixed
-- Fixed QIR simulator (`qbraid:qbraid:sim:qir-sv`) rejecting programs containing `barrier` instructions by stripping barriers in `QbraidDevice.transform()` before submission; barriers are no-ops in quantum computing but caused cryptic linker errors in the QIR runtime (`__quantum__qis__barrier__body`) ([#PR_NUMBER](https://github.com/qBraid/qBraid/pull/PR_NUMBER))
+- Fixed QIR simulator (`qbraid:qbraid:sim:qir-sv`) rejecting programs containing `barrier` instructions by stripping barriers in `QbraidDevice.transform()` before submission; barriers are no-ops in quantum computing but caused cryptic linker errors in the QIR runtime (`__quantum__qis__barrier__body`) ([#1170](https://github.com/qBraid/qBraid/pull/1170))
 - Fixed pyqpanda3-to-QASM2 conversion emitting invalid `creg c[0]` declarations, which caused downstream parsers to reject the output and broke round-trip conversions (e.g. `cirq → pyqpanda3 → cirq`)
 - Fixed azure-quantum version mismatch in development requirements to align with package optional dependency constraints ([#1135](https://github.com/qBraid/qBraid/pull/1135))
 - Fixed classical bit collisions in Braket `pad_measurements` method by detecting internal collisions, padding collisions, and out-of-range indices; rebases existing measures to sequential indices when necessary to ensure valid QASM output ([#1160](https://github.com/qBraid/qBraid/pull/1160))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,8 @@ Types of changes:
 - Added pytest remote tests for QIR simulator device with fixtures for Bell state circuits as both QASM and QIR module formats ([#1136](https://github.com/qBraid/qBraid/pull/1136))
 - Added CodeRabbit configuration file (`.coderabbit.yaml`) to disable automatic code review functionality ([#1162](https://github.com/qBraid/qBraid/pull/1162))
 - Added `@overload` method signatures to `QbraidDevice.submit` method to provide type hints for single `Program` vs `list[Program]` input types ([#1164](https://github.com/qBraid/qBraid/pull/1164))
+- Added `QbraidDevice.transform()` method and `_QIR_DEVICE_IDS` module-level set to `qbraid.runtime.native.device`; `transform()` uses `load_program()` + `pyqasm` to strip barrier operations from QASM programs before submission to QIR-based devices ([#PR_NUMBER](https://github.com/qBraid/qBraid/pull/PR_NUMBER))
+- Added 8 unit tests for `QbraidDevice.transform()` in `tests/runtime/native/test_qir_simulator_remote.py` covering barrier removal, no-barrier passthrough, non-QIR device preservation, non-QASM passthrough, multiple barriers, single-qubit barrier, barrier between gates/measurements, and barrier-only circuits ([#PR_NUMBER](https://github.com/qBraid/qBraid/pull/PR_NUMBER))
 
 ### Improved / Modified
 - Updated Azure Quantum provider to be compatible with `azure-quantum>=3.6.0`: replaced private `_current_availability` attribute access with public `current_availability` property on `Target`; simplified `AzureQuantumProvider.__init__` to accept only an optional `Workspace` (removed `credential` parameter) ([#1125](https://github.com/qBraid/qBraid/pull/1125))
@@ -174,6 +176,7 @@ Types of changes:
 - Added skip marker to `test_submit_qasm2_to_quantinuum` due to Quantinuum emulator usage quota exceeded ([#1136](https://github.com/qBraid/qBraid/pull/1136))
 - Added device status checks to QIR simulator remote tests (`test_qir_simulator_qasm_circuit` and `test_qir_simulator_qir_module`) to skip when device is not `ONLINE` ([#1150](https://github.com/qBraid/qBraid/pull/1150))
 - Simplified `test_qasm3_to_braket_error_includes_detail` test by removing reset case and converting from parametrized test to single case testing only the `c3x` undefined gate error ([#1161](https://github.com/qBraid/qBraid/pull/1161))
+- Broadened exception catch in `tests/fixtures/__init__.py` `import_circuit_functions()` from `ImportError` to `Exception` to handle broken native library imports (e.g. `quil_rs` incompatibility with `pyquil`) gracefully during test collection ([#PR_NUMBER](https://github.com/qBraid/qBraid/pull/PR_NUMBER))
 - Modernized type annotations throughout `qbraid.runtime` by replacing `Optional[]` and `Union[]` with PEP 604 syntax using `|` operator ([#1164](https://github.com/qBraid/qBraid/pull/1164))
 
 ### Deprecated
@@ -182,6 +185,7 @@ Types of changes:
 ### Removed
 
 ### Fixed
+- Fixed QIR simulator (`qbraid:qbraid:sim:qir-sv`) rejecting programs containing `barrier` instructions by stripping barriers in `QbraidDevice.transform()` before submission; barriers are no-ops in quantum computing but caused cryptic linker errors in the QIR runtime (`__quantum__qis__barrier__body`) ([#PR_NUMBER](https://github.com/qBraid/qBraid/pull/PR_NUMBER))
 - Fixed pyqpanda3-to-QASM2 conversion emitting invalid `creg c[0]` declarations, which caused downstream parsers to reject the output and broke round-trip conversions (e.g. `cirq → pyqpanda3 → cirq`)
 - Fixed azure-quantum version mismatch in development requirements to align with package optional dependency constraints ([#1135](https://github.com/qBraid/qBraid/pull/1135))
 - Fixed classical bit collisions in Braket `pad_measurements` method by detecting internal collisions, padding collisions, and out-of-range indices; rebases existing measures to sequential indices when necessary to ensure valid QASM output ([#1160](https://github.com/qBraid/qBraid/pull/1160))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,8 +165,6 @@ Types of changes:
 - Added pytest remote tests for QIR simulator device with fixtures for Bell state circuits as both QASM and QIR module formats ([#1136](https://github.com/qBraid/qBraid/pull/1136))
 - Added CodeRabbit configuration file (`.coderabbit.yaml`) to disable automatic code review functionality ([#1162](https://github.com/qBraid/qBraid/pull/1162))
 - Added `@overload` method signatures to `QbraidDevice.submit` method to provide type hints for single `Program` vs `list[Program]` input types ([#1164](https://github.com/qBraid/qBraid/pull/1164))
-- Added `QbraidDevice.transform()` method and `_QIR_DEVICE_IDS` module-level set to `qbraid.runtime.native.device`; `transform()` uses `load_program()` + `pyqasm` to strip barrier operations from QASM programs before submission to QIR-based devices ([#1170](https://github.com/qBraid/qBraid/pull/1170))
-- Added 8 unit tests for `QbraidDevice.transform()` in `tests/runtime/native/test_qir_simulator_remote.py` covering barrier removal, no-barrier passthrough, non-QIR device preservation, non-QASM passthrough, multiple barriers, single-qubit barrier, barrier between gates/measurements, and barrier-only circuits ([#1170](https://github.com/qBraid/qBraid/pull/1170))
 
 ### Improved / Modified
 - Updated Azure Quantum provider to be compatible with `azure-quantum>=3.6.0`: replaced private `_current_availability` attribute access with public `current_availability` property on `Target`; simplified `AzureQuantumProvider.__init__` to accept only an optional `Workspace` (removed `credential` parameter) ([#1125](https://github.com/qBraid/qBraid/pull/1125))
@@ -176,7 +174,6 @@ Types of changes:
 - Added skip marker to `test_submit_qasm2_to_quantinuum` due to Quantinuum emulator usage quota exceeded ([#1136](https://github.com/qBraid/qBraid/pull/1136))
 - Added device status checks to QIR simulator remote tests (`test_qir_simulator_qasm_circuit` and `test_qir_simulator_qir_module`) to skip when device is not `ONLINE` ([#1150](https://github.com/qBraid/qBraid/pull/1150))
 - Simplified `test_qasm3_to_braket_error_includes_detail` test by removing reset case and converting from parametrized test to single case testing only the `c3x` undefined gate error ([#1161](https://github.com/qBraid/qBraid/pull/1161))
-- Broadened exception catch in `tests/fixtures/__init__.py` `import_circuit_functions()` from `ImportError` to `Exception` to handle broken native library imports (e.g. `quil_rs` incompatibility with `pyquil`) gracefully during test collection ([#1170](https://github.com/qBraid/qBraid/pull/1170))
 - Modernized type annotations throughout `qbraid.runtime` by replacing `Optional[]` and `Union[]` with PEP 604 syntax using `|` operator ([#1164](https://github.com/qBraid/qBraid/pull/1164))
 
 ### Deprecated

--- a/qbraid/runtime/native/device.py
+++ b/qbraid/runtime/native/device.py
@@ -23,10 +23,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, overload
 
+import pyqasm
 from qbraid_core.services.runtime import QuantumRuntimeClient
 from qbraid_core.services.runtime.schemas import JobRequest, Program
 
 from qbraid._logging import logger
+from qbraid.programs import load_program
 from qbraid.runtime.device import QuantumDevice
 from qbraid.runtime.group import get_active_group, get_active_group_session
 from qbraid.runtime.noise import NoiseModel
@@ -37,6 +39,11 @@ if TYPE_CHECKING:
     import qbraid_core.services.runtime
 
     import qbraid.runtime
+
+
+_QIR_DEVICE_IDS = {
+    "qbraid:qbraid:sim:qir-sv",
+}
 
 
 class QbraidDevice(QuantumDevice):
@@ -87,6 +94,33 @@ class QbraidDevice(QuantumDevice):
             raise ValueError(f"Noise model '{noise_model}' not supported by device.")
 
         return self.profile.noise_models.get(noise_model).name
+
+    def transform(self, run_input: str) -> str:
+        """Apply device-specific transformations to the run input.
+
+        For QIR-based devices, removes barrier operations that are not
+        supported by the qBraid QIR runtime.
+        """
+        if self.id not in _QIR_DEVICE_IDS:
+            return run_input
+
+        try:
+            program = load_program(run_input)
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            logger.error("Failed to load program for barrier removal: %s", err)
+            return run_input
+
+        if not hasattr(program, "_module") or not program._module.has_barriers():
+            return run_input
+
+        logger.info(
+            "Removing barriers from program for QIR device '%s'. "
+            "Barriers are not supported by the QIR runtime.",
+            self.id,
+        )
+        program._module.remove_barriers()
+        program._program = pyqasm.dumps(program._module)
+        return program.program
 
     # pylint: disable=too-many-arguments
     @overload

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -31,8 +31,8 @@ def import_circuit_functions(module_name, bell_func_name, shared15_func_name):
     try:
         # Attempt to import the module relatively to the current script
         circuits = importlib.import_module(package, __package__)
-    except ImportError:
-        return None, None  # The module is not installed
+    except Exception:  # pylint: disable=broad-exception-caught
+        return None, None  # ImportError, AttributeError from broken native libs, etc.
 
     # Get the bell and shared15 functions
     bell_func = getattr(circuits, bell_func_name, None)

--- a/tests/runtime/native/test_qir_simulator_remote.py
+++ b/tests/runtime/native/test_qir_simulator_remote.py
@@ -17,11 +17,18 @@ Remote tests for QIR simulator device via qBraid native runtime.
 
 """
 
+import textwrap
+
 import pyqir
 import pytest
 from qiskit import QuantumCircuit
 
-from qbraid.runtime import DeviceStatus, JobStatus, QbraidProvider
+from qbraid.programs import ExperimentType
+from qbraid.runtime import DeviceStatus, JobStatus, QbraidProvider, TargetProfile
+from qbraid.runtime.native import QbraidDevice
+from qbraid.runtime.noise import NoiseModelSet
+
+from .._resources import MockClient
 
 DEFAULT_TIMEOUT = 120
 DEVICE_ID = "qbraid:qbraid:sim:qir-sv"
@@ -119,3 +126,172 @@ def test_qir_simulator_qir_module(bell_qir_module):
         pytest.skip(f"Job did not complete within {DEFAULT_TIMEOUT} seconds")
 
     assert job.status() == JobStatus.COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for QbraidDevice.transform barrier removal
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def qir_device():
+    """QbraidDevice configured as a QIR simulator (offline, for unit tests)."""
+    profile = TargetProfile(
+        device_id=DEVICE_ID,
+        simulator=True,
+        experiment_type=ExperimentType.GATE_MODEL,
+        num_qubits=64,
+        program_spec=QbraidProvider._get_program_spec("pyqir", DEVICE_ID),
+        noise_models=NoiseModelSet.from_iterable(["ideal"]),
+    )
+    return QbraidDevice(profile=profile, client=MockClient())
+
+
+@pytest.fixture
+def non_qir_device():
+    """QbraidDevice configured as a non-QIR device."""
+    non_qir_id = "qbraid:qbraid:sim:some-other-device"
+    profile = TargetProfile(
+        device_id=non_qir_id,
+        simulator=True,
+        experiment_type=ExperimentType.GATE_MODEL,
+        num_qubits=64,
+        program_spec=QbraidProvider._get_program_spec("pyqir", non_qir_id),
+        noise_models=NoiseModelSet.from_iterable(["ideal"]),
+    )
+    return QbraidDevice(profile=profile, client=MockClient())
+
+
+@pytest.fixture
+def qasm3_with_barrier():
+    """OpenQASM 3 program containing a barrier."""
+    return textwrap.dedent(
+        """
+        OPENQASM 3.0;
+        qubit[2] q;
+        bit[2] b;
+        h q[0];
+        barrier q[0], q[1];
+        cx q[0], q[1];
+        b = measure q;
+    """
+    ).strip()
+
+
+@pytest.fixture
+def qasm3_without_barrier():
+    """OpenQASM 3 program without barriers."""
+    return textwrap.dedent(
+        """
+        OPENQASM 3.0;
+        qubit[2] q;
+        bit[2] b;
+        h q[0];
+        cx q[0], q[1];
+        b = measure q;
+    """
+    ).strip()
+
+
+EXPECTED_BELL_NO_BARRIER = (
+    "OPENQASM 3.0;\nqubit[2] q;\nbit[2] b;\nh q[0];\ncx q[0], q[1];\nb = measure q;\n"
+)
+
+
+def test_transform_removes_barriers_for_qir_device(qir_device, qasm3_with_barrier):
+    """Barriers should be removed when targeting the QIR simulator."""
+    result = qir_device.transform(qasm3_with_barrier)
+    assert result == EXPECTED_BELL_NO_BARRIER
+
+
+def test_transform_no_barriers_passthrough(qir_device, qasm3_without_barrier):
+    """Programs without barriers should pass through unchanged for QIR devices."""
+    result = qir_device.transform(qasm3_without_barrier)
+    assert result == qasm3_without_barrier
+
+
+def test_transform_non_qir_device_preserves_barriers(non_qir_device, qasm3_with_barrier):
+    """Non-QIR devices should not strip barriers."""
+    result = non_qir_device.transform(qasm3_with_barrier)
+    assert result == qasm3_with_barrier
+
+
+def test_transform_non_qasm_input_passthrough(qir_device):
+    """Non-QASM input (e.g. random string) should pass through without error."""
+    non_qasm = "this is not a valid quantum program"
+    result = qir_device.transform(non_qasm)
+    assert result == non_qasm
+
+
+def test_transform_removes_multiple_barriers(qir_device):
+    """Multiple barriers scattered throughout the circuit should all be removed."""
+    qasm = textwrap.dedent(
+        """
+        OPENQASM 3.0;
+        qubit[3] q;
+        bit[3] b;
+        h q[0];
+        barrier q[0], q[1], q[2];
+        cx q[0], q[1];
+        barrier q[1], q[2];
+        cx q[1], q[2];
+        barrier q[0], q[1], q[2];
+        b = measure q;
+    """
+    ).strip()
+    expected = (
+        "OPENQASM 3.0;\nqubit[3] q;\nbit[3] b;\n"
+        "h q[0];\ncx q[0], q[1];\ncx q[1], q[2];\nb = measure q;\n"
+    )
+    result = qir_device.transform(qasm)
+    assert result == expected
+
+
+def test_transform_removes_barrier_on_single_qubit(qir_device):
+    """A barrier applied to a single qubit should be removed."""
+    qasm = textwrap.dedent(
+        """
+        OPENQASM 3.0;
+        qubit[1] q;
+        bit[1] b;
+        h q[0];
+        barrier q[0];
+        b[0] = measure q[0];
+    """
+    ).strip()
+    expected = "OPENQASM 3.0;\nqubit[1] q;\nbit[1] b;\nh q[0];\nb[0] = measure q[0];\n"
+    result = qir_device.transform(qasm)
+    assert result == expected
+
+
+def test_transform_removes_barrier_between_measurements(qir_device):
+    """Barrier placed between gate operations and measurements should be removed."""
+    qasm = textwrap.dedent(
+        """
+        OPENQASM 3.0;
+        qubit[2] q;
+        bit[2] b;
+        h q[0];
+        cx q[0], q[1];
+        barrier q[0], q[1];
+        b = measure q;
+    """
+    ).strip()
+    result = qir_device.transform(qasm)
+    assert result == EXPECTED_BELL_NO_BARRIER
+
+
+def test_transform_barrier_only_circuit(qir_device):
+    """A circuit that is just gates and a barrier (no measurement) should have barrier stripped."""
+    qasm = textwrap.dedent(
+        """
+        OPENQASM 3.0;
+        qubit[2] q;
+        h q[0];
+        barrier q[0], q[1];
+        cx q[0], q[1];
+    """
+    ).strip()
+    expected = "OPENQASM 3.0;\nqubit[2] q;\nh q[0];\ncx q[0], q[1];\n"
+    result = qir_device.transform(qasm)
+    assert result == expected


### PR DESCRIPTION
**Fix** — Bug Fix

Adds barrier removal to `QbraidDevice.transform()` so QASM programs containing `barrier` instructions can be submitted to QIR-based simulator devices without triggering linker errors (`Failed to link some declared functions: __quantum__qis__barrier__body`). Barriers are semantically no-ops in quantum computing but are unsupported by the qBraid QIR runtime.

## Changes

- **`_QIR_DEVICE_IDS`**: Added module-level set in `qbraid/runtime/native/device.py` enumerating device IDs that require barrier stripping (initially `{"qbraid:qbraid:sim:qir-sv"}`).
- **`QbraidDevice.transform()`**: New method that intercepts QASM run input for QIR devices, uses `load_program()` + `pyqasm` to detect and remove barrier operations before submission; non-QASM or non-QIR inputs pass through unchanged.
- **Unit tests**: Added 8 tests in `tests/runtime/native/test_qir_simulator_remote.py` covering barrier removal, no-barrier passthrough, non-QIR device preservation, non-QASM passthrough, multiple barriers, single-qubit barrier, barrier between gates/measurements, and barrier-only circuits.
