### PR TITLE
Remove QirRunner import from  runtime namespace [no ci]

### DIFF
--- a/qbraid/runtime/__init__.py
+++ b/qbraid/runtime/__init__.py
@@ -214,7 +214,6 @@ if TYPE_CHECKING:
     from .native import QbraidJob as QbraidJob
     from .native import QbraidProvider as QbraidProvider
     from .native import QbraidSessionV1 as QbraidSessionV1
-    from .native import QirRunner as QirRunner
     from .native import Session as Session
     from .oqc import OQCDevice as OQCDevice
     from .oqc import OQCJob as OQCJob


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

- Removes import of the `QirRunner` class from the `qbraid/runtime/__init__.py`