### PR TITLE
Remove QirRunner from native runtime API [no ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Types of changes:
 
 ### Removed
 
+- Removed `QirRunner` from native runtime API exports and imports ([#1175](https://github.com/qBraid/qBraid/pull/1175))
+
 ### Fixed
 
 ### Dependencies

--- a/qbraid/runtime/native/__init__.py
+++ b/qbraid/runtime/native/__init__.py
@@ -30,11 +30,9 @@ Classes
     QbraidProvider
     QbraidDevice
     QbraidJob
-    QirRunner
 
 """
 from qbraid_core import QbraidClientV1, QbraidSessionV1, Session
-from qbraid_core.services.quantum.runner import QirRunner
 
 from .device import QbraidDevice
 from .job import QbraidJob
@@ -47,5 +45,4 @@ __all__ = [
     "QbraidProvider",
     "QbraidDevice",
     "QbraidJob",
-    "QirRunner",
 ]


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

Removed the import and public export of `QirRunner` from `qbraid_core.services.quantum.runner`, as it is no longer needed.
