### PR TITLE
Change log level from warning to info for unregistered program

### DIFF
--- a/qbraid/runtime/native/provider.py
+++ b/qbraid/runtime/native/provider.py
@@ -162,7 +162,7 @@ class QbraidProvider(QuantumProvider):
 
         program_type = QPROGRAM_REGISTRY.get(run_package)
         if program_type is None:
-            logger.warning(
+            logger.info(
                 "The default runtime configuration for device '%s' includes "
                 "transpilation to program type '%s', which is not registered.",
                 device_id,

--- a/tests/runtime/test_device.py
+++ b/tests/runtime/test_device.py
@@ -611,7 +611,7 @@ def test_get_program_spec_not_registered_warning(caplog):
     """Test that a warning is logged when the program type is not registered."""
     run_package = "not_registered"
     device_id = "fake_device"
-    with caplog.at_level(logging.WARNING, logger="qbraid"):
+    with caplog.at_level(logging.INFO, logger="qbraid"):
         QbraidProvider._get_program_spec(run_package, device_id)
     assert any(
         f"device '{device_id}'" in record.message and f"'{run_package}'" in record.message


### PR DESCRIPTION
<!--
Before submitting a pull request, please complete the following checklist:

1. Read PR Guidelines: https://github.com/qBraid/qBraid/blob/main/CONTRIBUTING.md#pull-requests
2. Link Issues: Please link any issues that this PR aims to resolve or is related to.
3. Update Changelog: Add an entry to `CHANGELOG.md` summarizing the change, and including a link back to the PR.

Draft PRs are welcome if your code is still a work-in-progress.
-->

## Summary of changes

This pull request makes a minor logging adjustment in the `qbraid/runtime/native/provider.py` file. The log level for when an unregistered program type is encountered has been changed from a warning to an informational message. 

* Changed the log statement in `_get_program_spec` to use `logger.info` instead of `logger.warning` when the default runtime configuration includes a program type that is not registered.
