### PR TITLE
Add include_retired param to QbraidProvider.get_devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ Types of changes:
 ## [Unreleased]
 
 ### Added
+- Added `include_retired` parameter to `QbraidProvider.get_devices` method to optionally include retired devices in the device list ([#1201](https://github.com/qBraid/qBraid/pull/1201))
 
 ### Improved / Modified
 - Replaced `logging.getLogger(__name__)` with centralized `from qbraid._logging import logger` in Rigetti, Origin Quantum, and Quantinuum runtime modules ([#1197](https://github.com/qBraid/qBraid/pull/1197))
 - Modified `get_devices` and `get_device` methods in `IonQProvider` to use public endpoint access instead of authenticated requests ([#1194](https://github.com/qBraid/qBraid/pull/1194))
+- Updated `QbraidProvider.get_devices` method to accept `**kwargs` and pass them through to the underlying `client.list_devices` call ([#1201](https://github.com/qBraid/qBraid/pull/1201))
 
 ### Deprecated
 
@@ -29,6 +31,7 @@ Types of changes:
 
 ### Dependencies
 - Replaced `qiskit-qir` dependency with `qbraid-qir[qiskit]>=0.6.0`; the `qiskit_to_pyqir` conversion now uses `qbraid_qir.qiskit.qiskit_to_qir` instead of the archived `qiskit-qir` package ([#1132](https://github.com/qBraid/qBraid/pull/1132))
+- Updated `qbraid-core` requirement from `>=0.3.2,<0.4.0` to `>=0.3.3,<0.4.0` ([#1201](https://github.com/qBraid/qBraid/pull/1201))
 
 ## [0.12.1] - 2026-05-17
 

--- a/qbraid/runtime/native/provider.py
+++ b/qbraid/runtime/native/provider.py
@@ -216,12 +216,12 @@ class QbraidProvider(QuantumProvider):
         )
 
     @cached_method(ttl=120)
-    def get_devices(self) -> list[QbraidDevice]:
+    def get_devices(self, include_retired: bool = False, **kwargs) -> list[QbraidDevice]:
         """Return a list of devices matching the specified filtering."""
 
         try:
             # TODO: Implement support for device query
-            devices = self.client.list_devices()
+            devices = self.client.list_devices(include_retired=include_retired, **kwargs)
         except (ValueError, QuantumRuntimeServiceRequestError) as err:
             raise ResourceNotFoundError("No devices found matching given criteria.") from err
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 rustworkx>=0.15.0
 numpy>=1.17
 openqasm3[parser]>=0.4.0
-qbraid-core>=0.3.2,<0.4.0
+qbraid-core>=0.3.3,<0.4.0
 pydantic>2.0.0
 pydantic-core
 typing-extensions>=4.0.0

--- a/tests/runtime/_resources.py
+++ b/tests/runtime/_resources.py
@@ -510,7 +510,7 @@ class MockClient:
         }
 
     # New Runtime API methods
-    def list_devices(self) -> list[RuntimeDevice]:
+    def list_devices(self, include_retired: bool = False) -> list[RuntimeDevice]:
         """Returns a list of all quantum devices."""
         devices = []
         for device_data in [

--- a/tests/runtime/_resources.py
+++ b/tests/runtime/_resources.py
@@ -509,7 +509,7 @@ class MockClient:
             "organizationUserId": "68f94f8e0c6d3502fd4c37f5",
         }
 
-    # New Runtime API methods
+    # pylint: disable-next=unused-argument
     def list_devices(self, include_retired: bool = False) -> list[RuntimeDevice]:
         """Returns a list of all quantum devices."""
         devices = []

--- a/tests/runtime/native/test_runtime.py
+++ b/tests/runtime/native/test_runtime.py
@@ -17268,7 +17268,7 @@ class MockQuantumRuntimeClient(QuantumRuntimeClient):
             # Track call counts for get_job to simulate job progression
             self._job_call_counts = {}
 
-    def list_devices(self) -> list[RuntimeDevice]:
+    def list_devices(self, include_retired: bool = False) -> list[RuntimeDevice]:
         """Returns a list of all quantum devices."""
         return [SV1_DEVICE, AQUILA_DEVICE, RIGETTI_DEVICE, PASQAL_DEVICE]
 
@@ -17420,6 +17420,13 @@ def test_provider_get_devices(provider):
     assert AQUILA_DEVICE.qrn in device_ids
     assert RIGETTI_DEVICE.qrn in device_ids
     assert PASQAL_DEVICE.qrn in device_ids
+
+
+def test_provider_get_devices_passes_kwargs(provider):
+    """Test that get_devices passes kwargs through to client.list_devices."""
+    devices = provider.get_devices(include_retired=True)
+    assert len(devices) == 4
+    assert all(isinstance(device, QbraidDevice) for device in devices)
 
 
 def test_provider_get_device_sv1(provider):


### PR DESCRIPTION
## Summary
- Add explicit `include_retired: bool = False` parameter and `**kwargs` to `QbraidProvider.get_devices()`, passing them through to `client.list_devices()`
- Bump `qbraid-core` minimum from `>=0.3.2` to `>=0.3.3` (required for the `include_retired` param on `QuantumRuntimeClient.list_devices`)
- Fix `MockQuantumRuntimeClient.list_devices` signature to match the updated base class (resolves pylint W0221)