### PR TITLE
fix: stop qasm2→cirq parser from mutating cirq's shared QasmLexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ print(result.data.get_counts())
 ### Removed
 
 ### Fixed
+- Fixed `qasm2_to_cirq` corrupting cirq's shared OpenQASM lexer: the QASM 2 parser assigned a reduced token list onto `cirq.contrib.qasm_import._lexer.QasmLexer.tokens` at import time, stripping the OpenQASM 3 tokens (e.g. `STDGATESINC`) process-wide and causing `qasm3_to_cirq` to raise a ply `LexError` on any QASM 3 parse that followed a `qasm2_to_cirq` call. The reduced token set now lives on a local `QasmLexer` subclass, leaving cirq's class intact ([#1214](https://github.com/qBraid/qBraid/pull/1214))
 
 ### Dependencies
 - Replaced `qiskit-qir` dependency with `qbraid-qir[qiskit]>=0.6.0`; the `qiskit_to_pyqir` conversion now uses `qbraid_qir.qiskit.qiskit_to_qir` instead of the archived `qiskit-qir` package ([#1132](https://github.com/qBraid/qBraid/pull/1132))

--- a/qbraid/transpiler/conversions/qasm2/cirq_qasm_parser.py
+++ b/qbraid/transpiler/conversions/qasm2/cirq_qasm_parser.py
@@ -40,20 +40,27 @@ from .cirq_custom import U2Gate, U3Gate, rzz
 
 yacc = LazyLoader('yacc', globals(), 'ply.yacc')
 
-# Redefined lexer tokens (4/7/21) to surpress warning:
-# Token ['IF', 'NE'] defined, but not used
-QasmLexer.tokens = [
-    "FORMAT_SPEC",
-    "NUMBER",
-    "NATURAL_NUMBER",
-    "QELIBINC",
-    "ID",
-    "PI",
-    "QREG",
-    "CREG",
-    "MEASURE",
-    "ARROW",
-]
+# Use a subclass with a reduced token set for this QASM 2 grammar rather than
+# mutating cirq's shared ``QasmLexer.tokens`` in place. Assigning to the imported
+# class attribute corrupts cirq's own OpenQASM 3 importer (``qasm3_to_cirq``)
+# process-wide once this module is imported: cirq's lexer would no longer
+# recognize the QASM 3 tokens it defines rules for (e.g. ``STDGATESINC`` for
+# ``stdgates.inc``), raising a ply ``LexError`` on every subsequent QASM 3 parse.
+# The reduced list also suppresses the original ply "token defined but not used"
+# warning (e.g. ``IF``/``NE``) for this grammar.
+class _QasmLexer(QasmLexer):
+    tokens = [
+        "FORMAT_SPEC",
+        "NUMBER",
+        "NATURAL_NUMBER",
+        "QELIBINC",
+        "ID",
+        "PI",
+        "QREG",
+        "CREG",
+        "MEASURE",
+        "ARROW",
+    ]
 
 if TYPE_CHECKING:
     import cirq
@@ -173,7 +180,7 @@ class QasmParser:
         self.qregs: dict[str, int] = {}
         self.cregs: dict[str, int] = {}
         self.qelibinc = False
-        self.lexer = QasmLexer()
+        self.lexer = _QasmLexer()
         self.supported_format = False
         self.parsedQasm: Optional[Qasm] = None
         self.qubits: dict[str, ops.Qid] = {}
@@ -351,7 +358,7 @@ class QasmParser:
 
     all_gates = {**basic_gates, **qelib_gates}
 
-    tokens = QasmLexer.tokens
+    tokens = _QasmLexer.tokens
     start = 'start'
 
     precedence = (('left', '+', '-'), ('left', '*', '/'), ('right', '^'))

--- a/tests/transpiler/qasm/test_conversions_qasm3.py
+++ b/tests/transpiler/qasm/test_conversions_qasm3.py
@@ -20,9 +20,11 @@ import braket.circuits
 import numpy as np
 import pytest
 import qiskit
+from cirq.contrib.qasm_import._lexer import QasmLexer
 
 from qbraid.interface import circuits_allclose
 from qbraid.programs.exceptions import QasmError
+from qbraid.transpiler.conversions.qasm2.qasm2_to_cirq import qasm2_to_cirq
 from qbraid.transpiler.conversions.qasm3.qasm3_to_cirq import qasm3_to_cirq
 from qbraid.transpiler.converter import transpile
 
@@ -100,3 +102,20 @@ def test_qasm3_to_cirq_raises_for_invalid_qasm():
     invalid_qasm = "OPENQASM 2.0;\nqreg q[1];\nbarrier q;"
     with pytest.raises(QasmError):
         qasm3_to_cirq(invalid_qasm)
+
+
+def test_qasm2_to_cirq_preserves_cirq_qasm3_lexer():
+    """qasm2_to_cirq must not corrupt cirq's shared QASM lexer.
+
+    The qasm2->cirq parser previously mutated ``cirq...QasmLexer.tokens`` in
+    place at import time, dropping the OpenQASM 3 tokens (e.g. ``STDGATESINC``).
+    That broke cirq's built-in QASM 3 importer process-wide: a ``qasm3_to_cirq``
+    call after any ``qasm2_to_cirq`` rebuilt cirq's lexer from the truncated
+    token list and raised a ply ``LexError``. Assert the shared token set is
+    left intact and that qasm3_to_cirq still works afterwards.
+    """
+    qasm2_to_cirq('OPENQASM 2.0;\ninclude "qelib1.inc";\nqreg q[1];\nx q[0];\n')
+
+    assert "STDGATESINC" in QasmLexer.tokens
+    circuit = qasm3_to_cirq('OPENQASM 3.0;\ninclude "stdgates.inc";\nqubit[1] q;\nx q[0];\n')
+    assert len(circuit) == 1


### PR DESCRIPTION
## Summary

`qbraid/transpiler/conversions/qasm2/cirq_qasm_parser.py` mutates cirq's **shared** lexer class at import time:

```python
from cirq.contrib.qasm_import._lexer import QasmLexer
QasmLexer.tokens = [ ...reduced QASM-2 token list... ]   # assigns onto cirq's class
```

Because `QasmLexer` is cirq's own class, this **deletes the OpenQASM 3 tokens** (`STDGATESINC`, `BIT`, `EQ`, `GATE`, `IF`, `QUBIT`, `RESET`) from it process-wide. Once this module is imported anywhere (i.e. any `qasm2_to_cirq` use), cirq's built-in OpenQASM 3 importer — which `qasm3_to_cirq` relies on — rebuilds its lexer from the truncated token list and fails:

```
ply.lex.LexError: Rule 't_STDGATESINC' returned an unknown token type 'STDGATESINC'
```

So in a process that does `qasm2_to_cirq(...)` and later `qasm3_to_cirq(...)`, every QASM 3 parse raises. This is order-dependent and global, which is why it surfaces in the full test suite (where many tests exercise `qasm2_to_cirq`) but not when a `qasm3_to_cirq` test runs in isolation.

## Fix

Carry the reduced token set on a local `_QasmLexer(QasmLexer)` subclass and point the parser's lexer/`tokens` at the subclass, instead of mutating the shared class. cirq's `QasmLexer.tokens` is left intact, so `qasm3_to_cirq` keeps working. The QASM-2 grammar is unchanged (same reduced token set, same `ply` "token defined but not used" suppression).

## Test

Adds `test_qasm2_to_cirq_preserves_cirq_qasm3_lexer`, which asserts that after a `qasm2_to_cirq` call cirq's `QasmLexer.tokens` still contains `STDGATESINC` and `qasm3_to_cirq` still parses. It fails on `main` and passes with this change.

## Verification

- New regression test: fails before, passes after.
- Existing vendored-parser tests (`tests/transpiler/cirq/test_qasm_parser.py`, `test_from_qasm.py`) and the full `tests/transpiler` suite pass — QASM-2 parsing is unaffected.

## Why it matters

This unblocks `openqasm3_to_pyquil` PR #1203: its `test_coverage_from_openqasm3.py` uses `qasm3_to_cirq` as the equivalence reference and fails 26/26 in CI solely because of this latent bug.