### PR TITLE
Add openqasm3 to pyquil conversion (#1179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Types of changes:
 ## [Unreleased]
 
 ### Added
-- Added `openqasm3_to_pyquil` conversion, providing a direct, `pyqasm`-backed transpiler edge from OpenQASM 3 to pyQuil (previously only reachable via a lossy multi-hop path through cirq) ([#1203](https://github.com/qBraid/qBraid/pull/1203))
+- Added `openqasm3_to_pyquil` conversion, providing a direct, `pyqasm`-backed transpiler edge from OpenQASM 3 to pyQuil (previously only reachable via a lossy multi-hop path through cirq). Supports the standard gate set (incl. modifiers and controlled gates via `pyqasm` decomposition), measurement, `barrier` (→ `FENCE`), `reset` (→ `RESET`), `delay` (→ `DELAY`), and `if (c == 0|1)` classical feedforward (→ `JUMP-WHEN`); declared-but-idle qubits are padded with `I` so the operator dimension matches the source ([#1203](https://github.com/qBraid/qBraid/pull/1203))
 
 - Added `include_retired` parameter to `QbraidProvider.get_devices` method to optionally include retired devices in the device list ([#1201](https://github.com/qBraid/qBraid/pull/1201))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Types of changes:
 ## [Unreleased]
 
 ### Added
+- Added `openqasm3_to_pyquil` conversion, providing a direct, `pyqasm`-backed transpiler edge from OpenQASM 3 to pyQuil (previously only reachable via a lossy multi-hop path through cirq). Closes [#1179](https://github.com/qBraid/qBraid/issues/1179). ([#1203](https://github.com/qBraid/qBraid/pull/1203))
+
 - Added `include_retired` parameter to `QbraidProvider.get_devices` method to optionally include retired devices in the device list ([#1201](https://github.com/qBraid/qBraid/pull/1201))
 
 - Added `PasqalProvider`, `PasqalDevice`, and `PasqalJob` classes implementing the qBraid runtime interface for Pasqal Cloud Services (neutral-atom QPUs and emulators, using Pulser as the native IR). Closes [#1185](https://github.com/qBraid/qBraid/issues/1185).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Types of changes:
 ## [Unreleased]
 
 ### Added
-- Added `openqasm3_to_pyquil` conversion, providing a direct, `pyqasm`-backed transpiler edge from OpenQASM 3 to pyQuil (previously only reachable via a lossy multi-hop path through cirq). Closes [#1179](https://github.com/qBraid/qBraid/issues/1179). ([#1203](https://github.com/qBraid/qBraid/pull/1203))
+- Added `openqasm3_to_pyquil` conversion, providing a direct, `pyqasm`-backed transpiler edge from OpenQASM 3 to pyQuil (previously only reachable via a lossy multi-hop path through cirq) ([#1203](https://github.com/qBraid/qBraid/pull/1203))
 
 - Added `include_retired` parameter to `QbraidProvider.get_devices` method to optionally include retired devices in the device list ([#1201](https://github.com/qBraid/qBraid/pull/1201))
 

--- a/qbraid/transpiler/conversions/openqasm3/__init__.py
+++ b/qbraid/transpiler/conversions/openqasm3/__init__.py
@@ -35,4 +35,4 @@ from .openqasm3_to_ionq import openqasm3_to_ionq
 from .openqasm3_to_pyquil import openqasm3_to_pyquil
 from .openqasm3_to_qasm3 import openqasm3_to_qasm3
 
-__all__ = ["openqasm3_to_qasm3", "openqasm3_to_ionq", "openqasm3_to_cudaq", "openqasm3_to_pyquil"]
+__all__ = ["openqasm3_to_cudaq", "openqasm3_to_ionq", "openqasm3_to_pyquil", "openqasm3_to_qasm3"]

--- a/qbraid/transpiler/conversions/openqasm3/openqasm3_to_pyquil.py
+++ b/qbraid/transpiler/conversions/openqasm3/openqasm3_to_pyquil.py
@@ -80,12 +80,13 @@ _GATE_MAP = {
 }
 
 
-def _flat_qubit(qubit: ast.IndexedIdentifier | ast.Identifier, offsets: dict[str, int]) -> int:
-    """Map an (unrolled) qubit reference to a flat pyQuil integer index."""
-    if isinstance(qubit, ast.IndexedIdentifier):
-        return offsets[qubit.name.name] + qubit.indices[0][0].value
-    # bare Identifier => single-qubit register
-    return offsets[qubit.name]
+def _flat_qubit(qubit: ast.IndexedIdentifier, offsets: dict[str, int]) -> int:
+    """Map an (unrolled) qubit reference to a flat pyQuil integer index.
+
+    After ``pyqasm.unroll()`` every qubit reference is an ``IndexedIdentifier``
+    (single-qubit registers are normalized to ``name[0]``).
+    """
+    return offsets[qubit.name.name] + qubit.indices[0][0].value
 
 
 def _duration_seconds(duration: ast.DurationLiteral) -> float:
@@ -103,6 +104,24 @@ def _literal_bit(node: ast.Expression) -> int:
     if isinstance(node, ast.IntegerLiteral) and node.value in (0, 1):
         return node.value
     raise ProgramConversionError("Unsupported branch comparison value (expected 0 or 1).")
+
+
+def _branch_target(
+    condition: ast.Expression, clbit_offsets: dict[str, int], ro: object
+) -> tuple[object, int]:
+    """Resolve a branch condition ``c[i] == 0|1`` to ``(memory_ref, expected_bit)``."""
+    if not isinstance(condition, ast.BinaryExpression) or condition.op.name != "==":
+        raise ProgramConversionError("Unsupported branch condition (expected '==').")
+    lhs, rhs = condition.lhs, condition.rhs
+    if isinstance(lhs, (ast.BooleanLiteral, ast.IntegerLiteral)):
+        lhs, rhs = rhs, lhs
+    if not isinstance(lhs, ast.IndexExpression) or ro is None:
+        raise ProgramConversionError("Unsupported branch condition target.")
+    name = lhs.collection.name
+    if name not in clbit_offsets:
+        raise ProgramConversionError(f"Unknown classical register in branch: {name}")
+    ro_index = clbit_offsets[name] + lhs.index[0].value
+    return ro[ro_index], _literal_bit(rhs)
 
 
 @weight(1.0)  # pylint: disable-next=too-many-statements
@@ -164,21 +183,6 @@ def openqasm3_to_pyquil(program: QasmStringType | ast.Program) -> Program:
         used_qubits.add(index)
         return index
 
-    def branch_target(condition: ast.Expression) -> tuple[object, int]:
-        """Resolve a branch condition ``c[i] == 0|1`` to (memory_ref, expected_bit)."""
-        if not isinstance(condition, ast.BinaryExpression) or condition.op.name != "==":
-            raise ProgramConversionError("Unsupported branch condition (expected '==').")
-        lhs, rhs = condition.lhs, condition.rhs
-        if isinstance(lhs, (ast.BooleanLiteral, ast.IntegerLiteral)):
-            lhs, rhs = rhs, lhs
-        if not isinstance(lhs, ast.IndexExpression) or ro is None:
-            raise ProgramConversionError("Unsupported branch condition target.")
-        name = lhs.collection.name
-        if name not in clbit_offsets:
-            raise ProgramConversionError(f"Unknown classical register in branch: {name}")
-        ro_index = clbit_offsets[name] + lhs.index[0].value
-        return ro[ro_index], _literal_bit(rhs)
-
     # pylint: disable-next=too-many-statements
     def emit(statement: ast.Statement, prog: Program) -> None:
         # statements with no observable pyQuil equivalent that are safe to drop:
@@ -201,9 +205,9 @@ def openqasm3_to_pyquil(program: QasmStringType | ast.Program) -> Program:
             prog.inst(pyquil_quilbase.DelayQubits(qubits, _duration_seconds(statement.duration)))
 
         elif isinstance(statement, ast.QuantumGate):
+            # pyqasm.unroll() strips gate modifiers and decomposes non-basis gates
+            # (e.g. sxdg, u, u3, controlled/inverse forms) into the gates below.
             name = statement.name.name.lower()
-            if statement.modifiers:
-                raise ProgramConversionError(f"Unsupported gate modifier on: {name}")
             params = [arg.value for arg in statement.arguments]
             qubits = [flat(q) for q in statement.qubits]
 
@@ -213,10 +217,6 @@ def openqasm3_to_pyquil(program: QasmStringType | ast.Program) -> Program:
                 prog.inst(pyquil_gates.T(*qubits).dagger())
             elif name == "sx":
                 prog.inst(pyquil_gates.RX(math.pi / 2, *qubits))
-            elif name == "sxdg":
-                prog.inst(pyquil_gates.RX(-math.pi / 2, *qubits))
-            elif name in ("u", "u3"):
-                prog.inst(pyquil_gates.U(*params, *qubits))
             elif name in _GATE_MAP:
                 prog.inst(getattr(pyquil_gates, _GATE_MAP[name])(*params, *qubits))
             else:
@@ -233,7 +233,7 @@ def openqasm3_to_pyquil(program: QasmStringType | ast.Program) -> Program:
 
         elif isinstance(statement, ast.BranchingStatement):
             # classical feedforward: if (c[i] == 1) { ... } else { ... } -> JUMP-WHEN
-            reg, expected = branch_target(statement.condition)
+            reg, expected = _branch_target(statement.condition, clbit_offsets, ro)
             then_block, else_block = statement.if_block, statement.else_block
             if expected == 0:  # run the if-body when the bit is 0 => swap into the else slot
                 then_block, else_block = else_block, then_block

--- a/qbraid/transpiler/conversions/openqasm3/openqasm3_to_pyquil.py
+++ b/qbraid/transpiler/conversions/openqasm3/openqasm3_to_pyquil.py
@@ -1,0 +1,174 @@
+# Copyright 2025 qBraid
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Module defining OpenQASM 3 to pyQuil conversion function.
+
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import pyqasm
+from openqasm3 import ast
+from qbraid_core._import import LazyLoader
+
+from qbraid.transpiler.annotations import weight
+from qbraid.transpiler.exceptions import ProgramConversionError
+
+pyquil = LazyLoader("pyquil", globals(), "pyquil")
+pyquil_gates = LazyLoader("pyquil_gates", globals(), "pyquil.gates")
+
+if TYPE_CHECKING:
+    from pyquil import Program
+
+    from qbraid.programs.typer import QasmStringType
+
+# OpenQASM gate name -> pyQuil gate constructor name. pyQuil's signature is
+# uniform: fn(*params, *qubits), so a single dispatch handles every entry.
+_GATE_MAP = {
+    # one-qubit, no parameters
+    "i": "I",
+    "id": "I",
+    "x": "X",
+    "y": "Y",
+    "z": "Z",
+    "h": "H",
+    "s": "S",
+    "t": "T",
+    # one-qubit, parameterized
+    "rx": "RX",
+    "ry": "RY",
+    "rz": "RZ",
+    "p": "PHASE",
+    "phase": "PHASE",
+    # two-qubit, no parameters
+    "cx": "CNOT",
+    "cnot": "CNOT",
+    "cz": "CZ",
+    "swap": "SWAP",
+    "iswap": "ISWAP",
+    # two-qubit, parameterized
+    "cp": "CPHASE",
+    "cphase": "CPHASE",
+    "rxx": "RXX",
+    "ryy": "RYY",
+    "rzz": "RZZ",
+    "xy": "XY",
+    # three-qubit
+    "ccx": "CCNOT",
+    "toffoli": "CCNOT",
+    "cswap": "CSWAP",
+}
+
+
+def _flat_qubit(qubit: ast.IndexedIdentifier | ast.Identifier, offsets: dict[str, int]) -> int:
+    """Map an (unrolled) qubit reference to a flat pyQuil integer index."""
+    if isinstance(qubit, ast.IndexedIdentifier):
+        return offsets[qubit.name.name] + qubit.indices[0][0].value
+    # bare Identifier => single-qubit register
+    return offsets[qubit.name]
+
+
+@weight(1.0)  # pylint: disable-next=too-many-statements
+def openqasm3_to_pyquil(program: QasmStringType | ast.Program) -> Program:
+    """Returns a pyQuil Program equivalent to the input OpenQASM 3 program.
+
+    Args:
+        program (str or openqasm3.ast.Program): OpenQASM 3 program to convert.
+
+    Returns:
+        pyquil.Program: pyQuil Program equivalent to the input program.
+
+    Raises:
+        ProgramConversionError: If the program is malformed or contains a
+            gate/statement that is not supported by the conversion.
+    """
+    try:
+        module = pyqasm.loads(program)
+        module.validate()
+    except Exception as e:
+        raise ProgramConversionError("QASM program is not well-formed.") from e
+
+    module.unroll()
+    unrolled = module.unrolled_ast
+
+    quil = pyquil.Program()
+
+    # pass 1: build flat qubit + classical-bit offset maps
+    qubit_offsets: dict[str, int] = {}
+    clbit_offsets: dict[str, int] = {}
+    num_qubits = 0
+    num_clbits = 0
+    for statement in unrolled.statements:
+        if isinstance(statement, ast.QubitDeclaration):
+            size = statement.size.value if statement.size is not None else 1
+            qubit_offsets[statement.qubit.name] = num_qubits
+            num_qubits += size
+        elif isinstance(statement, ast.ClassicalDeclaration) and isinstance(
+            statement.type, ast.BitType
+        ):
+            size = statement.type.size.value if statement.type.size is not None else 1
+            clbit_offsets[statement.identifier.name] = num_clbits
+            num_clbits += size
+
+    ro = quil.declare("ro", "BIT", num_clbits) if num_clbits else None
+
+    # pass 2: emit gates + measurements
+    for statement in unrolled.statements:
+        # QuantumPhase = global phase (gphase); unobservable, safe to drop (pyqasm emits
+        # it when decomposing gates such as rzz; equivalence holds up to global phase).
+        if isinstance(
+            statement,
+            (ast.QubitDeclaration, ast.ClassicalDeclaration, ast.Include, ast.QuantumPhase),
+        ):
+            continue
+
+        if isinstance(statement, ast.QuantumGate):
+            name = statement.name.name.lower()
+            if statement.modifiers:
+                raise ProgramConversionError(f"Gate modifiers are not supported: {name}")
+            params = [arg.value for arg in statement.arguments]
+            qubits = [_flat_qubit(q, qubit_offsets) for q in statement.qubits]
+
+            if name == "sdg":
+                quil += pyquil_gates.S(*qubits).dagger()
+            elif name == "tdg":
+                quil += pyquil_gates.T(*qubits).dagger()
+            elif name == "sx":
+                quil += pyquil_gates.RX(math.pi / 2, *qubits)
+            elif name == "sxdg":
+                quil += pyquil_gates.RX(-math.pi / 2, *qubits)
+            elif name in ("u", "u3"):
+                quil += pyquil_gates.U(*params, *qubits)
+            elif name in _GATE_MAP:
+                quil += getattr(pyquil_gates, _GATE_MAP[name])(*params, *qubits)
+            else:
+                raise ProgramConversionError(f"Unsupported gate: {name}")
+
+        elif isinstance(statement, ast.QuantumMeasurementStatement):
+            src = _flat_qubit(statement.measure.qubit, qubit_offsets)
+            if statement.target is not None and ro is not None:
+                target = statement.target
+                ro_index = clbit_offsets[target.name.name] + target.indices[0][0].value
+                quil += pyquil_gates.MEASURE(src, ro[ro_index])
+            else:
+                quil += pyquil_gates.MEASURE(src, None)
+
+        else:
+            raise ProgramConversionError(f"Unsupported statement: {statement}")
+
+    return quil

--- a/qbraid/transpiler/conversions/openqasm3/openqasm3_to_pyquil.py
+++ b/qbraid/transpiler/conversions/openqasm3/openqasm3_to_pyquil.py
@@ -31,11 +31,16 @@ from qbraid.transpiler.exceptions import ProgramConversionError
 
 pyquil = LazyLoader("pyquil", globals(), "pyquil")
 pyquil_gates = LazyLoader("pyquil_gates", globals(), "pyquil.gates")
+pyquil_quilbase = LazyLoader("pyquil_quilbase", globals(), "pyquil.quilbase")
 
 if TYPE_CHECKING:
     from pyquil import Program
 
     from qbraid.programs.typer import QasmStringType
+
+# OpenQASM 3 delay time units -> seconds (pyQuil's DELAY duration is in seconds).
+# "dt" is backend-dependent and has no fixed conversion, so it is unsupported.
+_TIME_UNIT_SECONDS = {"ns": 1e-9, "us": 1e-6, "ms": 1e-3, "s": 1.0}
 
 # OpenQASM gate name -> pyQuil gate constructor name. pyQuil's signature is
 # uniform: fn(*params, *qubits), so a single dispatch handles every entry.
@@ -83,9 +88,32 @@ def _flat_qubit(qubit: ast.IndexedIdentifier | ast.Identifier, offsets: dict[str
     return offsets[qubit.name]
 
 
+def _duration_seconds(duration: ast.DurationLiteral) -> float:
+    """Convert an OpenQASM 3 delay duration to seconds for pyQuil's DELAY."""
+    unit = duration.unit.name
+    if unit not in _TIME_UNIT_SECONDS:
+        raise ProgramConversionError(f"Unsupported delay unit: {unit}")
+    return duration.value * _TIME_UNIT_SECONDS[unit]
+
+
+def _literal_bit(node: ast.Expression) -> int:
+    """Read a 0/1 from the literal side of a branch comparison."""
+    if isinstance(node, ast.BooleanLiteral):
+        return 1 if node.value else 0
+    if isinstance(node, ast.IntegerLiteral) and node.value in (0, 1):
+        return node.value
+    raise ProgramConversionError("Unsupported branch comparison value (expected 0 or 1).")
+
+
 @weight(1.0)  # pylint: disable-next=too-many-statements
 def openqasm3_to_pyquil(program: QasmStringType | ast.Program) -> Program:
     """Returns a pyQuil Program equivalent to the input OpenQASM 3 program.
+
+    Supports the standard gate set (including gate modifiers and controlled gates,
+    which ``pyqasm`` decomposes during unrolling), measurement, ``barrier`` (-> pyQuil
+    ``FENCE``), ``reset`` (-> ``RESET``), ``delay`` (-> ``DELAY``), and ``if (c == 0|1)``
+    classical feedforward (-> conditional ``JUMP-WHEN``). Declared-but-idle qubits are
+    padded with identity so the operator dimension matches the source register width.
 
     Args:
         program (str or openqasm3.ast.Program): OpenQASM 3 program to convert.
@@ -127,56 +155,104 @@ def openqasm3_to_pyquil(program: QasmStringType | ast.Program) -> Program:
 
     ro = quil.declare("ro", "BIT", num_clbits) if num_clbits else None
 
-    # pass 2: emit gates + measurements
-    for statement in unrolled.statements:
-        # Skip statements with no pyQuil equivalent that are safe to drop:
-        # - QuantumPhase = global phase (gphase); unobservable (pyqasm emits it when
+    # track which declared qubits are acted on, so idle ones can be padded with I
+    # (keeps the operator dimension equal to the declared register width)
+    used_qubits: set[int] = set()
+
+    def flat(qubit: ast.IndexedIdentifier | ast.Identifier) -> int:
+        index = _flat_qubit(qubit, qubit_offsets)
+        used_qubits.add(index)
+        return index
+
+    def branch_target(condition: ast.Expression) -> tuple[object, int]:
+        """Resolve a branch condition ``c[i] == 0|1`` to (memory_ref, expected_bit)."""
+        if not isinstance(condition, ast.BinaryExpression) or condition.op.name != "==":
+            raise ProgramConversionError("Unsupported branch condition (expected '==').")
+        lhs, rhs = condition.lhs, condition.rhs
+        if isinstance(lhs, (ast.BooleanLiteral, ast.IntegerLiteral)):
+            lhs, rhs = rhs, lhs
+        if not isinstance(lhs, ast.IndexExpression) or ro is None:
+            raise ProgramConversionError("Unsupported branch condition target.")
+        name = lhs.collection.name
+        if name not in clbit_offsets:
+            raise ProgramConversionError(f"Unknown classical register in branch: {name}")
+        ro_index = clbit_offsets[name] + lhs.index[0].value
+        return ro[ro_index], _literal_bit(rhs)
+
+    def emit(statement: ast.Statement, prog: Program) -> None:
+        # statements with no observable pyQuil equivalent that are safe to drop:
+        #   QuantumPhase = global phase (gphase), unobservable (pyqasm emits it when
         #   decomposing gates such as rzz; equivalence holds up to global phase).
-        # - QuantumBarrier = scheduling hint only; has no effect on the converted program.
         if isinstance(
             statement,
-            (
-                ast.QubitDeclaration,
-                ast.ClassicalDeclaration,
-                ast.Include,
-                ast.QuantumPhase,
-                ast.QuantumBarrier,
-            ),
+            (ast.QubitDeclaration, ast.ClassicalDeclaration, ast.Include, ast.QuantumPhase),
         ):
-            continue
+            return
 
-        if isinstance(statement, ast.QuantumGate):
+        if isinstance(statement, ast.QuantumBarrier):
+            prog.inst(pyquil_quilbase.Fence([flat(q) for q in statement.qubits]))
+
+        elif isinstance(statement, ast.QuantumReset):
+            prog.inst(pyquil_gates.RESET(flat(statement.qubits)))
+
+        elif isinstance(statement, ast.DelayInstruction):
+            qubits = [flat(q) for q in statement.qubits]
+            prog.inst(pyquil_quilbase.DelayQubits(qubits, _duration_seconds(statement.duration)))
+
+        elif isinstance(statement, ast.QuantumGate):
             name = statement.name.name.lower()
             if statement.modifiers:
                 raise ProgramConversionError(f"Unsupported gate modifier on: {name}")
             params = [arg.value for arg in statement.arguments]
-            qubits = [_flat_qubit(q, qubit_offsets) for q in statement.qubits]
+            qubits = [flat(q) for q in statement.qubits]
 
             if name == "sdg":
-                quil += pyquil_gates.S(*qubits).dagger()
+                prog.inst(pyquil_gates.S(*qubits).dagger())
             elif name == "tdg":
-                quil += pyquil_gates.T(*qubits).dagger()
+                prog.inst(pyquil_gates.T(*qubits).dagger())
             elif name == "sx":
-                quil += pyquil_gates.RX(math.pi / 2, *qubits)
+                prog.inst(pyquil_gates.RX(math.pi / 2, *qubits))
             elif name == "sxdg":
-                quil += pyquil_gates.RX(-math.pi / 2, *qubits)
+                prog.inst(pyquil_gates.RX(-math.pi / 2, *qubits))
             elif name in ("u", "u3"):
-                quil += pyquil_gates.U(*params, *qubits)
+                prog.inst(pyquil_gates.U(*params, *qubits))
             elif name in _GATE_MAP:
-                quil += getattr(pyquil_gates, _GATE_MAP[name])(*params, *qubits)
+                prog.inst(getattr(pyquil_gates, _GATE_MAP[name])(*params, *qubits))
             else:
                 raise ProgramConversionError(f"Unsupported gate: {name}")
 
         elif isinstance(statement, ast.QuantumMeasurementStatement):
-            src = _flat_qubit(statement.measure.qubit, qubit_offsets)
+            src = flat(statement.measure.qubit)
             if statement.target is not None and ro is not None:
                 target = statement.target
                 ro_index = clbit_offsets[target.name.name] + target.indices[0][0].value
-                quil += pyquil_gates.MEASURE(src, ro[ro_index])
+                prog.inst(pyquil_gates.MEASURE(src, ro[ro_index]))
             else:
-                quil += pyquil_gates.MEASURE(src, None)
+                prog.inst(pyquil_gates.MEASURE(src, None))
+
+        elif isinstance(statement, ast.BranchingStatement):
+            # classical feedforward: if (c[i] == 1) { ... } else { ... } -> JUMP-WHEN
+            reg, expected = branch_target(statement.condition)
+            then_block, else_block = statement.if_block, statement.else_block
+            if expected == 0:  # run the if-body when the bit is 0 => swap into the else slot
+                then_block, else_block = else_block, then_block
+            then_prog = pyquil.Program()
+            for inner in then_block:
+                emit(inner, then_prog)
+            else_prog = pyquil.Program()
+            for inner in else_block:
+                emit(inner, else_prog)
+            prog.if_then(reg, then_prog, else_prog if else_block else None)
 
         else:
             raise ProgramConversionError(f"Unsupported statement: {statement}")
+
+    for statement in unrolled.statements:
+        emit(statement, quil)
+
+    # pad idle declared qubits with identity so the operator spans the full register
+    for index in range(num_qubits):
+        if index not in used_qubits:
+            quil += pyquil_gates.I(index)
 
     return quil

--- a/qbraid/transpiler/conversions/openqasm3/openqasm3_to_pyquil.py
+++ b/qbraid/transpiler/conversions/openqasm3/openqasm3_to_pyquil.py
@@ -129,11 +129,19 @@ def openqasm3_to_pyquil(program: QasmStringType | ast.Program) -> Program:
 
     # pass 2: emit gates + measurements
     for statement in unrolled.statements:
-        # QuantumPhase = global phase (gphase); unobservable, safe to drop (pyqasm emits
-        # it when decomposing gates such as rzz; equivalence holds up to global phase).
+        # Skip statements with no pyQuil equivalent that are safe to drop:
+        # - QuantumPhase = global phase (gphase); unobservable (pyqasm emits it when
+        #   decomposing gates such as rzz; equivalence holds up to global phase).
+        # - QuantumBarrier = scheduling hint only; has no effect on the converted program.
         if isinstance(
             statement,
-            (ast.QubitDeclaration, ast.ClassicalDeclaration, ast.Include, ast.QuantumPhase),
+            (
+                ast.QubitDeclaration,
+                ast.ClassicalDeclaration,
+                ast.Include,
+                ast.QuantumPhase,
+                ast.QuantumBarrier,
+            ),
         ):
             continue
 

--- a/qbraid/transpiler/conversions/openqasm3/openqasm3_to_pyquil.py
+++ b/qbraid/transpiler/conversions/openqasm3/openqasm3_to_pyquil.py
@@ -179,6 +179,7 @@ def openqasm3_to_pyquil(program: QasmStringType | ast.Program) -> Program:
         ro_index = clbit_offsets[name] + lhs.index[0].value
         return ro[ro_index], _literal_bit(rhs)
 
+    # pylint: disable-next=too-many-statements
     def emit(statement: ast.Statement, prog: Program) -> None:
         # statements with no observable pyQuil equivalent that are safe to drop:
         #   QuantumPhase = global phase (gphase), unobservable (pyqasm emits it when
@@ -237,12 +238,14 @@ def openqasm3_to_pyquil(program: QasmStringType | ast.Program) -> Program:
             if expected == 0:  # run the if-body when the bit is 0 => swap into the else slot
                 then_block, else_block = else_block, then_block
             then_prog = pyquil.Program()
-            for inner in then_block:
+            for inner in then_block or []:
                 emit(inner, then_prog)
-            else_prog = pyquil.Program()
-            for inner in else_block:
-                emit(inner, else_prog)
-            prog.if_then(reg, then_prog, else_prog if else_block else None)
+            else_prog = None
+            if else_block:
+                else_prog = pyquil.Program()
+                for inner in else_block:
+                    emit(inner, else_prog)
+            prog.if_then(reg, then_prog, else_prog)
 
         else:
             raise ProgramConversionError(f"Unsupported statement: {statement}")

--- a/qbraid/transpiler/conversions/openqasm3/openqasm3_to_pyquil.py
+++ b/qbraid/transpiler/conversions/openqasm3/openqasm3_to_pyquil.py
@@ -148,7 +148,7 @@ def openqasm3_to_pyquil(program: QasmStringType | ast.Program) -> Program:
         if isinstance(statement, ast.QuantumGate):
             name = statement.name.name.lower()
             if statement.modifiers:
-                raise ProgramConversionError(f"Gate modifiers are not supported: {name}")
+                raise ProgramConversionError(f"Unsupported gate modifier on: {name}")
             params = [arg.value for arg in statement.arguments]
             qubits = [_flat_qubit(q, qubit_offsets) for q in statement.qubits]
 

--- a/tests/transpiler/openqasm3/__init__.py
+++ b/tests/transpiler/openqasm3/__init__.py
@@ -11,28 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-"""
-OpenQASM 3 conversions
-
-.. currentmodule:: qbraid.transpiler.conversions.openqasm3
-
-Functions
-----------
-
-.. autosummary::
-   :toctree: ../stubs/
-
-   openqasm3_to_qasm3
-   openqasm3_to_ionq
-   openqasm3_to_cudaq
-   openqasm3_to_pyquil
-
-"""
-
-from .openqasm3_to_cudaq import openqasm3_to_cudaq
-from .openqasm3_to_ionq import openqasm3_to_ionq
-from .openqasm3_to_pyquil import openqasm3_to_pyquil
-from .openqasm3_to_qasm3 import openqasm3_to_qasm3
-
-__all__ = ["openqasm3_to_qasm3", "openqasm3_to_ionq", "openqasm3_to_cudaq", "openqasm3_to_pyquil"]

--- a/tests/transpiler/openqasm3/test_conversions_openqasm3.py
+++ b/tests/transpiler/openqasm3/test_conversions_openqasm3.py
@@ -183,6 +183,25 @@ def test_openqasm3_to_pyquil_feedforward_else():
     assert "Z 1" in out
 
 
+def test_openqasm3_to_pyquil_feedforward_eq0_no_else():
+    """if (c == 0) without an else must not crash (the swap path) and still emit the body."""
+    qasm = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    bit[1] c;
+    c[0] = measure q[0];
+    if (c[0] == 0) {
+        x q[1];
+    }
+    """
+    result = openqasm3_to_pyquil(qasm)
+    result.resolve_label_placeholders()
+    out = result.out()
+    assert "JUMP-WHEN" in out
+    assert "X 1" in out
+
+
 def test_openqasm3_to_pyquil_gate_modifiers():
     """Gate modifiers (inv/ctrl/pow/negctrl) are decomposed by pyqasm and convert correctly."""
     qasm = """

--- a/tests/transpiler/openqasm3/test_conversions_openqasm3.py
+++ b/tests/transpiler/openqasm3/test_conversions_openqasm3.py
@@ -81,6 +81,23 @@ def test_openqasm3_to_pyquil_measurement():
     assert out.count("MEASURE") == 2
 
 
+def test_openqasm3_to_pyquil_barrier_skipped():
+    """Barrier statements have no pyQuil equivalent and are skipped, not raised."""
+    qasm = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    h q[0];
+    barrier q;
+    cx q[0], q[1];
+    """
+    result = openqasm3_to_pyquil(qasm)
+    out = result.out()
+    # the barrier emits no instruction, while the surrounding gates are preserved
+    assert "H 0" in out
+    assert "CNOT 0 1" in out
+
+
 def test_openqasm3_to_pyquil_malformed_raises():
     """Malformed QASM raises ProgramConversionError."""
     with pytest.raises(ProgramConversionError):

--- a/tests/transpiler/openqasm3/test_conversions_openqasm3.py
+++ b/tests/transpiler/openqasm3/test_conversions_openqasm3.py
@@ -17,11 +17,13 @@ Unit tests for OpenQASM 3 to pyQuil conversion.
 
 """
 
+import math
+
 import pytest
 
 try:
     from pyquil import Program
-    from pyquil.gates import CNOT, CPHASE, RX, RZ, H, I, S, X
+    from pyquil.gates import CNOT, CPHASE, RX, RZ, H, I, S, T, U, X
 
     from qbraid.interface import circuits_allclose
     from qbraid.transpiler.conversions.openqasm3.openqasm3_to_pyquil import openqasm3_to_pyquil
@@ -200,6 +202,27 @@ def test_openqasm3_to_pyquil_feedforward_eq0_no_else():
     out = result.out()
     assert "JUMP-WHEN" in out
     assert "X 1" in out
+
+
+def test_openqasm3_to_pyquil_special_gates():
+    """Gates needing bespoke handling (sx/sxdg -> RX(+-pi/2), u/u3 -> U, tdg -> T-dagger)."""
+    qasm = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[1] q;
+    sx q[0];
+    sxdg q[0];
+    tdg q[0];
+    u(0.1, 0.2, 0.3) q[0];
+    """
+    result = openqasm3_to_pyquil(qasm)
+    expected = Program(
+        RX(math.pi / 2, 0),
+        RX(-math.pi / 2, 0),
+        T(0).dagger(),
+        U(0.1, 0.2, 0.3, 0),
+    )
+    assert circuits_allclose(result, expected, strict_gphase=False)
 
 
 def test_openqasm3_to_pyquil_gate_modifiers():

--- a/tests/transpiler/openqasm3/test_conversions_openqasm3.py
+++ b/tests/transpiler/openqasm3/test_conversions_openqasm3.py
@@ -1,0 +1,99 @@
+# Copyright 2025 qBraid
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for OpenQASM 3 to pyQuil conversion.
+
+"""
+
+import pytest
+
+try:
+    import pyquil  # pylint: disable=unused-import
+
+    from qbraid.interface import circuits_allclose
+    from qbraid.transpiler.conversions.openqasm3.openqasm3_to_pyquil import openqasm3_to_pyquil
+    from qbraid.transpiler.conversions.qasm3 import qasm3_to_cirq
+    from qbraid.transpiler.exceptions import ProgramConversionError
+
+    pyquil_not_installed = False
+except ImportError:
+    pyquil_not_installed = True
+
+pytestmark = pytest.mark.skipif(pyquil_not_installed, reason="pyquil not installed")
+
+
+def test_openqasm3_to_pyquil_bell():
+    """Bell circuit converts and matches unitary."""
+    qasm = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    h q[0];
+    cx q[0], q[1];
+    """
+    result = openqasm3_to_pyquil(qasm)
+    reference = qasm3_to_cirq(qasm)
+    assert circuits_allclose(reference, result, strict_gphase=False)
+
+
+def test_openqasm3_to_pyquil_parameterized():
+    """Parameterized gates convert and match unitary."""
+    qasm = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    rx(0.5) q[0];
+    rz(1.2) q[1];
+    cp(0.3) q[0], q[1];
+    """
+    result = openqasm3_to_pyquil(qasm)
+    reference = qasm3_to_cirq(qasm)
+    assert circuits_allclose(reference, result, strict_gphase=False)
+
+
+def test_openqasm3_to_pyquil_measurement():
+    """Measurement produces a DECLARE + MEASURE."""
+    qasm = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    bit[2] c;
+    h q[0];
+    cx q[0], q[1];
+    c[0] = measure q[0];
+    c[1] = measure q[1];
+    """
+    result = openqasm3_to_pyquil(qasm)
+    out = result.out()
+    assert "DECLARE ro BIT[2]" in out
+    assert out.count("MEASURE") == 2
+
+
+def test_openqasm3_to_pyquil_malformed_raises():
+    """Malformed QASM raises ProgramConversionError."""
+    with pytest.raises(ProgramConversionError):
+        openqasm3_to_pyquil("OPENQASM 3.0; this is not valid;")
+
+
+def test_openqasm3_to_pyquil_unsupported_statement_raises():
+    """A statement outside the supported set (e.g. reset) raises ProgramConversionError."""
+    qasm = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[1] q;
+    reset q[0];
+    """
+    with pytest.raises(ProgramConversionError):
+        openqasm3_to_pyquil(qasm)

--- a/tests/transpiler/openqasm3/test_conversions_openqasm3.py
+++ b/tests/transpiler/openqasm3/test_conversions_openqasm3.py
@@ -21,7 +21,7 @@ import pytest
 
 try:
     from pyquil import Program
-    from pyquil.gates import CNOT, CPHASE, RX, RZ, H
+    from pyquil.gates import CNOT, CPHASE, RX, RZ, H, S, X
 
     from qbraid.interface import circuits_allclose
     from qbraid.transpiler.conversions.openqasm3.openqasm3_to_pyquil import openqasm3_to_pyquil
@@ -96,6 +96,23 @@ def test_openqasm3_to_pyquil_barrier_skipped():
     # the barrier emits no instruction, while the surrounding gates are preserved
     assert "H 0" in out
     assert "CNOT 0 1" in out
+
+
+def test_openqasm3_to_pyquil_gate_modifiers():
+    """Gate modifiers (inv/ctrl/pow/negctrl) are decomposed by pyqasm and convert correctly."""
+    qasm = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    inv @ s q[0];
+    ctrl @ x q[0], q[1];
+    pow(2) @ x q[0];
+    negctrl @ x q[0], q[1];
+    """
+    result = openqasm3_to_pyquil(qasm)
+    # inv @ s -> S-dagger; ctrl @ x -> CNOT; pow(2) @ x -> X X; negctrl @ x -> X CNOT X
+    expected = Program(S(0).dagger(), CNOT(0, 1), X(0), X(0), X(0), CNOT(0, 1), X(0))
+    assert circuits_allclose(result, expected, strict_gphase=False)
 
 
 def test_openqasm3_to_pyquil_malformed_raises():

--- a/tests/transpiler/openqasm3/test_conversions_openqasm3.py
+++ b/tests/transpiler/openqasm3/test_conversions_openqasm3.py
@@ -20,11 +20,11 @@ Unit tests for OpenQASM 3 to pyQuil conversion.
 import pytest
 
 try:
-    import pyquil  # pylint: disable=unused-import
+    from pyquil import Program
+    from pyquil.gates import CNOT, CPHASE, RX, RZ, H
 
     from qbraid.interface import circuits_allclose
     from qbraid.transpiler.conversions.openqasm3.openqasm3_to_pyquil import openqasm3_to_pyquil
-    from qbraid.transpiler.conversions.qasm3 import qasm3_to_cirq
     from qbraid.transpiler.exceptions import ProgramConversionError
 
     pyquil_not_installed = False
@@ -35,7 +35,7 @@ pytestmark = pytest.mark.skipif(pyquil_not_installed, reason="pyquil not install
 
 
 def test_openqasm3_to_pyquil_bell():
-    """Bell circuit converts and matches unitary."""
+    """Bell circuit converts and matches an explicit pyQuil reference."""
     qasm = """
     OPENQASM 3.0;
     include "stdgates.inc";
@@ -44,12 +44,12 @@ def test_openqasm3_to_pyquil_bell():
     cx q[0], q[1];
     """
     result = openqasm3_to_pyquil(qasm)
-    reference = qasm3_to_cirq(qasm)
-    assert circuits_allclose(reference, result, strict_gphase=False)
+    expected = Program(H(0), CNOT(0, 1))
+    assert circuits_allclose(result, expected, strict_gphase=False)
 
 
 def test_openqasm3_to_pyquil_parameterized():
-    """Parameterized gates convert and match unitary."""
+    """Parameterized gates convert and match an explicit pyQuil reference."""
     qasm = """
     OPENQASM 3.0;
     include "stdgates.inc";
@@ -59,8 +59,8 @@ def test_openqasm3_to_pyquil_parameterized():
     cp(0.3) q[0], q[1];
     """
     result = openqasm3_to_pyquil(qasm)
-    reference = qasm3_to_cirq(qasm)
-    assert circuits_allclose(reference, result, strict_gphase=False)
+    expected = Program(RX(0.5, 0), RZ(1.2, 1), CPHASE(0.3, 0, 1))
+    assert circuits_allclose(result, expected, strict_gphase=False)
 
 
 def test_openqasm3_to_pyquil_measurement():

--- a/tests/transpiler/openqasm3/test_conversions_openqasm3.py
+++ b/tests/transpiler/openqasm3/test_conversions_openqasm3.py
@@ -21,7 +21,7 @@ import pytest
 
 try:
     from pyquil import Program
-    from pyquil.gates import CNOT, CPHASE, RX, RZ, H, S, X
+    from pyquil.gates import CNOT, CPHASE, RX, RZ, H, I, S, X
 
     from qbraid.interface import circuits_allclose
     from qbraid.transpiler.conversions.openqasm3.openqasm3_to_pyquil import openqasm3_to_pyquil
@@ -81,8 +81,8 @@ def test_openqasm3_to_pyquil_measurement():
     assert out.count("MEASURE") == 2
 
 
-def test_openqasm3_to_pyquil_barrier_skipped():
-    """Barrier statements have no pyQuil equivalent and are skipped, not raised."""
+def test_openqasm3_to_pyquil_barrier_fence():
+    """Barrier maps to a pyQuil FENCE over its qubits, preserving surrounding gates."""
     qasm = """
     OPENQASM 3.0;
     include "stdgates.inc";
@@ -91,11 +91,96 @@ def test_openqasm3_to_pyquil_barrier_skipped():
     barrier q;
     cx q[0], q[1];
     """
-    result = openqasm3_to_pyquil(qasm)
-    out = result.out()
-    # the barrier emits no instruction, while the surrounding gates are preserved
+    out = openqasm3_to_pyquil(qasm).out()
     assert "H 0" in out
+    assert "FENCE 0 1" in out
     assert "CNOT 0 1" in out
+
+
+def test_openqasm3_to_pyquil_idle_qubits_padded():
+    """Declared-but-unused qubits are padded with I so the register width is preserved."""
+    qasm = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[4] q;
+    x q[0];
+    x q[2];
+    x q[3];
+    """
+    result = openqasm3_to_pyquil(qasm)
+    # q[1] is idle; without padding the program would be 3-qubit and mismatch the
+    # 4-qubit reference operator.
+    expected = Program(X(0), X(2), X(3), I(1))
+    assert circuits_allclose(result, expected, strict_gphase=False)
+
+
+def test_openqasm3_to_pyquil_reset():
+    """reset maps to pyQuil RESET on the target qubit."""
+    qasm = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    x q[0];
+    reset q[0];
+    """
+    out = openqasm3_to_pyquil(qasm).out()
+    assert "X 0" in out
+    assert "RESET 0" in out
+
+
+def test_openqasm3_to_pyquil_delay():
+    """delay maps to pyQuil DELAY with the duration converted to seconds."""
+    qasm = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[1] q;
+    delay[100ns] q[0];
+    """
+    out = openqasm3_to_pyquil(qasm).out()
+    assert "DELAY 0" in out
+
+
+def test_openqasm3_to_pyquil_feedforward():
+    """if (c == 1) classical feedforward maps to a conditional JUMP-WHEN block."""
+    qasm = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    bit[1] c;
+    h q[0];
+    c[0] = measure q[0];
+    if (c[0] == 1) {
+        x q[1];
+    }
+    """
+    result = openqasm3_to_pyquil(qasm)
+    result.resolve_label_placeholders()
+    out = result.out()
+    assert "MEASURE 0 ro[0]" in out
+    assert "JUMP-WHEN" in out
+    assert "X 1" in out
+
+
+def test_openqasm3_to_pyquil_feedforward_else():
+    """if/else feedforward emits both branches conditioned on the measured bit."""
+    qasm = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[2] q;
+    bit[1] c;
+    c[0] = measure q[0];
+    if (c[0] == 1) {
+        x q[1];
+    } else {
+        z q[1];
+    }
+    """
+    result = openqasm3_to_pyquil(qasm)
+    result.resolve_label_placeholders()
+    out = result.out()
+    assert "JUMP-WHEN" in out
+    assert "X 1" in out
+    assert "Z 1" in out
 
 
 def test_openqasm3_to_pyquil_gate_modifiers():
@@ -121,13 +206,18 @@ def test_openqasm3_to_pyquil_malformed_raises():
         openqasm3_to_pyquil("OPENQASM 3.0; this is not valid;")
 
 
-def test_openqasm3_to_pyquil_unsupported_statement_raises():
-    """A statement outside the supported set (e.g. reset) raises ProgramConversionError."""
+def test_openqasm3_to_pyquil_unsupported_condition_raises():
+    """A branch condition the converter cannot express raises ProgramConversionError."""
     qasm = """
     OPENQASM 3.0;
     include "stdgates.inc";
-    qubit[1] q;
-    reset q[0];
+    qubit[2] q;
+    bit[2] c;
+    c[0] = measure q[0];
+    c[1] = measure q[1];
+    if (c[0] == 1 && c[1] == 1) {
+        x q[0];
+    }
     """
     with pytest.raises(ProgramConversionError):
         openqasm3_to_pyquil(qasm)

--- a/tests/transpiler/openqasm3/test_conversions_openqasm3.py
+++ b/tests/transpiler/openqasm3/test_conversions_openqasm3.py
@@ -22,11 +22,17 @@ import math
 import pytest
 
 try:
+    from openqasm3 import ast
     from pyquil import Program
     from pyquil.gates import CNOT, CPHASE, RX, RZ, H, I, S, T, U, X
 
     from qbraid.interface import circuits_allclose
-    from qbraid.transpiler.conversions.openqasm3.openqasm3_to_pyquil import openqasm3_to_pyquil
+    from qbraid.transpiler.conversions.openqasm3.openqasm3_to_pyquil import (
+        _branch_target,
+        _duration_seconds,
+        _literal_bit,
+        openqasm3_to_pyquil,
+    )
     from qbraid.transpiler.exceptions import ProgramConversionError
 
     pyquil_not_installed = False
@@ -240,6 +246,104 @@ def test_openqasm3_to_pyquil_gate_modifiers():
     # inv @ s -> S-dagger; ctrl @ x -> CNOT; pow(2) @ x -> X X; negctrl @ x -> X CNOT X
     expected = Program(S(0).dagger(), CNOT(0, 1), X(0), X(0), X(0), CNOT(0, 1), X(0))
     assert circuits_allclose(result, expected, strict_gphase=False)
+
+
+def test_openqasm3_to_pyquil_two_qubit_registers():
+    """Multiple qubit registers map to offset flat indices."""
+    qasm = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[1] a;
+    qubit[1] b;
+    x a[0];
+    x b[0];
+    """
+    result = openqasm3_to_pyquil(qasm)
+    assert circuits_allclose(result, Program(X(0), X(1)), strict_gphase=False)
+
+
+def test_openqasm3_to_pyquil_measure_without_target():
+    """A bare ``measure q;`` (no classical target) emits MEASURE with no readout slot."""
+    qasm = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[1] q;
+    measure q[0];
+    """
+    out = openqasm3_to_pyquil(qasm).out()
+    assert "MEASURE 0" in out
+    assert "ro" not in out
+
+
+def test_openqasm3_to_pyquil_unsupported_statement_raises():
+    """A statement type with no pyQuil equivalent (e.g. box) raises."""
+    qasm = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    qubit[1] q;
+    box {
+        x q[0];
+    }
+    """
+    with pytest.raises(ProgramConversionError):
+        openqasm3_to_pyquil(qasm)
+
+
+# --- direct unit tests for the helper functions (guard branches) ---
+
+
+def test_literal_bit():
+    """_literal_bit reads 0/1 from boolean or integer literals, else raises."""
+    assert _literal_bit(ast.BooleanLiteral(value=True)) == 1
+    assert _literal_bit(ast.BooleanLiteral(value=False)) == 0
+    assert _literal_bit(ast.IntegerLiteral(value=1)) == 1
+    assert _literal_bit(ast.IntegerLiteral(value=0)) == 0
+    with pytest.raises(ProgramConversionError):
+        _literal_bit(ast.IntegerLiteral(value=2))
+
+
+def test_duration_seconds():
+    """_duration_seconds converts known units and raises on unsupported ones (e.g. dt)."""
+    assert _duration_seconds(
+        ast.DurationLiteral(value=100.0, unit=ast.TimeUnit.ns)
+    ) == pytest.approx(100e-9)
+    with pytest.raises(ProgramConversionError):
+        _duration_seconds(ast.DurationLiteral(value=5.0, unit=ast.TimeUnit.dt))
+
+
+def _cond(lhs, rhs, op="=="):
+    return ast.BinaryExpression(op=ast.BinaryOperator[op], lhs=lhs, rhs=rhs)
+
+
+def _index(name, idx=0):
+    return ast.IndexExpression(
+        collection=ast.Identifier(name=name), index=[ast.IntegerLiteral(value=idx)]
+    )
+
+
+def test_branch_target():
+    """_branch_target resolves c[i] == 0|1 conditions and rejects everything else."""
+    ro = Program().declare("ro", "BIT", 2)
+    offsets = {"c": 0}
+
+    # canonical form c[0] == true
+    reg, expected = _branch_target(
+        _cond(_index("c", 0), ast.BooleanLiteral(value=True)), offsets, ro
+    )
+    assert expected == 1
+    assert reg == ro[0]
+    # reversed operands (literal on the left) are normalized
+    _branch_target(_cond(ast.BooleanLiteral(value=True), _index("c", 0)), offsets, ro)
+
+    # non-"==" operator
+    with pytest.raises(ProgramConversionError):
+        _branch_target(_cond(_index("c", 0), ast.BooleanLiteral(value=True), op="!="), offsets, ro)
+    # target is not an indexed classical bit
+    with pytest.raises(ProgramConversionError):
+        _branch_target(_cond(ast.Identifier(name="c"), ast.BooleanLiteral(value=True)), offsets, ro)
+    # unknown classical register
+    with pytest.raises(ProgramConversionError):
+        _branch_target(_cond(_index("d", 0), ast.BooleanLiteral(value=True)), offsets, ro)
 
 
 def test_openqasm3_to_pyquil_malformed_raises():

--- a/tests/transpiler/openqasm3/test_coverage_from_openqasm3.py
+++ b/tests/transpiler/openqasm3/test_coverage_from_openqasm3.py
@@ -28,12 +28,18 @@ try:
     from qbraid.transpiler import ConversionGraph, transpile
     from qbraid.transpiler.conversions.qasm3 import qasm3_to_cirq
 
-    cirq_not_installed = False
+    cirq_missing = False
 except ImportError:
-    cirq_not_installed = True
+    cirq_missing = True
 
-# cirq is used as the equivalence reference (a raw QASM string has no unitary of its own)
-pytestmark = pytest.mark.skipif(cirq_not_installed, reason="cirq not installed")
+pyquil_missing = importlib.util.find_spec("pyquil") is None
+
+# This benchmark measures the openqasm3 -> pyquil edge added by this PR. pyQuil is
+# the target; cirq is only the equivalence reference (a raw QASM string has no
+# unitary of its own). Both must be installed, so the module is skipped otherwise.
+pytestmark = pytest.mark.skipif(
+    cirq_missing or pyquil_missing, reason="pyquil and/or cirq not installed"
+)
 
 
 def _qasm(body: str, num_qubits: int) -> str:
@@ -75,28 +81,14 @@ QASM_GATES = {
     "ccx": _qasm("ccx q[0], q[1], q[2];", 3),
     "cswap": _qasm("cswap q[0], q[1], q[2];", 3),
     "u": _qasm("u(0.1, 0.2, 0.3) q[0];", 1),
-    "u1": _qasm("u1(0.5) q[0];", 1),
-    "u2": _qasm("u2(0.1, 0.2) q[0];", 1),
-    "u3": _qasm("u3(0.1, 0.2, 0.3) q[0];", 1),
     "id": _qasm("id q[0];", 1),
 }
 
-
-def is_package_installed(package_name: str) -> bool:
-    """Check if a package is installed."""
-    return importlib.util.find_spec(package_name) is not None
-
-
-# (target, baseline). Baseline = measured coverage of openqasm3 -> target over the
-# standard gate set, transpiled through a require-native conversion graph.
-ALL_TARGETS = [
-    ("pyquil", 1.0),
-    ("qiskit", 1.0),
-    ("cirq", 1.0),
-    ("braket", 1.0),
-    ("pytket", 1.0),
-]
-AVAILABLE_TARGETS = [(name, version) for name, version in ALL_TARGETS if is_package_installed(name)]
+# Only pyquil is benchmarked here -- it is the target this PR adds. Coverage of the
+# other native targets (qiskit/cirq/braket/pytket) is deferred to a dedicated
+# multi-package benchmark PR. Baseline = measured openqasm3 -> pyquil coverage over
+# the gate set above, transpiled through a require-native conversion graph.
+ALL_TARGETS = [("pyquil", 1.0)]
 
 graph = ConversionGraph(require_native=True)
 
@@ -111,7 +103,7 @@ def convert_from_openqasm3_to_x(target, gate_name):
     assert circuits_allclose(reference, result, strict_gphase=False)
 
 
-@pytest.mark.parametrize(("target", "baseline"), AVAILABLE_TARGETS)
+@pytest.mark.parametrize(("target", "baseline"), ALL_TARGETS)
 def test_openqasm3_coverage(target, baseline):
     """Measure openqasm3 -> target coverage over a standard gate set."""
     ACCURACY_BASELINE = baseline

--- a/tests/transpiler/openqasm3/test_coverage_from_openqasm3.py
+++ b/tests/transpiler/openqasm3/test_coverage_from_openqasm3.py
@@ -24,57 +24,61 @@ import importlib.util
 import pytest
 
 try:
-    import pyquil  # pylint: disable=unused-import
-
     from qbraid.interface import circuits_allclose
-    from qbraid.transpiler.conversions.openqasm3 import openqasm3_to_pyquil
+    from qbraid.transpiler import ConversionGraph, transpile
     from qbraid.transpiler.conversions.qasm3 import qasm3_to_cirq
 
-    pyquil_not_installed = False
+    cirq_not_installed = False
 except ImportError:
-    pyquil_not_installed = True
+    cirq_not_installed = True
 
-pytestmark = pytest.mark.skipif(pyquil_not_installed, reason="pyquil not installed")
+# cirq is used as the equivalence reference (a raw QASM string has no unitary of its own)
+pytestmark = pytest.mark.skipif(cirq_not_installed, reason="cirq not installed")
 
 
-def _qasm(body: str, num_qubits: int = 3) -> str:
-    """Wrap a gate line in a minimal OpenQASM 3 program."""
+def _qasm(body: str, num_qubits: int) -> str:
+    """Wrap a gate line in a minimal OpenQASM 3 program.
+
+    The program declares exactly the number of qubits the gate acts on. This
+    matters because the cirq reference parser prunes unused qubits while several
+    target frameworks keep all declared qubits; declaring the minimum keeps the
+    reference and the target circuits dimensionally comparable.
+    """
     return "OPENQASM 3.0;\n" 'include "stdgates.inc";\n' f"qubit[{num_qubits}] q;\n" f"{body}\n"
 
 
 # The OpenQASM 3 standard gate set (stdgates.inc). `cu` is omitted because the
-# cirq reference parser rejects its 4-parameter form (it is still converted
-# correctly by openqasm3_to_pyquil, just not benchmarkable against cirq here).
+# cirq reference parser rejects its 4-parameter form.
 QASM_GATES = {
-    "p": _qasm("p(0.5) q[0];"),
-    "x": _qasm("x q[0];"),
-    "y": _qasm("y q[0];"),
-    "z": _qasm("z q[0];"),
-    "h": _qasm("h q[0];"),
-    "s": _qasm("s q[0];"),
-    "sdg": _qasm("sdg q[0];"),
-    "t": _qasm("t q[0];"),
-    "tdg": _qasm("tdg q[0];"),
-    "sx": _qasm("sx q[0];"),
-    "rx": _qasm("rx(0.5) q[0];"),
-    "ry": _qasm("ry(0.5) q[0];"),
-    "rz": _qasm("rz(0.5) q[0];"),
-    "cx": _qasm("cx q[0], q[1];"),
-    "cy": _qasm("cy q[0], q[1];"),
-    "cz": _qasm("cz q[0], q[1];"),
-    "cp": _qasm("cp(0.5) q[0], q[1];"),
-    "crx": _qasm("crx(0.5) q[0], q[1];"),
-    "cry": _qasm("cry(0.5) q[0], q[1];"),
-    "crz": _qasm("crz(0.5) q[0], q[1];"),
-    "ch": _qasm("ch q[0], q[1];"),
-    "swap": _qasm("swap q[0], q[1];"),
-    "ccx": _qasm("ccx q[0], q[1], q[2];"),
-    "cswap": _qasm("cswap q[0], q[1], q[2];"),
-    "u": _qasm("u(0.1, 0.2, 0.3) q[0];"),
-    "u1": _qasm("u1(0.5) q[0];"),
-    "u2": _qasm("u2(0.1, 0.2) q[0];"),
-    "u3": _qasm("u3(0.1, 0.2, 0.3) q[0];"),
-    "id": _qasm("id q[0];"),
+    "p": _qasm("p(0.5) q[0];", 1),
+    "x": _qasm("x q[0];", 1),
+    "y": _qasm("y q[0];", 1),
+    "z": _qasm("z q[0];", 1),
+    "h": _qasm("h q[0];", 1),
+    "s": _qasm("s q[0];", 1),
+    "sdg": _qasm("sdg q[0];", 1),
+    "t": _qasm("t q[0];", 1),
+    "tdg": _qasm("tdg q[0];", 1),
+    "sx": _qasm("sx q[0];", 1),
+    "rx": _qasm("rx(0.5) q[0];", 1),
+    "ry": _qasm("ry(0.5) q[0];", 1),
+    "rz": _qasm("rz(0.5) q[0];", 1),
+    "cx": _qasm("cx q[0], q[1];", 2),
+    "cy": _qasm("cy q[0], q[1];", 2),
+    "cz": _qasm("cz q[0], q[1];", 2),
+    "cp": _qasm("cp(0.5) q[0], q[1];", 2),
+    "crx": _qasm("crx(0.5) q[0], q[1];", 2),
+    "cry": _qasm("cry(0.5) q[0], q[1];", 2),
+    "crz": _qasm("crz(0.5) q[0], q[1];", 2),
+    "ch": _qasm("ch q[0], q[1];", 2),
+    "swap": _qasm("swap q[0], q[1];", 2),
+    "ccx": _qasm("ccx q[0], q[1], q[2];", 3),
+    "cswap": _qasm("cswap q[0], q[1], q[2];", 3),
+    "u": _qasm("u(0.1, 0.2, 0.3) q[0];", 1),
+    "u1": _qasm("u1(0.5) q[0];", 1),
+    "u2": _qasm("u2(0.1, 0.2) q[0];", 1),
+    "u3": _qasm("u3(0.1, 0.2, 0.3) q[0];", 1),
+    "id": _qasm("id q[0];", 1),
 }
 
 
@@ -84,16 +88,25 @@ def is_package_installed(package_name: str) -> bool:
 
 
 # (target, baseline). Baseline = measured coverage of openqasm3 -> target over the
-# standard gate set (matches the @weight on openqasm3_to_pyquil).
-ALL_TARGETS = [("pyquil", 1.0)]
-AVAILABLE_TARGETS = [(n, v) for n, v in ALL_TARGETS if is_package_installed(n)]
+# standard gate set, transpiled through a require-native conversion graph.
+ALL_TARGETS = [
+    ("pyquil", 1.0),
+    ("qiskit", 1.0),
+    ("cirq", 1.0),
+    ("braket", 1.0),
+    ("pytket", 1.0),
+]
+AVAILABLE_TARGETS = [(name, version) for name, version in ALL_TARGETS if is_package_installed(name)]
+
+graph = ConversionGraph(require_native=True)
 
 
-def convert_from_openqasm3_to_x(target, gate_name):  # pylint: disable=unused-argument
-    """Convert a single-gate OpenQASM 3 program to pyQuil and check equivalence
-    against a cirq reference (raw QASM strings have no unitary method)."""
+def convert_from_openqasm3_to_x(target, gate_name):
+    """Transpile a single-gate OpenQASM 3 program to the target program type
+    (via a require-native conversion graph) and check equivalence against a cirq
+    reference."""
     qasm = QASM_GATES[gate_name]
-    result = openqasm3_to_pyquil(qasm)
+    result = transpile(qasm, target, conversion_graph=graph)
     reference = qasm3_to_cirq(qasm)
     assert circuits_allclose(reference, result, strict_gphase=False)
 

--- a/tests/transpiler/openqasm3/test_coverage_from_openqasm3.py
+++ b/tests/transpiler/openqasm3/test_coverage_from_openqasm3.py
@@ -25,6 +25,7 @@ import pytest
 
 try:
     from qbraid.interface import circuits_allclose
+    from qbraid.programs.exceptions import QasmError
     from qbraid.transpiler import ConversionGraph, transpile
     from qbraid.transpiler.conversions.qasm3 import qasm3_to_cirq
 
@@ -96,11 +97,22 @@ graph = ConversionGraph(require_native=True)
 def convert_from_openqasm3_to_x(target, gate_name):
     """Transpile a single-gate OpenQASM 3 program to the target program type
     (via a require-native conversion graph) and check equivalence against a cirq
-    reference."""
+    reference.
+
+    Returns ``False`` if the cirq reference parser cannot represent the gate on
+    the installed cirq version (e.g. cirq < 1.6 lacks ``p``/``cp``/``crx``/``cry``/
+    ``u`` in its QASM importer). Without a ground-truth reference the gate cannot
+    be scored, so it is excluded from the accuracy rather than counted as a
+    converter failure. Returns ``True`` when the conversion was scored.
+    """
     qasm = QASM_GATES[gate_name]
     result = transpile(qasm, target, conversion_graph=graph)
-    reference = qasm3_to_cirq(qasm)
+    try:
+        reference = qasm3_to_cirq(qasm)
+    except QasmError:
+        return False
     assert circuits_allclose(reference, result, strict_gphase=False)
+    return True
 
 
 @pytest.mark.parametrize(("target", "baseline"), ALL_TARGETS)
@@ -109,16 +121,21 @@ def test_openqasm3_coverage(target, baseline):
     ACCURACY_BASELINE = baseline
     ALLOWANCE = 0.01
     failures = {}
+    unscoreable = []
     for gate_name in QASM_GATES:
         try:
-            convert_from_openqasm3_to_x(target, gate_name)
+            if not convert_from_openqasm3_to_x(target, gate_name):
+                unscoreable.append(gate_name)
         except Exception as e:  # pylint: disable=broad-exception-caught
             failures[f"{target}-{gate_name}"] = e
 
-    total = len(QASM_GATES)
+    total = len(QASM_GATES) - len(unscoreable)
     nb_fails = len(failures)
-    accuracy = (total - nb_fails) / total
-    print(f"\n{target} coverage: {accuracy:.2%}  failures: {list(failures.keys())}")
+    accuracy = (total - nb_fails) / total if total else 1.0
+    print(
+        f"\n{target} coverage: {accuracy:.2%}  failures: {list(failures.keys())}  "
+        f"unscoreable (no cirq reference): {unscoreable}"
+    )
 
     assert accuracy >= ACCURACY_BASELINE - ALLOWANCE, (
         f"Coverage threshold not met. {nb_fails}/{total} failed. " f"Failures: {failures.keys()}"

--- a/tests/transpiler/openqasm3/test_coverage_from_openqasm3.py
+++ b/tests/transpiler/openqasm3/test_coverage_from_openqasm3.py
@@ -1,0 +1,120 @@
+# Copyright 2025 qBraid
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=redefined-outer-name
+
+"""
+Benchmarking tests for OpenQASM 3 (source) conversions.
+
+"""
+
+import importlib.util
+
+import pytest
+
+try:
+    import pyquil  # pylint: disable=unused-import
+
+    from qbraid.interface import circuits_allclose
+    from qbraid.transpiler.conversions.openqasm3 import openqasm3_to_pyquil
+    from qbraid.transpiler.conversions.qasm3 import qasm3_to_cirq
+
+    pyquil_not_installed = False
+except ImportError:
+    pyquil_not_installed = True
+
+pytestmark = pytest.mark.skipif(pyquil_not_installed, reason="pyquil not installed")
+
+
+def _qasm(body: str, num_qubits: int = 3) -> str:
+    """Wrap a gate line in a minimal OpenQASM 3 program."""
+    return "OPENQASM 3.0;\n" 'include "stdgates.inc";\n' f"qubit[{num_qubits}] q;\n" f"{body}\n"
+
+
+# The OpenQASM 3 standard gate set (stdgates.inc). `cu` is omitted because the
+# cirq reference parser rejects its 4-parameter form (it is still converted
+# correctly by openqasm3_to_pyquil, just not benchmarkable against cirq here).
+QASM_GATES = {
+    "p": _qasm("p(0.5) q[0];"),
+    "x": _qasm("x q[0];"),
+    "y": _qasm("y q[0];"),
+    "z": _qasm("z q[0];"),
+    "h": _qasm("h q[0];"),
+    "s": _qasm("s q[0];"),
+    "sdg": _qasm("sdg q[0];"),
+    "t": _qasm("t q[0];"),
+    "tdg": _qasm("tdg q[0];"),
+    "sx": _qasm("sx q[0];"),
+    "rx": _qasm("rx(0.5) q[0];"),
+    "ry": _qasm("ry(0.5) q[0];"),
+    "rz": _qasm("rz(0.5) q[0];"),
+    "cx": _qasm("cx q[0], q[1];"),
+    "cy": _qasm("cy q[0], q[1];"),
+    "cz": _qasm("cz q[0], q[1];"),
+    "cp": _qasm("cp(0.5) q[0], q[1];"),
+    "crx": _qasm("crx(0.5) q[0], q[1];"),
+    "cry": _qasm("cry(0.5) q[0], q[1];"),
+    "crz": _qasm("crz(0.5) q[0], q[1];"),
+    "ch": _qasm("ch q[0], q[1];"),
+    "swap": _qasm("swap q[0], q[1];"),
+    "ccx": _qasm("ccx q[0], q[1], q[2];"),
+    "cswap": _qasm("cswap q[0], q[1], q[2];"),
+    "u": _qasm("u(0.1, 0.2, 0.3) q[0];"),
+    "u1": _qasm("u1(0.5) q[0];"),
+    "u2": _qasm("u2(0.1, 0.2) q[0];"),
+    "u3": _qasm("u3(0.1, 0.2, 0.3) q[0];"),
+    "id": _qasm("id q[0];"),
+}
+
+
+def is_package_installed(package_name: str) -> bool:
+    """Check if a package is installed."""
+    return importlib.util.find_spec(package_name) is not None
+
+
+# (target, baseline). Baseline = measured coverage of openqasm3 -> target over the
+# standard gate set (matches the @weight on openqasm3_to_pyquil).
+ALL_TARGETS = [("pyquil", 1.0)]
+AVAILABLE_TARGETS = [(n, v) for n, v in ALL_TARGETS if is_package_installed(n)]
+
+
+def convert_from_openqasm3_to_x(target, gate_name):  # pylint: disable=unused-argument
+    """Convert a single-gate OpenQASM 3 program to pyQuil and check equivalence
+    against a cirq reference (raw QASM strings have no unitary method)."""
+    qasm = QASM_GATES[gate_name]
+    result = openqasm3_to_pyquil(qasm)
+    reference = qasm3_to_cirq(qasm)
+    assert circuits_allclose(reference, result, strict_gphase=False)
+
+
+@pytest.mark.parametrize(("target", "baseline"), AVAILABLE_TARGETS)
+def test_openqasm3_coverage(target, baseline):
+    """Measure openqasm3 -> target coverage over a standard gate set."""
+    ACCURACY_BASELINE = baseline
+    ALLOWANCE = 0.01
+    failures = {}
+    for gate_name in QASM_GATES:
+        try:
+            convert_from_openqasm3_to_x(target, gate_name)
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            failures[f"{target}-{gate_name}"] = e
+
+    total = len(QASM_GATES)
+    nb_fails = len(failures)
+    accuracy = (total - nb_fails) / total
+    print(f"\n{target} coverage: {accuracy:.2%}  failures: {list(failures.keys())}")
+
+    assert accuracy >= ACCURACY_BASELINE - ALLOWANCE, (
+        f"Coverage threshold not met. {nb_fails}/{total} failed. " f"Failures: {failures.keys()}"
+    )


### PR DESCRIPTION
## Summary
Closes #1179. Adds `openqasm3_to_pyquil`, a direct transpiler conversion from
OpenQASM 3 to pyQuil. Submitted for unitaryHACK 2026.

Implements the approach I proposed and that was approved by @ryanhill1 in [#1179](https://github.com/qBraid/qBraid/issues/1179) (see my comment in the issue thread). I had this ready before noticing another PR was opened for the same issue; opening here so the maintainers can compare.

Previously, `openqasm3 -> pyquil` was only reachable via the 3-hop path
`openqasm3 -> qasm3 -> cirq -> pyquil`, with `pyquil` reachable only through
`cirq`. This adds a single high-fidelity edge.

## Approach
Mirrors `openqasm3_to_cudaq`: the program is loaded, validated, and unrolled
With `pyqasm`, then the flat AST is walked statement by statement and mapped
onto pyQuil:

| Unrolled AST node | pyQuil |
| --- | --- |
| `QubitDeclaration` | flat integer qubit indices |
| `ClassicalDeclaration` (`bit[n]`) | `Program.declare("ro", "BIT", n)` |
| `QuantumGate` | `pyquil.gates.*` via uniform `fn(*params, *qubits)` dispatch |
| `QuantumMeasurementStatement` | `MEASURE(q, ro[i])` |
| `QuantumPhase` (global phase) | dropped (unobservable; equivalence up to global phase) |

`pyqasm`'s `unroll()` decomposes custom gates, loops, and most standard gates
into a basis pyQuil supports, which is why coverage is high. `sx`/`sxdg` are
mapped to `RX(±pi/2)` (up to global phase); `sdg`/`tdg` use `.dagger()`; `u`/`u3`
map to `U`.

## Weight/coverage
Added `tests/transpiler/openqasm3/test_coverage_from_openqasm3.py`, benchmarking
the conversion over the OpenQASM 3 standard gate set against a cirq reference.
Coverage is **100%**, so `@weight(1.0)`.

`cu` is excluded from the benchmark only because the cirq reference parser
rejects its 4-parameter form — `openqasm3_to_pyquil` itself converts `cu`
correctly.

## Scope/limitations (first pass)
Standard gate set + measurements. Non-unitary statements (`reset`, `barrier`)
and gate modifiers that survive unrolling raise `ProgramConversionError`. Happy
to extend to a follow-up.

## Tests
- `tests/transpiler/openqasm3/test_conversions_openqasm3.py` — Bell, parameterised,
  measurement, and error cases (malformed input, unsupported statement)
- `tests/transpiler/openqasm3/test_coverage_from_openqasm3.py` — standard-gate-set
  coverage benchmark

All pass; `pylint` 10/10; `black`/`isort` clean; existing pyquil transpiler tests
unaffected.

## AI-Assisted Contribution Disclosure
I used an AI assistant (Claude) to help explore the existing conversion structure, discuss the design, and review code and tests. I traced the qBraid transpiler and pyqasm internals myself, made the implementation decisions (gate mapping, handling of `sx`/`sxdg`, `QuantumPhase`, the `cu` benchmark caveat, deriving the weight from coverage), and verified all behaviour locally with the tests listed above. I can explain and stand behind every line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenQASM 3 → pyQuil conversion with support for barriers→FENCE, resets, delays, measurements into a readout register, classical if/if‑else feedforward, gate‑modifier decomposition, and padding of unused qubits.

* **Documentation**
  * Updated changelog to announce the new conversion capability.

* **Tests**
  * Added unit and coverage tests exercising conversions, feedforward, delay/reset handling, modifier decomposition, padding behavior, and error cases; tests skip when runtimes are absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->