### PR TITLE
Use centralized logger in Rigetti, Origin, and Quantinuum runtime modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Types of changes:
 ### Added
 
 ### Improved / Modified
+- Replaced `logging.getLogger(__name__)` with centralized `from qbraid._logging import logger` in Rigetti, Origin Quantum, and Quantinuum runtime modules ([#PLACEHOLDER](https://github.com/qBraid/qBraid/pull/PLACEHOLDER))
 - Modified `get_devices` and `get_device` methods in `IonQProvider` to use public endpoint access instead of authenticated requests ([#1194](https://github.com/qBraid/qBraid/pull/1194))
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Types of changes:
 ### Added
 
 ### Improved / Modified
-- Replaced `logging.getLogger(__name__)` with centralized `from qbraid._logging import logger` in Rigetti, Origin Quantum, and Quantinuum runtime modules ([#PLACEHOLDER](https://github.com/qBraid/qBraid/pull/PLACEHOLDER))
+- Replaced `logging.getLogger(__name__)` with centralized `from qbraid._logging import logger` in Rigetti, Origin Quantum, and Quantinuum runtime modules ([#1197](https://github.com/qBraid/qBraid/pull/1197))
 - Modified `get_devices` and `get_device` methods in `IonQProvider` to use public endpoint access instead of authenticated requests ([#1194](https://github.com/qBraid/qBraid/pull/1194))
 
 ### Deprecated

--- a/qbraid/runtime/origin/device.py
+++ b/qbraid/runtime/origin/device.py
@@ -18,7 +18,6 @@ Module defining OriginQ device class.
 """
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING
 
 from qbraid.runtime.device import QuantumDevice
@@ -31,8 +30,6 @@ from .job import OriginJob
 if TYPE_CHECKING:
     from pyqpanda3.core import QProg
     from pyqpanda3.qcloud import QCloudBackend, QCloudService
-
-logger = logging.getLogger(__name__)
 
 
 class OriginDeviceError(QbraidRuntimeError):

--- a/qbraid/runtime/origin/job.py
+++ b/qbraid/runtime/origin/job.py
@@ -19,10 +19,10 @@ Module defining OriginQ job class.
 from __future__ import annotations
 
 import json
-import logging
 import os
 from typing import TYPE_CHECKING, Any
 
+from qbraid._logging import logger
 from qbraid.runtime.enums import JobStatus
 from qbraid.runtime.exceptions import QbraidRuntimeError
 from qbraid.runtime.job import QuantumJob
@@ -34,8 +34,6 @@ if TYPE_CHECKING:
     from pyqpanda3.qcloud.qcloud import JobStatus as OriginJobStatus
 
     from qbraid.runtime.origin.device import OriginDevice
-
-logger = logging.getLogger(__name__)
 
 _ORIGIN_STATUS_MAP: dict[str, JobStatus] = {
     "FINISHED": JobStatus.COMPLETED,

--- a/qbraid/runtime/origin/provider.py
+++ b/qbraid/runtime/origin/provider.py
@@ -18,11 +18,11 @@ Module defining OriginQ provider class.
 """
 from __future__ import annotations
 
-import logging
 import os
 from typing import TYPE_CHECKING
 
 from qbraid._caching import cached_method
+from qbraid._logging import logger
 from qbraid.programs import ExperimentType, ProgramSpec
 from qbraid.runtime.profile import TargetProfile
 from qbraid.runtime.provider import QuantumProvider
@@ -31,8 +31,6 @@ from .device import OriginDevice
 
 if TYPE_CHECKING:
     from pyqpanda3.qcloud import QCloudBackend, QCloudService
-
-logger = logging.getLogger(__name__)
 
 SIMULATOR_BACKENDS: dict[str, int] = {
     "full_amplitude": 35,

--- a/qbraid/runtime/quantinuum/device.py
+++ b/qbraid/runtime/quantinuum/device.py
@@ -18,12 +18,12 @@ Module defining Quantinuum device class.
 """
 from __future__ import annotations
 
-import logging
 import os
 import uuid
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
+from qbraid._logging import logger
 from qbraid.runtime.device import QuantumDevice
 from qbraid.runtime.enums import DeviceStatus
 from qbraid.runtime.exceptions import QbraidRuntimeError
@@ -34,8 +34,6 @@ if TYPE_CHECKING:
     from pytket.circuit import Circuit
 
     from qbraid.runtime.profile import TargetProfile
-
-logger = logging.getLogger(__name__)
 
 
 class QuantinuumDeviceError(QbraidRuntimeError):

--- a/qbraid/runtime/quantinuum/job.py
+++ b/qbraid/runtime/quantinuum/job.py
@@ -18,9 +18,9 @@ Module defining Quantinuum job class.
 """
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Any
 
+from qbraid._logging import logger
 from qbraid.runtime.enums import JobStatus
 from qbraid.runtime.exceptions import QbraidRuntimeError
 from qbraid.runtime.job import QuantumJob
@@ -31,8 +31,6 @@ if TYPE_CHECKING:
     from qnexus.models.references import ExecuteJobRef
 
     from qbraid.runtime.quantinuum.device import QuantinuumDevice
-
-logger = logging.getLogger(__name__)
 
 _QUANTINUUM_STATUS_MAP: dict[str, JobStatus] = {
     "COMPLETED": JobStatus.COMPLETED,

--- a/qbraid/runtime/quantinuum/provider.py
+++ b/qbraid/runtime/quantinuum/provider.py
@@ -18,7 +18,6 @@ Module defining Quantinuum provider class.
 """
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING
 
 from qbraid._caching import cached_method
@@ -31,8 +30,6 @@ from .device import QuantinuumDevice
 
 if TYPE_CHECKING:
     from pytket.backends.backendinfo import BackendInfo
-
-logger = logging.getLogger(__name__)
 
 
 def _fetch_quantinuum_devices_df():

--- a/qbraid/runtime/rigetti/job.py
+++ b/qbraid/runtime/rigetti/job.py
@@ -25,7 +25,6 @@ Module defining Rigetti job class
 
 from __future__ import annotations
 
-import logging
 import re
 from typing import TYPE_CHECKING, Any
 
@@ -41,14 +40,13 @@ from qcs_sdk.qpu.api import (
     retrieve_results,
 )
 
+from qbraid._logging import logger
 from qbraid.runtime import JobStateError
 from qbraid.runtime.enums import JobStatus
 from qbraid.runtime.exceptions import QbraidRuntimeError
 from qbraid.runtime.job import QuantumJob
 from qbraid.runtime.result import Result
 from qbraid.runtime.result_data import GateModelResultData
-
-logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from .device import RigettiDevice

--- a/qbraid/runtime/rigetti/provider.py
+++ b/qbraid/runtime/rigetti/provider.py
@@ -127,9 +127,7 @@ class RigettiProvider(QuantumProvider):
             try:
                 proc.wait(timeout=5)
             except TimeoutExpired:
-                logger.warning(
-                    "Process %d did not exit in time, sending SIGKILL", proc.pid
-                )
+                logger.warning("Process %d did not exit in time, sending SIGKILL", proc.pid)
                 proc.kill()
             setattr(self, attr, None)
 
@@ -198,23 +196,15 @@ class RigettiProvider(QuantumProvider):
         # overridden retain their existing values so the rebuild never
         # silently clears them. Execution options derive from the gRPC
         # URL, so refresh them whenever the client is rebuilt.
-        if (
-            quilc_endpoint is not None
-            or qvm_endpoint is not None
-            or grpc_endpoint is not None
-        ):
+        if quilc_endpoint is not None or qvm_endpoint is not None or grpc_endpoint is not None:
             current = self._qcs_client
             # current is bound be non-null as we instantiate it in the
             # constructor when no client is provided, so we can safely read
             # its properties
             self._qcs_client = build_qcs_client(
                 current.oauth_session,
-                grpc_api_url=grpc_endpoint
-                if grpc_endpoint is not None
-                else current.grpc_api_url,
-                quilc_url=quilc_endpoint
-                if quilc_endpoint is not None
-                else current.quilc_url,
+                grpc_api_url=grpc_endpoint if grpc_endpoint is not None else current.grpc_api_url,
+                quilc_url=quilc_endpoint if quilc_endpoint is not None else current.quilc_url,
                 qvm_url=qvm_endpoint if qvm_endpoint is not None else current.qvm_url,
                 api_url=current.api_url,
             )
@@ -225,9 +215,7 @@ class RigettiProvider(QuantumProvider):
             logger.info("Using provided quilc endpoint: %s", quilc_endpoint)
         elif start_quilc:
             if is_port_in_use(DEFAULT_QUILC_PORT):
-                logger.info(
-                    "quilc already running on port %d, skipping.", DEFAULT_QUILC_PORT
-                )
+                logger.info("quilc already running on port %d, skipping.", DEFAULT_QUILC_PORT)
             else:
                 binary = find_binary("quilc")
                 if binary is None:
@@ -239,9 +227,7 @@ class RigettiProvider(QuantumProvider):
             logger.info("Using provided qvm endpoint: %s", qvm_endpoint)
         elif start_qvm:
             if is_port_in_use(DEFAULT_QVM_PORT):
-                logger.info(
-                    "qvm already running on port %d, skipping.", DEFAULT_QVM_PORT
-                )
+                logger.info("qvm already running on port %d, skipping.", DEFAULT_QVM_PORT)
             else:
                 binary = find_binary("qvm")
                 if binary is None:
@@ -275,9 +261,7 @@ class RigettiProvider(QuantumProvider):
             device_id=quantum_processor_id,
             simulator=False,
             experiment_type=ExperimentType.GATE_MODEL,
-            program_spec=ProgramSpec(
-                pyquil.Program, serialize=lambda program: program.out()
-            ),
+            program_spec=ProgramSpec(pyquil.Program, serialize=lambda program: program.out()),
             num_qubits=num_qubits,
             provider_name="rigetti",
         )

--- a/qbraid/runtime/rigetti/provider.py
+++ b/qbraid/runtime/rigetti/provider.py
@@ -26,7 +26,6 @@ Module defining Rigetti provider class
 from __future__ import annotations
 
 import atexit
-import logging
 import os
 import signal
 from subprocess import DEVNULL, Popen, TimeoutExpired
@@ -37,6 +36,7 @@ from qcs_sdk.qpu import list_quantum_processors
 from qcs_sdk.qpu.api import ConnectionStrategy, ExecutionOptionsBuilder
 from qcs_sdk.qpu.isa import get_instruction_set_architecture
 
+from qbraid._logging import logger
 from qbraid.programs.experiment import ExperimentType
 from qbraid.programs.spec import ProgramSpec
 from qbraid.runtime import QuantumProvider, TargetProfile
@@ -55,8 +55,6 @@ from .setup import (
     is_port_in_use,
     wait_for_port,
 )
-
-logger = logging.getLogger(__name__)
 
 
 class RigettiProvider(QuantumProvider):
@@ -129,7 +127,9 @@ class RigettiProvider(QuantumProvider):
             try:
                 proc.wait(timeout=5)
             except TimeoutExpired:
-                logger.warning("Process %d did not exit in time, sending SIGKILL", proc.pid)
+                logger.warning(
+                    "Process %d did not exit in time, sending SIGKILL", proc.pid
+                )
                 proc.kill()
             setattr(self, attr, None)
 
@@ -198,15 +198,23 @@ class RigettiProvider(QuantumProvider):
         # overridden retain their existing values so the rebuild never
         # silently clears them. Execution options derive from the gRPC
         # URL, so refresh them whenever the client is rebuilt.
-        if quilc_endpoint is not None or qvm_endpoint is not None or grpc_endpoint is not None:
+        if (
+            quilc_endpoint is not None
+            or qvm_endpoint is not None
+            or grpc_endpoint is not None
+        ):
             current = self._qcs_client
             # current is bound be non-null as we instantiate it in the
             # constructor when no client is provided, so we can safely read
             # its properties
             self._qcs_client = build_qcs_client(
                 current.oauth_session,
-                grpc_api_url=grpc_endpoint if grpc_endpoint is not None else current.grpc_api_url,
-                quilc_url=quilc_endpoint if quilc_endpoint is not None else current.quilc_url,
+                grpc_api_url=grpc_endpoint
+                if grpc_endpoint is not None
+                else current.grpc_api_url,
+                quilc_url=quilc_endpoint
+                if quilc_endpoint is not None
+                else current.quilc_url,
                 qvm_url=qvm_endpoint if qvm_endpoint is not None else current.qvm_url,
                 api_url=current.api_url,
             )
@@ -217,7 +225,9 @@ class RigettiProvider(QuantumProvider):
             logger.info("Using provided quilc endpoint: %s", quilc_endpoint)
         elif start_quilc:
             if is_port_in_use(DEFAULT_QUILC_PORT):
-                logger.info("quilc already running on port %d, skipping.", DEFAULT_QUILC_PORT)
+                logger.info(
+                    "quilc already running on port %d, skipping.", DEFAULT_QUILC_PORT
+                )
             else:
                 binary = find_binary("quilc")
                 if binary is None:
@@ -229,7 +239,9 @@ class RigettiProvider(QuantumProvider):
             logger.info("Using provided qvm endpoint: %s", qvm_endpoint)
         elif start_qvm:
             if is_port_in_use(DEFAULT_QVM_PORT):
-                logger.info("qvm already running on port %d, skipping.", DEFAULT_QVM_PORT)
+                logger.info(
+                    "qvm already running on port %d, skipping.", DEFAULT_QVM_PORT
+                )
             else:
                 binary = find_binary("qvm")
                 if binary is None:
@@ -263,7 +275,9 @@ class RigettiProvider(QuantumProvider):
             device_id=quantum_processor_id,
             simulator=False,
             experiment_type=ExperimentType.GATE_MODEL,
-            program_spec=ProgramSpec(pyquil.Program, serialize=lambda program: program.out()),
+            program_spec=ProgramSpec(
+                pyquil.Program, serialize=lambda program: program.out()
+            ),
             num_qubits=num_qubits,
             provider_name="rigetti",
         )


### PR DESCRIPTION
**Refactor** — Use centralized logger across Rigetti, Origin Quantum, and Quantinuum runtime modules

Replaces per-module `logging.getLogger(__name__)` calls with the centralized `from qbraid._logging import logger` in Rigetti, Origin Quantum, and Quantinuum runtime implementations. This aligns these three providers with the pattern already used by OQC, Azure, IonQ, and IBM.

## Changes

- **Rigetti**: replaced local logger in `provider.py` and `job.py` with centralized `qbraid._logging.logger`
- **Origin Quantum**: replaced local logger in `provider.py` and `job.py`; removed unused `import logging` and `logger` assignment from `device.py`
- **Quantinuum**: replaced local logger in `device.py` and `job.py`; removed unused `import logging` and `logger` assignment from `provider.py`
- **CHANGELOG**: added entry under `Improved / Modified` for the logger consolidation

