### PR TITLE
Skip auth headers for public IonQ /backends endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ Types of changes:
 ## [Unreleased]
 
 ### Added
-- Added `_get_public` method in `IonQProvider` class to make GET requests without auth headers for public endpoints ([#1194](https://github.com/qBraid/qBraid/pull/1194))
 
 ### Improved / Modified
 - Modified `get_devices` and `get_device` methods in `IonQProvider` to use public endpoint access instead of authenticated requests ([#1194](https://github.com/qBraid/qBraid/pull/1194))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@ Types of changes:
 ## [Unreleased]
 
 ### Added
+- Added `_get_public` method in `IonQProvider` class to make GET requests without auth headers for public endpoints ([#1194](https://github.com/qBraid/qBraid/pull/1194))
 
 ### Improved / Modified
+- Modified `get_devices` and `get_device` methods in `IonQProvider` to use public endpoint access instead of authenticated requests ([#1194](https://github.com/qBraid/qBraid/pull/1194))
 
 ### Deprecated
 
@@ -26,6 +28,7 @@ Types of changes:
 ### Fixed
 
 ### Dependencies
+- Added `requests` import as `http_requests` in `qbraid.runtime.ionq.provider` module ([#1194](https://github.com/qBraid/qBraid/pull/1194))
 
 ## [0.12.1] - 2026-05-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ Types of changes:
 ### Fixed
 
 ### Dependencies
-- Added `requests` import as `http_requests` in `qbraid.runtime.ionq.provider` module ([#1194](https://github.com/qBraid/qBraid/pull/1194))
 
 ## [0.12.1] - 2026-05-17
 

--- a/qbraid/runtime/ionq/provider.py
+++ b/qbraid/runtime/ionq/provider.py
@@ -20,6 +20,7 @@ Module defining IonQ session and provider classes
 import os
 from typing import Any, Optional
 
+import requests as http_requests
 from qbraid_core.sessions import Session
 
 from qbraid._caching import cached_method
@@ -61,16 +62,24 @@ class IonQSession(Session):
         self.api_key = api_key
         self.add_user_agent(f"QbraidSDK/{qbraid_version}")
 
+    def _get_public(self, path: str, **kwargs) -> http_requests.Response:
+        """Make a GET request without auth headers for public endpoints."""
+        url = self.base_url.rstrip("/") + "/" + path.lstrip("/")
+        timeout = kwargs.pop("timeout", 30)
+        response = http_requests.get(url, timeout=timeout, **kwargs)
+        response.raise_for_status()
+        return response
+
     def get_devices(self, **kwargs) -> dict[str, dict[str, Any]]:
         """Get all IonQ devices."""
-        devices_list = self.get("/backends", **kwargs).json()
+        devices_list = self._get_public("/backends", **kwargs).json()
         devices_dict = {device["backend"]: device for device in devices_list}
         return devices_dict
 
     def get_device(self, device_id: str) -> dict[str, Any]:
         """Get a specific IonQ device."""
         try:
-            return self.get(f"/backends/{device_id}").json()
+            return self._get_public(f"/backends/{device_id}").json()
         except Exception as err:
             raise ResourceNotFoundError(f"Device '{device_id}' not found.") from err
 

--- a/tests/runtime/native/test_ionq_runtime_remote.py
+++ b/tests/runtime/native/test_ionq_runtime_remote.py
@@ -50,7 +50,7 @@ def test_qiskit_ionq_workflow():
             qiskit_circuit_transpiled = qiskit.transpile(qiskit_circuit, qiskit_ionq_backend)
 
         provider = QbraidProvider()
-        device = provider.get_device("azure:ionq:sim:simulator")
+        device = provider.get_device("ionq:ionq:sim:simulator")
 
         shots = 10
         job: QbraidJob = device.run(qiskit_circuit_transpiled, shots=shots)


### PR DESCRIPTION
## Summary
- IonQ's API returns 401 when an `Authorization` header is sent to its unauthenticated `/backends` routes. Added `_get_public` helper to `IonQSession` that uses plain `requests.get` (no auth headers) for `get_devices` and `get_device`.
- Authenticated endpoints (`/jobs`, `/characterizations`) continue using the session as before.
- Updated test device ID from `azure:ionq:sim:simulator` to `ionq:ionq:sim:simulator`.

## Test plan
- [x] Verified `GET /backends` and `GET /backends/{id}` return 200 without auth, 401 with auth
- [x] Verified `GET /backends/{id}/characterizations/{id}` still requires auth (unchanged)
- [x] All 37 IonQ tests pass (`pytest tests/runtime/ionq/ --remote true`)
- [x] Pylint clean (no new warnings)