### PR TITLE
Add OpenQASM3 to pyQuil conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ result = job.result()
 print(result.data.get_counts())
 ```
 
+- Added direct OpenQASM 3 to pyQuil conversion through `openqasm3_to_pyquil`, including conversion graph registration and coverage benchmarks for the new target path ([#1202](https://github.com/qBraid/qBraid/pull/1202)).
+
 ### Improved / Modified
 - Replaced `logging.getLogger(__name__)` with centralized `from qbraid._logging import logger` in Rigetti, Origin Quantum, and Quantinuum runtime modules ([#1197](https://github.com/qBraid/qBraid/pull/1197))
 - Modified `get_devices` and `get_device` methods in `IonQProvider` to use public endpoint access instead of authenticated requests ([#1194](https://github.com/qBraid/qBraid/pull/1194))

--- a/qbraid/transpiler/conversions/openqasm3/__init__.py
+++ b/qbraid/transpiler/conversions/openqasm3/__init__.py
@@ -26,10 +26,17 @@ Functions
    openqasm3_to_qasm3
    openqasm3_to_ionq
    openqasm3_to_cudaq
+   openqasm3_to_pyquil
 
 """
 from .openqasm3_to_cudaq import openqasm3_to_cudaq
 from .openqasm3_to_ionq import openqasm3_to_ionq
+from .openqasm3_to_pyquil import openqasm3_to_pyquil
 from .openqasm3_to_qasm3 import openqasm3_to_qasm3
 
-__all__ = ["openqasm3_to_qasm3", "openqasm3_to_ionq", "openqasm3_to_cudaq"]
+__all__ = [
+    "openqasm3_to_qasm3",
+    "openqasm3_to_ionq",
+    "openqasm3_to_cudaq",
+    "openqasm3_to_pyquil",
+]

--- a/qbraid/transpiler/conversions/openqasm3/openqasm3_to_pyquil.py
+++ b/qbraid/transpiler/conversions/openqasm3/openqasm3_to_pyquil.py
@@ -1,0 +1,192 @@
+# Copyright 2025 qBraid
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Module containing OpenQASM 3 AST to pyQuil conversion function.
+
+"""
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import pyqasm
+from openqasm3 import ast
+from qbraid_core._import import LazyLoader
+
+from qbraid.transpiler.annotations import weight
+from qbraid.transpiler.exceptions import ProgramConversionError
+
+pyquil = LazyLoader("pyquil", globals(), "pyquil")
+
+if TYPE_CHECKING:
+    from pyquil import Program
+
+    from qbraid.programs.typer import QasmStringType
+
+
+def _index_value(identifier: ast.IndexedIdentifier) -> int:
+    """Return the single integer index from an unrolled OpenQASM identifier."""
+    if not isinstance(identifier, ast.IndexedIdentifier):
+        raise ProgramConversionError(f"Expected indexed identifier, got: {identifier}")
+    if len(identifier.indices) != 1 or len(identifier.indices[0]) != 1:
+        raise ProgramConversionError(f"Unsupported multi-dimensional identifier: {identifier}")
+
+    index = identifier.indices[0][0]
+    if not isinstance(index, ast.IntegerLiteral):
+        raise ProgramConversionError(f"Expected integer index, got: {index}")
+
+    return index.value
+
+
+def _declaration_size(size: ast.Expression | None) -> int:
+    """Return register size, defaulting scalar declarations to size one."""
+    if size is None:
+        return 1
+    if not isinstance(size, ast.IntegerLiteral):
+        raise ProgramConversionError(f"Expected integer register size, got: {size}")
+    return size.value
+
+
+def _argument_value(argument: ast.Expression) -> float:
+    """Return a numeric gate argument after pyqasm validation and unrolling."""
+    value = getattr(argument, "value", None)
+    if not isinstance(value, (int, float)):
+        raise ProgramConversionError(f"Expected numeric gate argument, got: {argument}")
+    return float(value)
+
+
+@weight(1.0)  # pylint: disable-next=too-many-locals,too-many-branches
+def openqasm3_to_pyquil(program: QasmStringType | ast.Program) -> Program:
+    """Returns a pyQuil Program equivalent to the input OpenQASM 3 AST program.
+
+    Args:
+        program: OpenQASM 3 AST program or string to convert.
+
+    Returns:
+        pyQuil Program representation equivalent to the input OpenQASM 3 program.
+    """
+    try:
+        module = pyqasm.loads(program)
+        module.validate()
+    except Exception as err:
+        raise ProgramConversionError("QASM program is not well-formed.") from err
+
+    module.unroll()
+    qasm_program = module.unrolled_ast
+    quil_program = pyquil.Program()
+
+    qubit_offsets: dict[str, int] = {}
+    memory_regions: dict[str, object] = {}
+    next_qubit = 0
+
+    def qubit_index(qubit: ast.IndexedIdentifier) -> int:
+        register = qubit.name.name
+        if register not in qubit_offsets:
+            raise ProgramConversionError(f"Undeclared qubit register: {register}")
+        return qubit_offsets[register] + _index_value(qubit)
+
+    def memory_reference(target: ast.IndexedIdentifier):
+        register = target.name.name
+        if register not in memory_regions:
+            raise ProgramConversionError(f"Undeclared classical register: {register}")
+        return memory_regions[register][_index_value(target)]
+
+    def add_gate(name: str, arguments: list[float], qubits: list[int]) -> None:
+        nonlocal quil_program
+
+        lower_name = name.lower()
+        gate_map = {
+            "i": pyquil.gates.I,
+            "id": pyquil.gates.I,
+            "iden": pyquil.gates.I,
+            "x": pyquil.gates.X,
+            "y": pyquil.gates.Y,
+            "z": pyquil.gates.Z,
+            "h": pyquil.gates.H,
+            "s": pyquil.gates.S,
+            "t": pyquil.gates.T,
+        }
+        param_gate_map = {
+            "rx": pyquil.gates.RX,
+            "ry": pyquil.gates.RY,
+            "rz": pyquil.gates.RZ,
+            "p": pyquil.gates.PHASE,
+            "phase": pyquil.gates.PHASE,
+        }
+        two_qubit_gate_map = {
+            "cx": pyquil.gates.CNOT,
+            "cnot": pyquil.gates.CNOT,
+            "cz": pyquil.gates.CZ,
+            "swap": pyquil.gates.SWAP,
+        }
+
+        if lower_name in gate_map and len(arguments) == 0 and len(qubits) == 1:
+            quil_program += gate_map[lower_name](qubits[0])
+        elif lower_name == "sdg" and len(arguments) == 0 and len(qubits) == 1:
+            quil_program += pyquil.gates.PHASE(-math.pi / 2, qubits[0])
+        elif lower_name == "tdg" and len(arguments) == 0 and len(qubits) == 1:
+            quil_program += pyquil.gates.PHASE(-math.pi / 4, qubits[0])
+        elif lower_name == "sx" and len(arguments) == 0 and len(qubits) == 1:
+            quil_program += pyquil.gates.RX(math.pi / 2, qubits[0])
+        elif lower_name in param_gate_map and len(arguments) == 1 and len(qubits) == 1:
+            quil_program += param_gate_map[lower_name](arguments[0], qubits[0])
+        elif lower_name in two_qubit_gate_map and len(arguments) == 0 and len(qubits) == 2:
+            quil_program += two_qubit_gate_map[lower_name](*qubits)
+        elif lower_name == "cp" and len(arguments) == 1 and len(qubits) == 2:
+            quil_program += pyquil.gates.CPHASE(arguments[0], *qubits)
+        elif lower_name == "ccx" and len(arguments) == 0 and len(qubits) == 3:
+            quil_program += pyquil.gates.CCNOT(*qubits)
+        elif lower_name == "cswap" and len(arguments) == 0 and len(qubits) == 3:
+            quil_program += pyquil.gates.CSWAP(*qubits)
+        elif lower_name == "rzz" and len(arguments) == 1 and len(qubits) == 2:
+            quil_program += pyquil.gates.RZZ(arguments[0], *qubits)
+        else:
+            raise ProgramConversionError(f"Unsupported gate: {name}")
+
+    for statement in qasm_program.statements:
+        if isinstance(statement, ast.Include):
+            if statement.filename not in {"stdgates.inc", "qelib1.inc"}:
+                raise ProgramConversionError(f"Custom includes are unsupported: {statement}")
+        elif isinstance(statement, ast.QubitDeclaration):
+            qubit_offsets[statement.qubit.name] = next_qubit
+            next_qubit += _declaration_size(statement.size)
+        elif isinstance(statement, ast.ClassicalDeclaration):
+            if not isinstance(statement.type, ast.BitType):
+                raise ProgramConversionError(f"Unsupported classical declaration: {statement}")
+            size = _declaration_size(statement.type.size)
+            memory_regions[statement.identifier.name] = quil_program.declare(
+                statement.identifier.name, "BIT", size
+            )
+            if isinstance(statement.init_expression, ast.QuantumMeasurement):
+                quil_program += pyquil.gates.MEASURE(
+                    qubit_index(statement.init_expression.qubit),
+                    memory_regions[statement.identifier.name][0],
+                )
+            elif statement.init_expression is not None:
+                raise ProgramConversionError(f"Unsupported classical initializer: {statement}")
+        elif isinstance(statement, ast.QuantumMeasurementStatement):
+            qubit = qubit_index(statement.measure.qubit)
+            target = memory_reference(statement.target) if statement.target is not None else None
+            quil_program += pyquil.gates.MEASURE(qubit, target)
+        elif isinstance(statement, ast.QuantumGate):
+            if statement.modifiers:
+                raise ProgramConversionError(f"Unsupported gate modifiers: {statement.modifiers}")
+            arguments = [_argument_value(argument) for argument in statement.arguments]
+            qubits = [qubit_index(qubit) for qubit in statement.qubits]
+            add_gate(statement.name.name, arguments, qubits)
+        else:
+            raise ProgramConversionError(f"Unsupported statement: {statement}")
+
+    return quil_program

--- a/tests/transpiler/openqasm3/test_coverage_from_openqasm3.py
+++ b/tests/transpiler/openqasm3/test_coverage_from_openqasm3.py
@@ -1,0 +1,98 @@
+# Copyright 2025 qBraid
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Benchmarking tests for OpenQASM 3 conversions.
+
+"""
+import importlib.util
+
+import openqasm3
+import pytest
+
+from qbraid.interface import circuits_allclose
+from qbraid.transpiler import ConversionGraph, transpile
+from qbraid.transpiler.conversions.qasm3 import qasm3_to_cirq
+
+
+def is_package_installed(package_name: str) -> bool:
+    """Check if a package is installed."""
+    return importlib.util.find_spec(package_name) is not None
+
+
+OPENQASM3_GATE_STATEMENTS = {
+    "x": "x q[0];",
+    "y": "y q[0];",
+    "z": "z q[0];",
+    "h": "h q[0];",
+    "s": "s q[0];",
+    "sdg": "sdg q[0];",
+    "t": "t q[0];",
+    "tdg": "tdg q[0];",
+    "sx": "sx q[0];",
+    "rx": "rx(pi / 3) q[0];",
+    "ry": "ry(pi / 4) q[0];",
+    "rz": "rz(pi / 5) q[0];",
+    "cx": "cx q[0], q[1];",
+    "cz": "cz q[0], q[1];",
+    "swap": "swap q[0], q[1];",
+    "ccx": "ccx q[0], q[1], q[2];",
+}
+
+ALL_TARGETS = [("pyquil", 1.0)]
+AVAILABLE_TARGETS = [
+    (name, baseline) for name, baseline in ALL_TARGETS if is_package_installed(name)
+]
+
+
+def _openqasm3_program(gate_statement: str) -> str:
+    return f"""
+    OPENQASM 3.0;
+    include "stdgates.inc";
+
+    qubit[3] q;
+    {gate_statement}
+    """
+
+
+def convert_from_openqasm3_to_x(target, gate_name, graph):
+    """Construct an OpenQASM 3 AST program with the given gate and transpile it to target."""
+    qasm = _openqasm3_program(OPENQASM3_GATE_STATEMENTS[gate_name])
+    source_circuit = qasm3_to_cirq(qasm)
+    target_circuit = transpile(openqasm3.parse(qasm), target, conversion_graph=graph)
+    assert circuits_allclose(source_circuit, target_circuit, strict_gphase=False)
+
+
+@pytest.mark.parametrize(("target", "baseline"), AVAILABLE_TARGETS)
+def test_openqasm3_coverage(target, baseline):
+    """Test converting OpenQASM 3 programs to supported target program types."""
+    graph = ConversionGraph(require_native=True)
+    allowance = 0.01
+    failures = {}
+    for gate_name in OPENQASM3_GATE_STATEMENTS:
+        try:
+            convert_from_openqasm3_to_x(target, gate_name, graph)
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            failures[f"{target}-{gate_name}"] = err
+
+    total_tests = len(OPENQASM3_GATE_STATEMENTS)
+    nb_fails = len(failures)
+    nb_passes = total_tests - nb_fails
+    accuracy = float(nb_passes) / float(total_tests)
+
+    assert accuracy >= baseline - allowance, (
+        f"The coverage threshold was not met. {nb_fails}/{total_tests} tests failed "
+        f"({nb_fails / total_tests:.2%}) and {nb_passes}/{total_tests} passed "
+        f"(expected >= {baseline}).\nFailures: {failures.keys()}\n\n"
+    )

--- a/tests/transpiler/qasm/test_openqasm3_to_pyquil.py
+++ b/tests/transpiler/qasm/test_openqasm3_to_pyquil.py
@@ -1,0 +1,82 @@
+# Copyright 2025 qBraid
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for OpenQASM 3 AST to pyQuil Program conversion.
+
+"""
+import openqasm3
+import pytest
+
+from qbraid.transpiler import ConversionGraph
+from qbraid.transpiler.conversions.openqasm3 import openqasm3_to_pyquil
+
+pyquil = pytest.importorskip("pyquil")
+
+
+def test_openqasm3_to_pyquil_bell_program():
+    """Test converting an OpenQASM 3 AST program to a pyQuil Program."""
+    program = openqasm3.parse(
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+
+        qubit[2] q;
+
+        h q[0];
+        cx q[0], q[1];
+        """
+    )
+
+    quil_program = openqasm3_to_pyquil(program)
+
+    assert isinstance(quil_program, pyquil.Program)
+    assert quil_program.out() == "H 0\nCNOT 0 1\n"
+
+
+def test_openqasm3_to_pyquil_parameters_and_measurements():
+    """Test converting parameterized gates and measurements to a pyQuil Program."""
+    program = openqasm3.parse(
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+
+        qubit[2] q;
+        bit[2] c;
+
+        rx(pi / 2) q[0];
+        sdg q[0];
+        t q[1];
+        measure q[0] -> c[0];
+        measure q[1] -> c[1];
+        """
+    )
+
+    quil_program = openqasm3_to_pyquil(program)
+
+    assert quil_program.out() == (
+        "DECLARE c BIT[2]\n"
+        "RX(1.5707963267948966) 0\n"
+        "PHASE(-1.5707963267948966) 0\n"
+        "T 1\n"
+        "MEASURE 0 c[0]\n"
+        "MEASURE 1 c[1]\n"
+    )
+
+
+def test_conversion_graph_has_direct_openqasm3_to_pyquil_edge():
+    """Test that OpenQASM 3 AST to pyQuil is registered as a direct conversion."""
+    graph = ConversionGraph(nodes={"openqasm3", "pyquil"}, include_isolated=True)
+
+    assert graph.has_edge("openqasm3", "pyquil")


### PR DESCRIPTION
Closes #1179.

## Summary

- add `openqasm3_to_pyquil` as a direct OpenQASM 3 AST/string to pyQuil conversion
- use `pyqasm` validation/unrolling and build a `pyquil.Program` directly
- export the conversion from the `openqasm3` conversion package
- add tests for Bell programs, parameterized gates, measurements, and direct graph registration
- add an OpenQASM 3 source coverage benchmark for the measured `pyquil` conversion weight

## Verification

- `python -m pytest tests/transpiler/qasm/test_openqasm3_to_pyquil.py tests/transpiler/openqasm3/test_coverage_from_openqasm3.py tests/transpiler/pyquil/test_conversions_pyquil.py`
- `git diff --check`

## AI-Assisted Contribution Disclosure

I used Codex as a development assistant to inspect the existing conversion structure, draft the implementation, and draft regression/coverage tests. I manually reviewed the generated changes and verified the behavior locally with the tests listed above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OpenQASM 3 to pyQuil conversion capability.

* **Tests**
  * Added comprehensive unit tests for OpenQASM 3 conversions.
  * Added coverage benchmarks to measure conversion accuracy across supported gates and targets.

* **Documentation**
  * Updated changelog documenting new OpenQASM 3 conversion functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->