### PR TITLE
test: remove intermediate cirq conversion from pytket coverage test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ print(result.data.get_counts())
 ### Removed
 
 ### Fixed
+- Implemented `remove_idle_qubits` and `reverse_qubit_order` on `PyQuilProgram` (previously inherited base stubs that raised `NotImplementedError`). They remap the program's qubits onto contiguous indices, which also fixes incorrect unitaries for programs acting on non-contiguous qubits and unblocks `circuits_allclose(..., index_contig=True)` for pyQuil targets ([#622](https://github.com/qBraid/qBraid/issues/622))
 - Removed the intermediate cirq round-trip from the PyTKET transpiler coverage test; it now transpiles each PyTKET source circuit directly to the target and compares with `circuits_allclose(..., index_contig=True)`, which drops idle qubits so the source and target unitaries have matching dimensions ([#622](https://github.com/qBraid/qBraid/issues/622))
 - Fixed `qasm2_to_cirq` corrupting cirq's shared OpenQASM lexer: the QASM 2 parser assigned a reduced token list onto `cirq.contrib.qasm_import._lexer.QasmLexer.tokens` at import time, stripping the OpenQASM 3 tokens (e.g. `STDGATESINC`) process-wide and causing `qasm3_to_cirq` to raise a ply `LexError` on any QASM 3 parse that followed a `qasm2_to_cirq` call. The reduced token set now lives on a local `QasmLexer` subclass, leaving cirq's class intact ([#1214](https://github.com/qBraid/qBraid/pull/1214))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ print(result.data.get_counts())
 ### Removed
 
 ### Fixed
+- Removed the intermediate cirq round-trip from the PyTKET transpiler coverage test; it now transpiles each PyTKET source circuit directly to the target and compares with `circuits_allclose(..., index_contig=True)`, which drops idle qubits so the source and target unitaries have matching dimensions ([#622](https://github.com/qBraid/qBraid/issues/622))
 - Fixed `qasm2_to_cirq` corrupting cirq's shared OpenQASM lexer: the QASM 2 parser assigned a reduced token list onto `cirq.contrib.qasm_import._lexer.QasmLexer.tokens` at import time, stripping the OpenQASM 3 tokens (e.g. `STDGATESINC`) process-wide and causing `qasm3_to_cirq` to raise a ply `LexError` on any QASM 3 parse that followed a `qasm2_to_cirq` call. The reduced token set now lives on a local `QasmLexer` subclass, leaving cirq's class intact ([#1214](https://github.com/qBraid/qBraid/pull/1214))
 
 ### Dependencies

--- a/qbraid/programs/gate_model/pyquil.py
+++ b/qbraid/programs/gate_model/pyquil.py
@@ -21,7 +21,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pyquil
-from pyquil.quilbase import Declare, Measurement
+from pyquil.quilatom import Qubit
+from pyquil.quilbase import Declare, Gate, Measurement
 from pyquil.simulation.tools import program_unitary
 from qbraid_core.services.runtime.schemas import Program
 
@@ -57,6 +58,39 @@ class PyQuilProgram(GateModelProgram):
     def depth(self) -> int:
         """Return the circuit depth (i.e., length of critical path)."""
         return len(self.program)
+
+    def _remap_qubits(self, mapping: dict[int, int]) -> None:
+        """Rebuild the program with each qubit index replaced via ``mapping``."""
+        remapped = pyquil.Program()
+        for instruction in self.program:
+            if isinstance(instruction, Gate):
+                remapped += Gate(
+                    instruction.name,
+                    list(instruction.params),
+                    [Qubit(mapping[qubit.index]) for qubit in instruction.qubits],
+                    instruction.modifiers,
+                )
+            elif isinstance(instruction, Measurement):
+                remapped += Measurement(
+                    Qubit(mapping[instruction.qubit.index]), instruction.classical_reg
+                )
+            else:
+                remapped += instruction
+        self._program = remapped
+
+    def remove_idle_qubits(self) -> None:
+        """Remap the program's qubits onto contiguous indices starting at zero."""
+        qubits = sorted(self.program.get_qubits())
+        mapping = {qubit: index for index, qubit in enumerate(qubits)}
+        if all(qubit == index for qubit, index in mapping.items()):
+            return
+        self._remap_qubits(mapping)
+
+    def reverse_qubit_order(self) -> None:
+        """Reverse the qubit ordering of the program."""
+        qubits = sorted(self.program.get_qubits())
+        mapping = dict(zip(qubits, reversed(qubits)))
+        self._remap_qubits(mapping)
 
     @staticmethod
     def remove_measurements(original_program):

--- a/tests/programs/test_program_circuits_pyquil.py
+++ b/tests/programs/test_program_circuits_pyquil.py
@@ -21,7 +21,7 @@ import pytest
 
 try:
     from pyquil import Program
-    from pyquil.gates import CNOT, H
+    from pyquil.gates import CNOT, MEASURE, H
     from qbraid_core.services.runtime.schemas import Program as RuntimeProgram
 
     from qbraid.programs.exceptions import ProgramTypeError
@@ -89,3 +89,20 @@ def test_reverse_qubit_order():
     out = program.program.out()
     assert "H 1" in out
     assert "CNOT 1 0" in out
+
+
+def test_remove_idle_qubits_remaps_measurements_and_passes_through_declarations():
+    """Measurements are remapped and non-gate instructions (e.g. DECLARE) are
+    preserved when remapping qubits."""
+    program = Program()
+    ro = program.declare("ro", "BIT", 1)
+    program += H(2)
+    program += MEASURE(2, ro[0])
+
+    qprogram = PyQuilProgram(program)
+    qprogram.remove_idle_qubits()
+    out = qprogram.program.out()
+
+    assert "DECLARE ro BIT[1]" in out
+    assert "H 0" in out
+    assert "MEASURE 0 ro[0]" in out

--- a/tests/programs/test_program_circuits_pyquil.py
+++ b/tests/programs/test_program_circuits_pyquil.py
@@ -16,10 +16,12 @@
 Unit tests for qbraid.programs.pyquil.PyQuilProgram
 
 """
+import numpy as np
 import pytest
 
 try:
     from pyquil import Program
+    from pyquil.gates import CNOT, H
     from qbraid_core.services.runtime.schemas import Program as RuntimeProgram
 
     from qbraid.programs.exceptions import ProgramTypeError
@@ -60,3 +62,30 @@ def test_pyquil_program_serialize():
     assert serialized.format == "quil"
     assert "H 0" in serialized.data
     assert "CNOT 0 1" in serialized.data
+
+
+def test_remove_idle_qubits_remaps_to_contiguous():
+    """Non-contiguous qubits are remapped to contiguous indices from zero,
+    preserving the (reduced) unitary."""
+    program = PyQuilProgram(Program(H(2), CNOT(2, 5)))
+    program.remove_idle_qubits()
+
+    assert sorted(program.program.get_qubits()) == [0, 1]
+    reference = PyQuilProgram(Program(H(0), CNOT(0, 1)))
+    assert np.allclose(program.unitary(), reference.unitary())
+
+
+def test_remove_idle_qubits_noop_when_contiguous():
+    """A program already on contiguous qubits is left unchanged."""
+    program = PyQuilProgram(Program(H(0), CNOT(0, 1)))
+    program.remove_idle_qubits()
+    assert sorted(program.program.get_qubits()) == [0, 1]
+
+
+def test_reverse_qubit_order():
+    """Reversing qubit order swaps the qubit indices of every instruction."""
+    program = PyQuilProgram(Program(H(0), CNOT(0, 1)))
+    program.reverse_qubit_order()
+    out = program.program.out()
+    assert "H 1" in out
+    assert "CNOT 1 0" in out

--- a/tests/transpiler/pytket/test_coverage_from_pytket.py
+++ b/tests/transpiler/pytket/test_coverage_from_pytket.py
@@ -23,7 +23,6 @@ import string
 
 import numpy as np
 import pytest
-from cirq.contrib.qasm_import import circuit_from_qasm
 
 from qbraid.interface import circuits_allclose
 from qbraid.transpiler import ConversionGraph, transpile
@@ -172,11 +171,11 @@ def convert_from_pytket_to_x(target, circuit_name, circuits, graph):
     target program type, and check equivalence.
     """
     source_circuit = circuits[circuit_name]
-    circuit = transpile(source_circuit, "cirq", conversion_graph=graph)
-    qasm = circuit.to_qasm()
-    cirq_circuit = circuit_from_qasm(qasm)
-    target_circuit = transpile(cirq_circuit, target)
-    assert circuits_allclose(cirq_circuit, target_circuit, strict_gphase=False)
+    target_circuit = transpile(source_circuit, target, conversion_graph=graph)
+    # index_contig drops idle qubits before comparing unitaries; some targets
+    # (e.g. cirq, braket) omit idle qubits on conversion while the source keeps
+    # the full register, so without it the unitary dimensions would mismatch.
+    assert circuits_allclose(source_circuit, target_circuit, index_contig=True, strict_gphase=False)
 
 
 @pytest.mark.parametrize(("target", "baseline"), AVAILABLE_TARGETS)


### PR DESCRIPTION
Closes #622.

## What

The pytket transpiler coverage test (`tests/transpiler/pytket/test_coverage_from_pytket.py`) routed every source circuit through cirq — `pytket → cirq → QASM → cirq → target` — and compared the cirq intermediate against the target, instead of comparing the pytket source directly.

This replaces that with the direct comparison the issue proposed:

```python
target_circuit = transpile(source_circuit, target, conversion_graph=graph)
assert circuits_allclose(source_circuit, target_circuit, index_contig=True, strict_gphase=False)
```

## Why the workaround existed

It wasn't a unitary-calculation bug. `circuits_allclose` only strips idle qubits when `index_contig=True`, and the test never passed that flag. The circuits are built on a 3-qubit `pytket.Circuit(3, 1)`, but cirq and braket **drop idle qubits** on conversion, so a single-qubit gate becomes a 1-qubit circuit while the pytket source stays 3-qubit → mismatched unitary dimensions → failure for nearly every gate. qiskit preserves the full register, so it would have worked directly all along. The cirq round-trip masked the mismatch by comparing two circuits derived from the same cirq circuit.

Passing `index_contig=True` drops idle qubits on both sides before the unitary comparison, so the direct check works for all targets.

## Additional fix: `PyQuilProgram` idle-qubit handling

Switching to `index_contig=True` exposed a gap in the pyQuil program wrapper. `circuits_allclose(..., index_contig=True)` calls `remove_idle_qubits()` on both programs, but `PyQuilProgram` never implemented it (nor `reverse_qubit_order`) — it inherited the base `GateModelProgram` stubs that `raise NotImplementedError`. As a result every pyQuil comparison errored: **49/49 failed on Python 3.10–3.12**. (CI's 3.13 job is green only because the `rigetti`/pyquil extra excludes 3.13, so the pyQuil target is skipped there — which is also why local runs without pyquil installed didn't surface it.)

Both methods are now implemented on `PyQuilProgram`, remapping the program's qubits onto contiguous indices by rebuilding instructions (preserving gate modifiers and measurements). This additionally fixes incorrect unitaries for programs acting on non-contiguous qubit indices, since `program_unitary` assumes a contiguous register sized by qubit count. Regression tests were added in `tests/programs/test_program_circuits_pyquil.py`.

## Verification

`tests/transpiler/pytket/test_coverage_from_pytket.py` passes for braket, cirq, qiskit, **and pyquil**. Measured coverage is unchanged at **0.959** (47/49) for each target — identical to the previous via-cirq approach — so no baselines move. The only two failures (`PhasedX`, `Sycamore`) are pre-existing gate-coverage gaps that also failed through the old path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated PyTKET transpiler test coverage methodology. Circuits are transpiled directly from PyTKET source to target. Equivalence checking enhanced with improved logic to accurately handle idle qubit differences between source and target circuits.

* **Documentation**
  * Updated changelog to document test methodology refinements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
