### PR TITLE
Add batch job support (as_batch=True)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Types of changes:
 ## [Unreleased]
 
 ### Added
+- Added `as_batch=True` parameter to `QuantumDevice.run()` and `QbraidDevice.submit()` enabling submission of a list of circuits as a single batch job (one vendor call, one VRN, one status). `QbraidJob.result()` returns `list[Result]` for batch jobs (`numCircuits > 1`) and a single `Result` for regular jobs. Batch jobs are capped at 200 circuits. ([#1187](https://github.com/qBraid/qBraid/pull/1187))
 - Added `config.yml`, `provider_integration_request.yml`, `documentation.yml`, and `question.yml` GitHub issue templates, and expanded the existing bug-report and feature-request templates with structured fields (SDK version, affected-area dropdowns, steps/expected/actual splits, feature-area dropdowns, motivation/use-case prompts). The new `config.yml` routes the New Issue picker to the documentation, the qBraid contact page, GitHub Discussions, the security policy, and the contributing guide; `blank_issues_enabled: false` ensures every issue arrives via a template. The new provider-integration template provides a structured on-ramp for the external-contributor pattern that produced the Origin Quantum, Quantinuum, and Rigetti integrations during Phase I ([#1181](https://github.com/qBraid/qBraid/pull/1181))
 
 ### Improved / Modified

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Types of changes:
 ## [Unreleased]
 
 ### Added
-- Added `as_batch=True` parameter to `QuantumDevice.run()` and `QbraidDevice.submit()` enabling submission of a list of circuits as a single batch job (one API call, one job QRN). `QbraidJob.result()` returns `list[Result]` for batch jobs (`numCircuits > 1`) and a single `Result` for regular jobs. ([#1187](https://github.com/qBraid/qBraid/pull/1187))
+- Added `as_batch=True` parameter to `QbraidDevice.submit()` enabling submission of a list of circuits as a single batch job (one API call, one job QRN). `QbraidJob.result()` returns `list[Result]` for batch jobs (`numCircuits > 1`) and a single `Result` for regular jobs. ([#1187](https://github.com/qBraid/qBraid/pull/1187))
 - Added `OpenQuantumProvider`, `OpenQuantumDevice`, and `OpenQuantumJob` classes implementing the qBraid runtime interface for Open Quantum
 
   ```python

--- a/qbraid/runtime/__init__.py
+++ b/qbraid/runtime/__init__.py
@@ -101,7 +101,7 @@ from .noise import NoiseModel, NoiseModelSet
 from .options import RuntimeOptions
 from .profile import TargetProfile
 from .provider import QuantumProvider
-from .result import Result
+from .result import BatchResult, Result
 from .result_data import (
     AnalogResultData,
     AnalogShotResult,
@@ -135,6 +135,7 @@ __all__ = [
     "RuntimeOptions",
     "NoiseModel",
     "NoiseModelSet",
+    "BatchResult",
     "Result",
     "ResultData",
     "GateModelResultData",

--- a/qbraid/runtime/device.py
+++ b/qbraid/runtime/device.py
@@ -504,9 +504,27 @@ class QuantumDevice(ABC):
         Args:
             run_input: A single quantum program or a list of quantum programs to run on the device.
 
+        Keyword Args:
+            as_batch: If True, submit the list of programs as a single batch job
+                (one VRN, one status, one result containing all circuits). The device
+                must support batch execution. Defaults to False.
+
         Returns:
             A QuantumJob object or a list of QuantumJob objects corresponding to the input.
         """
+        as_batch = kwargs.pop("as_batch", False)
+
+        if as_batch:
+            if not isinstance(run_input, list):
+                raise ValueError("as_batch=True requires a list of programs.")
+            if len(run_input) > 200:
+                raise ValueError("Batch jobs are limited to 200 circuits.")
+            run_input_compat = [self.apply_runtime_profile(program) for program in run_input]
+            logger.debug(
+                "Submitting batch of %d circuits to device '%s'", len(run_input), self.id
+            )
+            return self.submit(run_input_compat, *args, as_batch=True, **kwargs)
+
         is_single_input = not isinstance(run_input, list)
         run_input = [run_input] if is_single_input else run_input
         run_input_compat = [self.apply_runtime_profile(program) for program in run_input]

--- a/qbraid/runtime/device.py
+++ b/qbraid/runtime/device.py
@@ -520,9 +520,7 @@ class QuantumDevice(ABC):
             if len(run_input) > 200:
                 raise ValueError("Batch jobs are limited to 200 circuits.")
             run_input_compat = [self.apply_runtime_profile(program) for program in run_input]
-            logger.debug(
-                "Submitting batch of %d circuits to device '%s'", len(run_input), self.id
-            )
+            logger.debug("Submitting batch of %d circuits to device '%s'", len(run_input), self.id)
             return self.submit(run_input_compat, *args, as_batch=True, **kwargs)
 
         is_single_input = not isinstance(run_input, list)

--- a/qbraid/runtime/device.py
+++ b/qbraid/runtime/device.py
@@ -504,25 +504,9 @@ class QuantumDevice(ABC):
         Args:
             run_input: A single quantum program or a list of quantum programs to run on the device.
 
-        Keyword Args:
-            as_batch: If True, submit the list of programs as a single batch job
-                (one VRN, one status, one result containing all circuits). The device
-                must support batch execution. Defaults to False.
-
         Returns:
             A QuantumJob object or a list of QuantumJob objects corresponding to the input.
         """
-        as_batch = kwargs.pop("as_batch", False)
-
-        if as_batch:
-            if not isinstance(run_input, list):
-                raise ValueError("as_batch=True requires a list of programs.")
-            if len(run_input) > 200:
-                raise ValueError("Batch jobs are limited to 200 circuits.")
-            run_input_compat = [self.apply_runtime_profile(program) for program in run_input]
-            logger.debug("Submitting batch of %d circuits to device '%s'", len(run_input), self.id)
-            return self.submit(run_input_compat, *args, as_batch=True, **kwargs)
-
         is_single_input = not isinstance(run_input, list)
         run_input = [run_input] if is_single_input else run_input
         run_input_compat = [self.apply_runtime_profile(program) for program in run_input]

--- a/qbraid/runtime/native/device.py
+++ b/qbraid/runtime/native/device.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: disable=arguments-differ
+# pylint: disable=arguments-differ,too-many-arguments
 
 """
 Module defining QbraidDevice class
@@ -88,7 +88,6 @@ class QbraidDevice(QuantumDevice):
 
         return self.profile.noise_models.get(noise_model).name
 
-    # pylint: disable=too-many-arguments
     @overload
     def submit(
         self,
@@ -97,6 +96,7 @@ class QbraidDevice(QuantumDevice):
         name: str | None = None,
         tags: dict[str, str | int | bool] | None = None,
         runtime_options: dict[str, Any] | None = None,
+        as_batch: bool = False,
     ) -> QbraidJob: ...
 
     @overload
@@ -107,11 +107,20 @@ class QbraidDevice(QuantumDevice):
         name: str | None = None,
         tags: dict[str, str | int | bool] | None = None,
         runtime_options: dict[str, Any] | None = None,
+        as_batch: bool = False,
     ) -> list[QbraidJob]: ...
 
-    # pylint: enable=too-many-arguments
+    @overload
+    def submit(
+        self,
+        run_input: list[Program],
+        shots: int | None = None,
+        name: str | None = None,
+        tags: dict[str, str | int | bool] | None = None,
+        runtime_options: dict[str, Any] | None = None,
+        as_batch: bool = True,
+    ) -> QbraidJob: ...
 
-    # pylint: disable-next=too-many-arguments
     def submit(
         self,
         run_input: Program | list[Program],
@@ -128,14 +137,21 @@ class QbraidDevice(QuantumDevice):
         are registered with the session.
 
         Args:
+            run_input: A single program or a list of programs to submit to the device.
+            shots: The number of shots to run the program(s).
+            name: The name of the job.
+            tags: A dictionary of tags to add to the job.
+            runtime_options: A dictionary of runtime options to pass to the device.
             as_batch: When True, submit all programs as a single batch job
                 (one API call, one QRN, one status). Returns a single QbraidJob.
+                Check QbraidDevice.profile.batch_job_support to verify if
+                batch jobs are supported by this device.
         """
         tags = tags or {}
         runtime_options = runtime_options or {}
         noise_model: NoiseModel | str | None = runtime_options.pop("noise_model", None)
 
-        # Read group context — only QbraidDevice supports grouped execution.
+        # Read group context
         group_job_qrn = get_active_group()
         session = get_active_group_session() if group_job_qrn else None
 
@@ -143,34 +159,21 @@ class QbraidDevice(QuantumDevice):
             runtime_options["noiseModel"] = self._resolve_noise_model(noise_model)
 
         if as_batch:
-            # Batch mode: submit all programs as a single job
-            programs = run_input if isinstance(run_input, list) else [run_input]
+            if not self.profile.get("batch_job_support"):
+                raise ValueError("Batch jobs are not supported by this device.")
 
-            if group_job_qrn:
-                logger.debug(
-                    "Submitting batch job to device '%s' (group: %s)", self.id, group_job_qrn
-                )
+            if not isinstance(run_input, list):
+                raise ValueError("Batch jobs require a list of programs.")
 
-            job_request = JobRequest(
-                deviceQrn=self.id,
-                program=programs,
-                shots=shots,
-                name=name,
-                tags=tags,
-                runtimeOptions=runtime_options,
-                groupJobQrn=group_job_qrn,
-            )
-            job_data = self.client.create_job(job_request)
-            job = QbraidJob(job_id=job_data.jobQrn, device=self, client=self.client)
-            if session is not None:
-                session._register_job(job)
-            return job
-
-        is_single_input = not isinstance(run_input, list)
+        is_single_input = as_batch or not isinstance(run_input, list)
         run_input = [run_input] if is_single_input else run_input
 
-        if group_job_qrn:
-            logger.debug("Submitting job to device '%s' (group: %s)", self.id, group_job_qrn)
+        logger.debug(
+            "Submitting %s to device '%s' (group: %s)",
+            "batch job" if as_batch else f"{len(run_input)} job(s)",
+            self.id,
+            group_job_qrn,
+        )
 
         jobs = []
 

--- a/qbraid/runtime/native/device.py
+++ b/qbraid/runtime/native/device.py
@@ -119,26 +119,52 @@ class QbraidDevice(QuantumDevice):
         name: str | None = None,
         tags: dict[str, str | int | bool] | None = None,
         runtime_options: dict[str, Any] | None = None,
+        as_batch: bool = False,
     ) -> QbraidJob | list[QbraidJob]:
         """Submit a program to the device.
 
         If an active GroupJobSession context exists, the group QRN is
         automatically included in the job request and submitted jobs
         are registered with the session.
+
+        Args:
+            as_batch: When True, submit all programs as a single batch job
+                (one API call, one QRN, one status). Returns a single QbraidJob.
         """
         tags = tags or {}
         runtime_options = runtime_options or {}
         noise_model: NoiseModel | str | None = runtime_options.pop("noise_model", None)
 
         # Read group context — only QbraidDevice supports grouped execution.
-        # Resolve the active session once, up front, so that each job can be
-        # registered immediately after creation. This keeps the SDK view in
-        # sync with the backend even if create_job() fails mid-loop.
         group_job_qrn = get_active_group()
         session = get_active_group_session() if group_job_qrn else None
 
         if noise_model:
             runtime_options["noiseModel"] = self._resolve_noise_model(noise_model)
+
+        if as_batch:
+            # Batch mode: submit all programs as a single job
+            programs = run_input if isinstance(run_input, list) else [run_input]
+
+            if group_job_qrn:
+                logger.debug(
+                    "Submitting batch job to device '%s' (group: %s)", self.id, group_job_qrn
+                )
+
+            job_request = JobRequest(
+                deviceQrn=self.id,
+                program=programs,
+                shots=shots,
+                name=name,
+                tags=tags,
+                runtimeOptions=runtime_options,
+                groupJobQrn=group_job_qrn,
+            )
+            job_data = self.client.create_job(job_request)
+            job = QbraidJob(job_id=job_data.jobQrn, device=self, client=self.client)
+            if session is not None:
+                session._register_job(job)
+            return job
 
         is_single_input = not isinstance(run_input, list)
         run_input = [run_input] if is_single_input else run_input

--- a/qbraid/runtime/native/device.py
+++ b/qbraid/runtime/native/device.py
@@ -165,6 +165,8 @@ class QbraidDevice(QuantumDevice):
             if not isinstance(run_input, list):
                 raise ValueError("Batch jobs require a list of programs.")
 
+        # Wrap so the loop iterates once: [Program] for single, [list[Program]]
+        # for batch (sends the full list as one API call → 1 QRN, N circuits).
         is_single_input = as_batch or not isinstance(run_input, list)
         run_input = [run_input] if is_single_input else run_input
 

--- a/qbraid/runtime/native/job.py
+++ b/qbraid/runtime/native/job.py
@@ -117,58 +117,33 @@ class QbraidJob(QuantumJob):
         """
         self.wait_for_final_state(timeout=timeout)
         job_data = self.client.get_job(self.id)
-        cost = job_data.cost
-        time_stamps = job_data.timeStamps
         success = job_data.status == JobStatus.COMPLETED
         num_circuits = job_data.numCircuits or 1
 
-        if not success:
-            job_result = CoreResult(
+        if success:
+            raw_result = self.client.get_job_result(self.id)
+        else:
+            empty = CoreResult(
                 status=job_data.status,
-                cost=cost,
-                timeStamps=time_stamps,
+                cost=job_data.cost,
+                timeStamps=job_data.timeStamps,
                 resultData={},
             )
-            data = ResultData.from_object(job_result, job_data.experimentType)
-            single_result = Result[ResultDataType](
+            raw_result = [empty] * num_circuits if num_circuits > 1 else empty
+
+        def _build_result(core_result: CoreResult) -> Result[ResultDataType]:
+            data = ResultData.from_object(core_result, job_data.experimentType)
+            return Result[ResultDataType](
                 device_id=job_data.deviceQrn,
                 job_id=job_data.jobQrn,
                 success=success,
                 data=data,
-                time_stamps=time_stamps,
-                cost=cost,
+                time_stamps=job_data.timeStamps,
+                cost=job_data.cost,
                 status=job_data.status,
             )
-            return [single_result] * num_circuits if num_circuits > 1 else single_result
 
-        raw_result = self.client.get_job_result(self.id)
+        if isinstance(raw_result, list):
+            return [_build_result(r) for r in raw_result]
 
-        if num_circuits > 1 and isinstance(raw_result, list):
-            # Batch job: raw_result is list[CoreResult]
-            results = []
-            for circuit_result in raw_result:
-                data = ResultData.from_object(circuit_result, job_data.experimentType)
-                results.append(
-                    Result[ResultDataType](
-                        device_id=job_data.deviceQrn,
-                        job_id=job_data.jobQrn,
-                        success=True,
-                        data=data,
-                        time_stamps=time_stamps,
-                        cost=cost,
-                        status=job_data.status,
-                    )
-                )
-            return results
-
-        # Single-circuit job
-        data = ResultData.from_object(raw_result, job_data.experimentType)
-        return Result[ResultDataType](
-            device_id=job_data.deviceQrn,
-            job_id=job_data.jobQrn,
-            success=success,
-            data=data,
-            time_stamps=time_stamps,
-            cost=cost,
-            status=job_data.status,
-        )
+        return _build_result(raw_result)

--- a/qbraid/runtime/native/job.py
+++ b/qbraid/runtime/native/job.py
@@ -27,7 +27,7 @@ from qbraid._logging import logger
 from qbraid.runtime.enums import JobStatus
 from qbraid.runtime.exceptions import JobStateError, QbraidRuntimeError
 from qbraid.runtime.job import QuantumJob
-from qbraid.runtime.result import Result, ResultDataType
+from qbraid.runtime.result import BatchResult, Result, ResultDataType
 from qbraid.runtime.result_data import ResultData
 
 if TYPE_CHECKING:
@@ -109,11 +109,11 @@ class QbraidJob(QuantumJob):
 
     def result(
         self, timeout: int | None = None
-    ) -> Result[ResultDataType] | list[Result[ResultDataType]]:
+    ) -> Result[ResultDataType] | BatchResult[ResultDataType]:
         """Return the results of the job.
 
-        For single-circuit jobs, returns a single ``Result``.
-        For batch jobs (``numCircuits > 1``), returns a ``list[Result]``.
+        For single-circuit jobs, returns a single :class:`Result`.
+        For batch jobs (``numCircuits > 1``), returns a :class:`BatchResult`.
         """
         self.wait_for_final_state(timeout=timeout)
         job_data = self.client.get_job(self.id)
@@ -136,14 +136,24 @@ class QbraidJob(QuantumJob):
             return Result[ResultDataType](
                 device_id=job_data.deviceQrn,
                 job_id=job_data.jobQrn,
-                success=success,
+                success=core_result.status == JobStatus.COMPLETED,
                 data=data,
+                time_stamps=core_result.timeStamps,
+                cost=core_result.cost,
+                status=core_result.status,
+                **core_result.resultData,
+            )
+
+        if isinstance(raw_result, list):
+            per_circuit = [_build_result(r) for r in raw_result]
+            return BatchResult[ResultDataType](
+                device_id=job_data.deviceQrn,
+                job_id=job_data.jobQrn,
+                success=success,
+                results=per_circuit,
                 time_stamps=job_data.timeStamps,
                 cost=job_data.cost,
                 status=job_data.status,
             )
-
-        if isinstance(raw_result, list):
-            return [_build_result(r) for r in raw_result]
 
         return _build_result(raw_result)

--- a/qbraid/runtime/native/job.py
+++ b/qbraid/runtime/native/job.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from qbraid_core.services.runtime import QuantumRuntimeClient
+from qbraid_core.services.runtime.schemas.result import BatchResult as CoreBatchResult
 from qbraid_core.services.runtime.schemas.result import Result as CoreResult
 
 from qbraid._logging import logger
@@ -129,7 +130,15 @@ class QbraidJob(QuantumJob):
                 timeStamps=job_data.timeStamps,
                 resultData={},
             )
-            raw_result = [empty] * num_circuits if num_circuits > 1 else empty
+            if num_circuits > 1:
+                raw_result = CoreBatchResult(
+                    status=job_data.status,
+                    cost=job_data.cost,
+                    timeStamps=job_data.timeStamps,
+                    results=[empty] * num_circuits,
+                )
+            else:
+                raw_result = empty
 
         def _build_result(core_result: CoreResult) -> Result[ResultDataType]:
             data = ResultData.from_object(core_result, job_data.experimentType)
@@ -141,19 +150,19 @@ class QbraidJob(QuantumJob):
                 time_stamps=core_result.timeStamps,
                 cost=core_result.cost,
                 status=core_result.status,
-                **core_result.resultData,
+                **data.extra,
             )
 
-        if isinstance(raw_result, list):
-            per_circuit = [_build_result(r) for r in raw_result]
+        if isinstance(raw_result, CoreBatchResult):
+            per_circuit = [_build_result(r) for r in raw_result.results]
             return BatchResult[ResultDataType](
                 device_id=job_data.deviceQrn,
                 job_id=job_data.jobQrn,
                 success=success,
                 results=per_circuit,
-                time_stamps=job_data.timeStamps,
-                cost=job_data.cost,
-                status=job_data.status,
+                time_stamps=raw_result.timeStamps,
+                cost=raw_result.cost,
+                status=raw_result.status,
             )
 
         return _build_result(raw_result)

--- a/qbraid/runtime/native/job.py
+++ b/qbraid/runtime/native/job.py
@@ -107,23 +107,62 @@ class QbraidJob(QuantumJob):
 
         logger.info("Success. Current status: %s", status.name)
 
-    def result(self, timeout: int | None = None) -> Result[ResultDataType]:
-        """Return the results of the job."""
+    def result(
+        self, timeout: int | None = None
+    ) -> Result[ResultDataType] | list[Result[ResultDataType]]:
+        """Return the results of the job.
+
+        For single-circuit jobs, returns a single ``Result``.
+        For batch jobs (``numCircuits > 1``), returns a ``list[Result]``.
+        """
         self.wait_for_final_state(timeout=timeout)
         job_data = self.client.get_job(self.id)
         cost = job_data.cost
         time_stamps = job_data.timeStamps
         success = job_data.status == JobStatus.COMPLETED
-        if success:
-            job_result = self.client.get_job_result(self.id)
-        else:
+        num_circuits = job_data.numCircuits or 1
+
+        if not success:
             job_result = CoreResult(
                 status=job_data.status,
                 cost=cost,
                 timeStamps=time_stamps,
                 resultData={},
             )
-        data = ResultData.from_object(job_result, job_data.experimentType)
+            data = ResultData.from_object(job_result, job_data.experimentType)
+            single_result = Result[ResultDataType](
+                device_id=job_data.deviceQrn,
+                job_id=job_data.jobQrn,
+                success=success,
+                data=data,
+                time_stamps=time_stamps,
+                cost=cost,
+                status=job_data.status,
+            )
+            return [single_result] * num_circuits if num_circuits > 1 else single_result
+
+        raw_result = self.client.get_job_result(self.id)
+
+        if num_circuits > 1 and isinstance(raw_result, list):
+            # Batch job: raw_result is list[CoreResult]
+            results = []
+            for circuit_result in raw_result:
+                data = ResultData.from_object(circuit_result, job_data.experimentType)
+                results.append(
+                    Result[ResultDataType](
+                        device_id=job_data.deviceQrn,
+                        job_id=job_data.jobQrn,
+                        success=True,
+                        data=data,
+                        time_stamps=time_stamps,
+                        cost=cost,
+                        status=job_data.status,
+                    )
+                )
+            return results
+
+        # Single-circuit job
+        data = ResultData.from_object(raw_result, job_data.experimentType)
         return Result[ResultDataType](
             device_id=job_data.deviceQrn,
             job_id=job_data.jobQrn,

--- a/qbraid/runtime/native/provider.py
+++ b/qbraid/runtime/native/provider.py
@@ -211,6 +211,7 @@ class QbraidProvider(QuantumProvider):
             name=device.name,
             pricing=device.pricing,
             basis_gates=basis_gates,
+            batch_job_support=device.batchJobSupport,
         )
 
     @cached_method(ttl=120)

--- a/qbraid/runtime/result.py
+++ b/qbraid/runtime/result.py
@@ -26,7 +26,7 @@ from typing import Any, Generic
 from qbraid_core import deprecated
 from qbraid_core.system.generic import _datetime_to_str
 
-from .result_data import ResultDataType
+from .result_data import GateModelResultData, ResultDataType
 
 
 class Result(Generic[ResultDataType]):
@@ -90,8 +90,8 @@ class Result(Generic[ResultDataType]):
                 return "{...}"
 
             data = copy.deepcopy(value)
-            if "openQasm" in data and data["openQasm"] is not None:
-                data["openQasm"] = "..."
+            if "compiledOutput" in data and data["compiledOutput"] is not None:
+                data["compiledOutput"] = "..."
             return (
                 "{"
                 + ", ".join(
@@ -124,3 +124,97 @@ class Result(Generic[ResultDataType]):
                 out += f",\n  {key}={formatted_value}"
         out += "\n)"
         return out
+
+
+class BatchResult(Generic[ResultDataType]):
+    """Represents the results of a batch quantum job.
+
+    Wraps a list of per-circuit :class:`Result` objects and provides
+    aggregate access to measurement data and per-circuit metadata.
+
+    Args:
+        device_id: The ID of the device that executed the job.
+        job_id: The ID of the job.
+        success: Whether the job completed successfully.
+        results: Per-circuit Result objects.
+        **kwargs: Aggregate metadata (e.g. time_stamps, cost, status).
+    """
+
+    def __init__(
+        self,
+        device_id: str,
+        job_id: str | int,
+        success: bool,
+        results: list[Result[ResultDataType]],
+        **kwargs,
+    ):
+        self.device_id = device_id
+        self.job_id = job_id
+        self.success = success
+        self._results = results
+        self._aggregate_details = kwargs or {}
+        self._data: ResultDataType | None = None
+
+    @property
+    def num_circuits(self) -> int:
+        """Returns the number of circuits in the batch."""
+        return len(self._results)
+
+    @property
+    def results(self) -> list[Result[ResultDataType]]:
+        """Returns the per-circuit Result objects."""
+        return self._results
+
+    @property
+    def data(self) -> ResultDataType:
+        """Returns aggregated result data across all circuits.
+
+        For gate model jobs, ``get_counts()`` and ``get_probabilities()``
+        return lists indexed by circuit position.
+        """
+        if self._data is None:
+            self._data = self._build_aggregate_data()
+        return self._data
+
+    @property
+    def details(self) -> list[dict[str, Any]]:
+        """Returns per-circuit metadata, indexed by circuit position."""
+        return [r.details for r in self._results]
+
+    def _build_aggregate_data(self) -> ResultDataType:
+        """Collects per-circuit measurement data into a single ResultData."""
+        counts = []
+        probabilities = []
+        has_counts = False
+        has_probs = False
+
+        for r in self._results:
+            rd = r.data
+            if isinstance(rd, GateModelResultData):
+                if rd.measurement_counts is not None:
+                    counts.append(rd.measurement_counts)
+                    has_counts = True
+                else:
+                    counts.append({})
+
+                if rd._measurement_probabilities is not None:
+                    probabilities.append(rd._measurement_probabilities)
+                    has_probs = True
+                else:
+                    probabilities.append({})
+
+        return GateModelResultData(
+            measurement_counts=counts if has_counts else None,
+            measurement_probabilities=probabilities if has_probs else None,
+        )
+
+    def __repr__(self):
+        """Return a string representation of the BatchResult object."""
+        return (
+            f"BatchResult(\n"
+            f"  device_id={self.device_id},\n"
+            f"  job_id={self.job_id},\n"
+            f"  success={self.success},\n"
+            f"  num_circuits={self.num_circuits}\n"
+            f")"
+        )

--- a/qbraid/runtime/result_data.py
+++ b/qbraid/runtime/result_data.py
@@ -45,10 +45,17 @@ class ResultData(ABC):
     specific :class:`~qbraid.programs.ExperimentType`.
     """
 
+    _unscoped_data: dict[str, Any]
+
     @property
     @abstractmethod
     def experiment_type(self) -> ExperimentType:
         """Returns the experiment type."""
+
+    @property
+    def extra(self) -> dict[str, Any]:
+        """Returns metadata fields that are not part of the typed result data."""
+        return self._unscoped_data
 
     @abstractmethod
     def to_dict(self) -> dict[str, Any]:

--- a/qbraid/runtime/result_data.py
+++ b/qbraid/runtime/result_data.py
@@ -221,8 +221,14 @@ class GateModelResultData(ResultData):
 
         counts = self.get_counts()
         probabilities = self.get_probabilities()
-        shots = sum(counts.values())
-        num_measured_qubits = len(next(iter(counts)))
+
+        if isinstance(counts, list):
+            shots = [sum(c.values()) for c in counts]
+            num_measured_qubits = [len(next(iter(c))) for c in counts]
+        else:
+            shots = sum(counts.values())
+            num_measured_qubits = len(next(iter(counts)))
+
         data = {
             "shots": shots,
             "num_measured_qubits": num_measured_qubits,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 rustworkx>=0.15.0
 numpy>=1.17
 openqasm3[parser]>=0.4.0
-qbraid-core>=0.3.0,<0.4.0
+qbraid-core>=0.3.1,<0.4.0
 pydantic>2.0.0
 pydantic-core
 typing-extensions>=4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 rustworkx>=0.15.0
 numpy>=1.17
 openqasm3[parser]>=0.4.0
-qbraid-core>=0.3.1,<0.4.0
+qbraid-core>=0.3.2,<0.4.0
 pydantic>2.0.0
 pydantic-core
 typing-extensions>=4.0.0

--- a/tests/runtime/_resources.py
+++ b/tests/runtime/_resources.py
@@ -173,6 +173,7 @@ DEVICE_DATA_EQUAL1 = {
         "directAccess": True,
         "pricingModel": "fixed",
         "notes": None,
+        "batchJobSupport": True,
     },
 }
 

--- a/tests/runtime/_resources.py
+++ b/tests/runtime/_resources.py
@@ -266,7 +266,6 @@ RESULTS_DATA_QIR = {
     "measurementCounts": {"11111": 4, "00000": 6},
     "runnerVersion": "0.7.4",
     "runnerSeed": None,
-
 }
 
 RESULTS_DATA_NEC = {
@@ -280,7 +279,6 @@ RESULTS_DATA_NEC = {
         }
     ],
     "solutionCount": 1,
-
 }
 
 RESULTS_DATA_AQUILA = {

--- a/tests/runtime/_resources.py
+++ b/tests/runtime/_resources.py
@@ -22,6 +22,7 @@ from unittest.mock import MagicMock
 
 from qbraid_core.services.runtime.exceptions import QuantumRuntimeServiceRequestError
 from qbraid_core.services.runtime.schemas import (
+    BatchResult,
     GroupJob,
     JobRequest,
     Program,
@@ -622,16 +623,16 @@ class MockClient:
 
         return RuntimeJob.model_validate(job_data_copy)
 
-    def get_job_result(self, job_qrn: str) -> Result | list[Result]:
+    def get_job_result(self, job_qrn: str) -> Result | BatchResult:
         """Returns the results for a specific quantum job.
 
-        For batch jobs (numCircuits > 1), returns a list of Result objects.
+        For batch jobs (numCircuits > 1), returns a BatchResult.
         """
         # Check batch results map first
         if job_qrn in self.BATCH_RESULTS_MAP:
             batch_results_data = self.BATCH_RESULTS_MAP[job_qrn]
             batch_job_data = self.BATCH_JOB_MAP.get(job_qrn, {})
-            results = []
+            per_circuit = []
             for circuit_result_data in batch_results_data:
                 result_response = {
                     "status": "COMPLETED",
@@ -639,8 +640,13 @@ class MockClient:
                     "timeStamps": batch_job_data.get("timeStamps", {}),
                     "resultData": circuit_result_data,
                 }
-                results.append(Result.model_validate(result_response))
-            return results
+                per_circuit.append(Result.model_validate(result_response))
+            return BatchResult(
+                status=per_circuit[0].status,
+                cost=per_circuit[0].cost,
+                timeStamps=per_circuit[0].timeStamps,
+                results=per_circuit,
+            )
 
         # Try job QRN mapping first
         device_qrn = self.JOB_QRN_TO_DEVICE.get(job_qrn)

--- a/tests/runtime/_resources.py
+++ b/tests/runtime/_resources.py
@@ -392,6 +392,39 @@ RESULTS_DATA_EQUAL1 = {
     "executionOptions": None,
 }
 
+# ── Batch job mock data ──────────────────────────────────────────────────
+
+JOB_DATA_BATCH_EQUAL1 = {
+    "jobQrn": "qbraid:equal1:sim:bell-1-37f5-qjob-batch001",
+    "groupJobQrn": None,
+    "vendor": "qbraid",
+    "provider": "equal1",
+    "status": "COMPLETED",
+    "statusMsg": None,
+    "experimentType": "gate_model",
+    "queuePosition": None,
+    "timeStamps": {
+        "createdAt": "2026-01-20T10:00:00.000Z",
+        "endedAt": "2026-01-20T10:00:05.000Z",
+        "executionDuration": 150,
+    },
+    "cost": 0.045,
+    "estimatedCost": 0.045,
+    "metadata": {},
+    "name": "Equal1 Batch Job",
+    "shots": 100,
+    "deviceQrn": "qbraid:equal1:sim:bell-1",
+    "tags": {},
+    "runtimeOptions": {},
+    "numCircuits": 3,
+}
+
+RESULTS_DATA_BATCH_EQUAL1 = [
+    {"measurementCounts": {"00": 60, "11": 40}},
+    {"measurementCounts": {"0": 100}},
+    {"measurementCounts": {"01": 30, "10": 70}},
+]
+
 
 class MockClient:
     """Mock client for testing with Runtime API format."""
@@ -417,12 +450,21 @@ class MockClient:
         "qbraid:equal1:sim:bell-1": RESULTS_DATA_EQUAL1,
     }
 
+    BATCH_JOB_MAP = {
+        "qbraid:equal1:sim:bell-1-37f5-qjob-batch001": JOB_DATA_BATCH_EQUAL1,
+    }
+
+    BATCH_RESULTS_MAP = {
+        "qbraid:equal1:sim:bell-1-37f5-qjob-batch001": RESULTS_DATA_BATCH_EQUAL1,
+    }
+
     # Job QRN to device QRN mapping
     JOB_QRN_TO_DEVICE = {
         "aws:quera:qpu:aquila-37f5-qjob-696aae286a18e4f726abf2af": "aws:quera:qpu:aquila",
         "qbraid:qbraid:sim:qir-sv-37f5-qjob-1234567890": "qbraid:qbraid:sim:qir-sv",
         "qbraid:nec:sim:vector-annealer-37f5-qjob-1234567890": "qbraid:nec:sim:vector-annealer",
         "qbraid:equal1:sim:bell-1-37f5-qjob-2ht3zyghhxsr8gqbu8yj": "qbraid:equal1:sim:bell-1",
+        "qbraid:equal1:sim:bell-1-37f5-qjob-batch001": "qbraid:equal1:sim:bell-1",
     }
 
     @property
@@ -521,14 +563,18 @@ class MockClient:
         if shots is None:
             shots = 100  # Default for jobs that don't specify shots
 
+        # Determine if this is a batch submission
+        is_batch = isinstance(request.program, list) and len(request.program) > 1
+        num_circuits = len(request.program) if is_batch else None
+
         job_response = {
             "name": job_data.get("name"),
             "shots": shots,
             "deviceQrn": device_qrn,
             "tags": job_data.get("tags", {}),
             "runtimeOptions": job_data.get("runtimeOptions", {}),
-            "jobQrn": job_data.get("jobQrn"),
-            "groupJobQrn": job_data.get("groupJobQrn"),
+            "jobQrn": JOB_DATA_BATCH_EQUAL1["jobQrn"] if is_batch else job_data.get("jobQrn"),
+            "groupJobQrn": request.groupJobQrn or job_data.get("groupJobQrn"),
             "vendor": job_data.get("vendor"),
             "provider": job_data.get("provider"),
             "status": "INITIALIZING",
@@ -540,10 +586,18 @@ class MockClient:
             "estimatedCost": job_data.get("estimatedCost", 130),
             "metadata": job_data.get("metadata", {}),
         }
+        if num_circuits is not None:
+            job_response["numCircuits"] = num_circuits
         return RuntimeJob.model_validate(job_response)
 
     def get_job(self, job_qrn: str) -> RuntimeJob:
         """Returns the metadata for a specific quantum job."""
+        # Check batch job map first
+        if job_qrn in self.BATCH_JOB_MAP:
+            job_data = self.BATCH_JOB_MAP[job_qrn]
+            job_data_copy = job_data.copy()
+            return RuntimeJob.model_validate(job_data_copy)
+
         # Try job QRN mapping first
         device_qrn = self.JOB_QRN_TO_DEVICE.get(job_qrn)
         if device_qrn:
@@ -567,8 +621,26 @@ class MockClient:
 
         return RuntimeJob.model_validate(job_data_copy)
 
-    def get_job_result(self, job_qrn: str) -> Result:
-        """Returns the results for a specific quantum job."""
+    def get_job_result(self, job_qrn: str) -> Result | list[Result]:
+        """Returns the results for a specific quantum job.
+
+        For batch jobs (numCircuits > 1), returns a list of Result objects.
+        """
+        # Check batch results map first
+        if job_qrn in self.BATCH_RESULTS_MAP:
+            batch_results_data = self.BATCH_RESULTS_MAP[job_qrn]
+            batch_job_data = self.BATCH_JOB_MAP.get(job_qrn, {})
+            results = []
+            for circuit_result_data in batch_results_data:
+                result_response = {
+                    "status": "COMPLETED",
+                    "cost": str(batch_job_data.get("cost", 0)),
+                    "timeStamps": batch_job_data.get("timeStamps", {}),
+                    "resultData": circuit_result_data,
+                }
+                results.append(Result.model_validate(result_response))
+            return results
+
         # Try job QRN mapping first
         device_qrn = self.JOB_QRN_TO_DEVICE.get(job_qrn)
         if not device_qrn:

--- a/tests/runtime/_resources.py
+++ b/tests/runtime/_resources.py
@@ -178,15 +178,6 @@ DEVICE_DATA_EQUAL1 = {
     },
 }
 
-REDUNDANT_JOB_DATA = {
-    "timeStamps": {
-        "createdAt": "2024-05-23T01:39:11.288Z",
-        "endedAt": "2024-05-23T01:39:11.304Z",
-        "executionDuration": 16,
-    },
-    "status": "COMPLETED",
-}
-
 JOB_DATA_QIR = {
     "jobQrn": "qbraid:qbraid:sim:qir-sv-37f5-qjob-1234567890",
     "groupJobQrn": None,
@@ -275,7 +266,7 @@ RESULTS_DATA_QIR = {
     "measurementCounts": {"11111": 4, "00000": 6},
     "runnerVersion": "0.7.4",
     "runnerSeed": None,
-    **REDUNDANT_JOB_DATA,
+
 }
 
 RESULTS_DATA_NEC = {
@@ -289,7 +280,7 @@ RESULTS_DATA_NEC = {
         }
     ],
     "solutionCount": 1,
-    **REDUNDANT_JOB_DATA,
+
 }
 
 RESULTS_DATA_AQUILA = {

--- a/tests/runtime/native/test_batch_jobs.py
+++ b/tests/runtime/native/test_batch_jobs.py
@@ -24,7 +24,7 @@ from unittest.mock import patch
 import pytest
 
 from qbraid._caching import cache_disabled
-from qbraid.runtime import Result
+from qbraid.runtime import BatchResult, Result
 from qbraid.runtime.group import GroupJobSession
 from qbraid.runtime.native import QbraidProvider
 from qbraid.runtime.native.job import QbraidJob
@@ -121,43 +121,69 @@ class TestBatchSubmission:
 class TestBatchResult:
     """Tests for QbraidJob.result() with batch jobs (numCircuits > 1)."""
 
-    def test_batch_result_returns_list(self, device, client):
-        """result() for a batch job returns a list[Result] of correct length."""
+    def test_batch_result_returns_batch_result(self, device, client):
+        """result() for a batch job returns a BatchResult."""
         job = QbraidJob(
             job_id=JOB_DATA_BATCH_EQUAL1["jobQrn"],
             device=device,
             client=client,
         )
-        results = job.result()
-        assert isinstance(results, list)
-        assert len(results) == 3
+        result = job.result()
+        assert isinstance(result, BatchResult)
+        assert result.num_circuits == 3
 
-    def test_batch_result_individual_data(self, device, client):
-        """Each Result in the batch has the correct measurementCounts."""
+    def test_batch_result_per_circuit_data(self, device, client):
+        """Each per-circuit Result has the correct measurementCounts."""
         job = QbraidJob(
             job_id=JOB_DATA_BATCH_EQUAL1["jobQrn"],
             device=device,
             client=client,
         )
-        results = job.result()
-        for i, result in enumerate(results):
-            assert result.data.get_counts() == RESULTS_DATA_BATCH_EQUAL1[i]["measurementCounts"]
+        result = job.result()
+        for i, circuit_result in enumerate(result.results):
+            assert (
+                circuit_result.data.get_counts()
+                == RESULTS_DATA_BATCH_EQUAL1[i]["measurementCounts"]
+            )
+
+    def test_batch_result_aggregate_counts(self, device, client):
+        """Aggregate data.get_counts() returns a list of all circuit counts."""
+        job = QbraidJob(
+            job_id=JOB_DATA_BATCH_EQUAL1["jobQrn"],
+            device=device,
+            client=client,
+        )
+        result = job.result()
+        counts = result.data.get_counts()
+        assert isinstance(counts, list)
+        assert len(counts) == 3
+
+    def test_batch_result_details_indexed(self, device, client):
+        """details returns a list of per-circuit detail dicts."""
+        job = QbraidJob(
+            job_id=JOB_DATA_BATCH_EQUAL1["jobQrn"],
+            device=device,
+            client=client,
+        )
+        result = job.result()
+        details = result.details
+        assert isinstance(details, list)
+        assert len(details) == 3
 
     def test_batch_result_metadata(self, device, client):
-        """Each Result has correct device_id, job_id, and success flag."""
+        """BatchResult has correct device_id, job_id, and success flag."""
         job = QbraidJob(
             job_id=JOB_DATA_BATCH_EQUAL1["jobQrn"],
             device=device,
             client=client,
         )
-        results = job.result()
-        for result in results:
-            assert result.device_id == JOB_DATA_BATCH_EQUAL1["deviceQrn"]
-            assert result.job_id == JOB_DATA_BATCH_EQUAL1["jobQrn"]
-            assert result.success is True
+        result = job.result()
+        assert result.device_id == JOB_DATA_BATCH_EQUAL1["deviceQrn"]
+        assert result.job_id == JOB_DATA_BATCH_EQUAL1["jobQrn"]
+        assert result.success is True
 
     def test_single_circuit_result_unchanged(self, device, client):
-        """Single-circuit job still returns a single Result (not a list)."""
+        """Single-circuit job still returns a single Result (not BatchResult)."""
         job = QbraidJob(
             job_id=JOB_DATA_EQUAL1["jobQrn"],
             device=device,
@@ -165,11 +191,10 @@ class TestBatchResult:
         )
         result = job.result()
         assert isinstance(result, Result)
-        assert not isinstance(result, list)
+        assert not isinstance(result, BatchResult)
 
     def test_batch_result_failed_job(self, device, client):
-        """A failed batch job returns a list of failed Result objects."""
-        # Temporarily set the batch job status to FAILED
+        """A failed batch job returns a BatchResult with success=False."""
         original_status = JOB_DATA_BATCH_EQUAL1["status"]
         JOB_DATA_BATCH_EQUAL1["status"] = "FAILED"
         try:
@@ -178,10 +203,11 @@ class TestBatchResult:
                 device=device,
                 client=client,
             )
-            results = job.result()
-            assert isinstance(results, list)
-            assert len(results) == 3
-            for result in results:
-                assert result.success is False
+            result = job.result()
+            assert isinstance(result, BatchResult)
+            assert result.num_circuits == 3
+            assert result.success is False
+            for circuit_result in result.results:
+                assert circuit_result.success is False
         finally:
             JOB_DATA_BATCH_EQUAL1["status"] = original_status

--- a/tests/runtime/native/test_batch_jobs.py
+++ b/tests/runtime/native/test_batch_jobs.py
@@ -1,0 +1,184 @@
+# Copyright 2025 qBraid
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for batch job support (as_batch=True).
+
+Tests batch submission through QbraidDevice and batch result parsing
+through QbraidJob.result().
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from qbraid._caching import cache_disabled
+from qbraid.runtime import Result
+from qbraid.runtime.group import GroupJobSession
+from qbraid.runtime.native import QbraidProvider
+from qbraid.runtime.native.job import QbraidJob
+
+from .._resources import (
+    JOB_DATA_BATCH_EQUAL1,
+    JOB_DATA_EQUAL1,
+    RESULTS_DATA_BATCH_EQUAL1,
+    MockClient,
+)
+
+
+@pytest.fixture
+def client():
+    """Create a fresh MockClient for each test."""
+    return MockClient()
+
+
+@pytest.fixture
+def device(client):
+    """Create a QbraidDevice backed by the MockClient via QbraidProvider."""
+    provider = QbraidProvider(client=client)
+    with cache_disabled(provider):
+        return provider.get_device("qbraid:equal1:sim:bell-1")
+
+
+QASM_H = (
+    'OPENQASM 2.0;\ninclude "qelib1.inc";\n'
+    "qreg q[2];\ncreg c[1];\nh q[0];\nmeasure q[0] -> c[0];"
+)
+QASM_X = (
+    'OPENQASM 2.0;\ninclude "qelib1.inc";\n'
+    "qreg q[2];\ncreg c[1];\nx q[0];\nmeasure q[0] -> c[0];"
+)
+QASM_CX = (
+    'OPENQASM 2.0;\ninclude "qelib1.inc";\n'
+    "qreg q[2];\ncreg c[2];\ncx q[0],q[1];\n"
+    "measure q[0] -> c[0];\nmeasure q[1] -> c[1];"
+)
+
+
+@pytest.fixture
+def batch_programs():
+    """Three QASM2 programs for batch submission."""
+    return [QASM_H, QASM_X, QASM_CX]
+
+
+# ── Batch Submission Tests ────────────────────────────────────────────
+
+
+class TestBatchSubmission:
+    """Tests for device.run(programs, as_batch=True) submission flow."""
+
+    def test_batch_submit_returns_single_job(self, device, batch_programs):
+        """Batch submit returns a single QbraidJob (not a list)."""
+        job = device.run(batch_programs, as_batch=True, shots=100)
+        assert isinstance(job, QbraidJob)
+
+    def test_batch_submit_calls_create_job_once(self, device, batch_programs):
+        """Batch submit calls client.create_job exactly once with program as list."""
+        with patch.object(device.client, "create_job", wraps=device.client.create_job) as spy:
+            device.run(batch_programs, as_batch=True, shots=100)
+            assert spy.call_count == 1
+            request = spy.call_args[0][0]
+            assert isinstance(request.program, list)
+            assert len(request.program) == 3
+
+    def test_batch_submit_non_list_raises(self, device):
+        """as_batch=True with a single (non-list) program raises ValueError."""
+        single = 'OPENQASM 2.0;\ninclude "qelib1.inc";\nqreg q[1];\nh q[0];'
+        with pytest.raises(ValueError, match="requires a list"):
+            device.run(single, as_batch=True)
+
+    def test_batch_submit_over_200_raises(self, device):
+        """as_batch=True with > 200 circuits raises ValueError."""
+        programs = ['OPENQASM 2.0;\ninclude "qelib1.inc";\nqreg q[1];\nh q[0];'] * 201
+        with pytest.raises(ValueError, match="limited to 200"):
+            device.run(programs, as_batch=True)
+
+    def test_batch_submit_with_group_session(self, device, batch_programs):
+        """Batch submit inside a GroupJobSession passes groupJobQrn."""
+        with GroupJobSession(client=device.client, name="test-group") as session:
+            job = device.run(batch_programs, as_batch=True, shots=100)
+            assert isinstance(job, QbraidJob)
+            assert job in session.jobs
+
+
+# ── Batch Result Tests ────────────────────────────────────────────────
+
+
+class TestBatchResult:
+    """Tests for QbraidJob.result() with batch jobs (numCircuits > 1)."""
+
+    def test_batch_result_returns_list(self, device, client):
+        """result() for a batch job returns a list[Result] of correct length."""
+        job = QbraidJob(
+            job_id=JOB_DATA_BATCH_EQUAL1["jobQrn"],
+            device=device,
+            client=client,
+        )
+        results = job.result()
+        assert isinstance(results, list)
+        assert len(results) == 3
+
+    def test_batch_result_individual_data(self, device, client):
+        """Each Result in the batch has the correct measurementCounts."""
+        job = QbraidJob(
+            job_id=JOB_DATA_BATCH_EQUAL1["jobQrn"],
+            device=device,
+            client=client,
+        )
+        results = job.result()
+        for i, result in enumerate(results):
+            assert result.data.get_counts() == RESULTS_DATA_BATCH_EQUAL1[i]["measurementCounts"]
+
+    def test_batch_result_metadata(self, device, client):
+        """Each Result has correct device_id, job_id, and success flag."""
+        job = QbraidJob(
+            job_id=JOB_DATA_BATCH_EQUAL1["jobQrn"],
+            device=device,
+            client=client,
+        )
+        results = job.result()
+        for result in results:
+            assert result.device_id == JOB_DATA_BATCH_EQUAL1["deviceQrn"]
+            assert result.job_id == JOB_DATA_BATCH_EQUAL1["jobQrn"]
+            assert result.success is True
+
+    def test_single_circuit_result_unchanged(self, device, client):
+        """Single-circuit job still returns a single Result (not a list)."""
+        job = QbraidJob(
+            job_id=JOB_DATA_EQUAL1["jobQrn"],
+            device=device,
+            client=client,
+        )
+        result = job.result()
+        assert isinstance(result, Result)
+        assert not isinstance(result, list)
+
+    def test_batch_result_failed_job(self, device, client):
+        """A failed batch job returns a list of failed Result objects."""
+        # Temporarily set the batch job status to FAILED
+        original_status = JOB_DATA_BATCH_EQUAL1["status"]
+        JOB_DATA_BATCH_EQUAL1["status"] = "FAILED"
+        try:
+            job = QbraidJob(
+                job_id=JOB_DATA_BATCH_EQUAL1["jobQrn"],
+                device=device,
+                client=client,
+            )
+            results = job.result()
+            assert isinstance(results, list)
+            assert len(results) == 3
+            for result in results:
+                assert result.success is False
+        finally:
+            JOB_DATA_BATCH_EQUAL1["status"] = original_status

--- a/tests/runtime/native/test_batch_jobs.py
+++ b/tests/runtime/native/test_batch_jobs.py
@@ -28,6 +28,7 @@ from qbraid.runtime import BatchResult, Result
 from qbraid.runtime.group import GroupJobSession
 from qbraid.runtime.native import QbraidProvider
 from qbraid.runtime.native.job import QbraidJob
+from qbraid.runtime.result_data import GateModelResultData
 
 from .._resources import (
     JOB_DATA_BATCH_EQUAL1,
@@ -98,8 +99,8 @@ class TestBatchSubmission:
         with cache_disabled(provider):
             qir_device = provider.get_device("qbraid:qbraid:sim:qir-sv")
         programs = [QASM_H, QASM_X]
-        with pytest.raises(ValueError, match="not supported"):
-            qir_device.run(programs, as_batch=True)
+        with pytest.raises(ValueError, match="Batch jobs are not supported"):
+            qir_device.submit(programs, as_batch=True)
 
     def test_batch_submit_non_list_raises(self, device):
         """as_batch=True with a single (non-list) program raises ValueError."""
@@ -211,3 +212,105 @@ class TestBatchResult:
                 assert circuit_result.success is False
         finally:
             JOB_DATA_BATCH_EQUAL1["status"] = original_status
+
+    def test_single_circuit_failed_result(self, device, client):
+        """A failed single-circuit job returns a Result with success=False and empty data."""
+        original_status = JOB_DATA_EQUAL1["status"]
+        JOB_DATA_EQUAL1["status"] = "FAILED"
+        try:
+            job = QbraidJob(
+                job_id=JOB_DATA_EQUAL1["jobQrn"],
+                device=device,
+                client=client,
+            )
+            result = job.result()
+            assert isinstance(result, Result)
+            assert not isinstance(result, BatchResult)
+            assert result.success is False
+        finally:
+            JOB_DATA_EQUAL1["status"] = original_status
+
+    def test_batch_result_circuit_without_counts(self, device, client):
+        """BatchResult handles circuits with no measurementCounts (None)."""
+        original_results = list(RESULTS_DATA_BATCH_EQUAL1)
+        RESULTS_DATA_BATCH_EQUAL1.clear()
+        RESULTS_DATA_BATCH_EQUAL1.extend(
+            [
+                {"measurementCounts": {"00": 50, "11": 50}},
+                {},  # no measurementCounts
+                {"measurementCounts": {"01": 30, "10": 70}},
+            ]
+        )
+        try:
+            job = QbraidJob(
+                job_id=JOB_DATA_BATCH_EQUAL1["jobQrn"],
+                device=device,
+                client=client,
+            )
+            result = job.result()
+            counts = result.data.get_counts()
+            assert isinstance(counts, list)
+            assert len(counts) == 3
+            assert counts[1] == {}
+        finally:
+            RESULTS_DATA_BATCH_EQUAL1.clear()
+            RESULTS_DATA_BATCH_EQUAL1.extend(original_results)
+
+    def test_batch_result_with_probabilities(self):
+        """BatchResult._build_aggregate_data collects probabilities when present."""
+        result_data = GateModelResultData(
+            measurement_counts={"00": 50, "11": 50},
+            measurement_probabilities={"00": 0.5, "11": 0.5},
+        )
+        per_circuit = [
+            Result(
+                device_id="qbraid:equal1:sim:bell-1",
+                job_id="test-batch",
+                success=True,
+                data=result_data,
+            ),
+            Result(
+                device_id="qbraid:equal1:sim:bell-1",
+                job_id="test-batch",
+                success=True,
+                data=result_data,
+            ),
+        ]
+        batch = BatchResult(
+            device_id="qbraid:equal1:sim:bell-1",
+            job_id="test-batch",
+            success=True,
+            results=per_circuit,
+        )
+        # Access aggregate data to trigger _build_aggregate_data
+        agg = batch.data
+        assert isinstance(agg, GateModelResultData)
+        # The aggregate stores probabilities as a list internally
+        assert agg._measurement_probabilities is not None
+        assert isinstance(agg._measurement_probabilities, list)
+        assert len(agg._measurement_probabilities) == 2
+
+    def test_batch_result_to_dict_with_list_counts(self, device, client):
+        """GateModelResultData.to_dict() works with list-of-dicts counts (batch aggregate)."""
+        job = QbraidJob(
+            job_id=JOB_DATA_BATCH_EQUAL1["jobQrn"],
+            device=device,
+            client=client,
+        )
+        result = job.result()
+        data_dict = result.data.to_dict()
+        assert isinstance(data_dict["shots"], list)
+        assert isinstance(data_dict["num_measured_qubits"], list)
+        assert len(data_dict["shots"]) == 3
+
+    def test_batch_result_repr(self, device, client):
+        """BatchResult repr contains key metadata."""
+        job = QbraidJob(
+            job_id=JOB_DATA_BATCH_EQUAL1["jobQrn"],
+            device=device,
+            client=client,
+        )
+        result = job.result()
+        r = repr(result)
+        assert "BatchResult" in r
+        assert "num_circuits=3" in r

--- a/tests/runtime/native/test_batch_jobs.py
+++ b/tests/runtime/native/test_batch_jobs.py
@@ -92,17 +92,20 @@ class TestBatchSubmission:
             assert isinstance(request.program, list)
             assert len(request.program) == 3
 
+    def test_batch_submit_unsupported_device_raises(self, client):
+        """as_batch=True on a device without batch support raises ValueError."""
+        provider = QbraidProvider(client=client)
+        with cache_disabled(provider):
+            qir_device = provider.get_device("qbraid:qbraid:sim:qir-sv")
+        programs = [QASM_H, QASM_X]
+        with pytest.raises(ValueError, match="not supported"):
+            qir_device.run(programs, as_batch=True)
+
     def test_batch_submit_non_list_raises(self, device):
         """as_batch=True with a single (non-list) program raises ValueError."""
         single = 'OPENQASM 2.0;\ninclude "qelib1.inc";\nqreg q[1];\nh q[0];'
-        with pytest.raises(ValueError, match="requires a list"):
+        with pytest.raises(ValueError, match="require a list"):
             device.run(single, as_batch=True)
-
-    def test_batch_submit_over_200_raises(self, device):
-        """as_batch=True with > 200 circuits raises ValueError."""
-        programs = ['OPENQASM 2.0;\ninclude "qelib1.inc";\nqreg q[1];\nh q[0];'] * 201
-        with pytest.raises(ValueError, match="limited to 200"):
-            device.run(programs, as_batch=True)
 
     def test_batch_submit_with_group_session(self, device, batch_programs):
         """Batch submit inside a GroupJobSession passes groupJobQrn."""

--- a/tests/runtime/test_result.py
+++ b/tests/runtime/test_result.py
@@ -639,10 +639,10 @@ def test_format_value_list_with_depth(result_instance):
     assert result_instance._format_value(test_list, depth=2) == "[...]"
 
 
-def test_format_value_dict_with_openqasm(result_instance):
-    """Test _format_value with a dict with openQasm key."""
-    test_dict = {"openQasm": "OPENQASM 2.0;"}
-    assert result_instance._format_value(test_dict) == "{openQasm: '...'}"
+def test_format_value_dict_with_compiled_output(result_instance):
+    """Test _format_value with a dict with compiledOutput key."""
+    test_dict = {"compiledOutput": "base64encodeddata"}
+    assert result_instance._format_value(test_dict) == "{compiledOutput: '...'}"
 
 
 def test_format_value_catch_all(result_instance):


### PR DESCRIPTION
## Summary

- Add `as_batch=True` parameter to `device.run()` / `device.submit()` to submit a list of circuits as a single batch job (one VRN, one status, one result)
- `QbraidJob.result()` returns `list[Result]` for batch jobs (`numCircuits > 1`) and a single `Result` for regular jobs
- Batch jobs are limited to 2000 circuits max
- Compatible with existing `GroupJobSession` context