### PR TITLE
Fix Cirq → pyQuil transpilation of XX/YY/ZZ/SwapPow two-qubit gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ print(result.data.get_counts())
 ### Removed
 
 ### Fixed
-- Fixed Cirq → pyQuil transpilation of the `XXPowGate`, `YYPowGate`, and `ZZPowGate` interaction gates for non-integer exponents. These were previously decomposed into independent single-qubit rotations, producing a circuit whose unitary did not match the input. They now round-trip exactly (including global phase) via `PHASE`/`CPHASE` decompositions. ([#386](https://github.com/qBraid/qBraid/issues/386))
+- Fixed Cirq → pyQuil transpilation of the `XXPowGate`, `YYPowGate`, `ZZPowGate`, and `SwapPowGate` two-qubit gates for non-integer exponents. The interaction gates were previously decomposed into independent single-qubit rotations, and `SwapPowGate` was emitted as `PSWAP` (a parametric swap-with-phase), both producing a circuit whose unitary did not match the input. The interaction gates now round-trip exactly (including global phase) via `PHASE`/`CPHASE` decompositions, and `SwapPowGate` falls back to cirq's `CNOT`/`RY`/`CPHASE` decomposition. ([#386](https://github.com/qBraid/qBraid/issues/386))
 - Fixed `qasm2_to_cirq` corrupting cirq's shared OpenQASM lexer: the QASM 2 parser assigned a reduced token list onto `cirq.contrib.qasm_import._lexer.QasmLexer.tokens` at import time, stripping the OpenQASM 3 tokens (e.g. `STDGATESINC`) process-wide and causing `qasm3_to_cirq` to raise a ply `LexError` on any QASM 3 parse that followed a `qasm2_to_cirq` call. The reduced token set now lives on a local `QasmLexer` subclass, leaving cirq's class intact ([#1214](https://github.com/qBraid/qBraid/pull/1214))
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ print(result.data.get_counts())
 ### Removed
 
 ### Fixed
+- Fixed Cirq → pyQuil transpilation of the `XXPowGate`, `YYPowGate`, and `ZZPowGate` interaction gates for non-integer exponents. These were previously decomposed into independent single-qubit rotations, producing a circuit whose unitary did not match the input. They now round-trip exactly (including global phase) via `PHASE`/`CPHASE` decompositions. ([#386](https://github.com/qBraid/qBraid/issues/386))
 
 ### Dependencies
 - Replaced `qiskit-qir` dependency with `qbraid-qir[qiskit]>=0.6.0`; the `qiskit_to_pyqir` conversion now uses `qbraid_qir.qiskit.qiskit_to_qir` instead of the archived `qiskit-qir` package ([#1132](https://github.com/qBraid/qBraid/pull/1132))

--- a/qbraid/transpiler/conversions/cirq/cirq_quil_output.py
+++ b/qbraid/transpiler/conversions/cirq/cirq_quil_output.py
@@ -255,13 +255,15 @@ def _quiltwoqubit_gate(op: cirq.Operation, formatter: QuilFormatter) -> str:
     )
 
 
-def _swappow_gate(op: cirq.Operation, formatter: QuilFormatter) -> str:
+def _swappow_gate(op: cirq.Operation, formatter: QuilFormatter) -> Optional[str]:
     gate = cast(cirq.SwapPowGate, op.gate)
     if gate._exponent % 2 == 1:
         return formatter.format("SWAP {0} {1}\n", op.qubits[0], op.qubits[1])
-    return formatter.format(
-        "PSWAP({0}) {1} {2}\n", gate._exponent * np.pi, op.qubits[0], op.qubits[1]
-    )
+    # Non-integer powers: Quil's PSWAP is a parametric swap-with-phase, not a
+    # fractional SWAP, so PSWAP(pi*t) does not reproduce SWAP**t. Return None to
+    # fall back to cirq's decomposition (CNOT / RY / CPHASE), which Quil
+    # represents exactly.
+    return None
 
 
 def _twoqubitdiagonal_gate(op: cirq.Operation, formatter: QuilFormatter) -> Optional[str]:
@@ -317,9 +319,7 @@ def _xxpow_gate(op: cirq.Operation, formatter: QuilFormatter) -> str:
     # e^{i pi t}, 1) realized exactly (including global phase) by single-qubit
     # PHASE gates and a CPHASE.
     return formatter.format(
-        "H {0}\nH {1}\n"
-        "PHASE({2}) {0}\nPHASE({2}) {1}\nCPHASE({3}) {0} {1}\n"
-        "H {0}\nH {1}\n",
+        "H {0}\nH {1}\nPHASE({2}) {0}\nPHASE({2}) {1}\nCPHASE({3}) {0} {1}\nH {0}\nH {1}\n",
         op.qubits[0],
         op.qubits[1],
         gate._exponent * np.pi,

--- a/qbraid/transpiler/conversions/cirq/cirq_quil_output.py
+++ b/qbraid/transpiler/conversions/cirq/cirq_quil_output.py
@@ -310,15 +310,20 @@ def _xpow_gate(op: cirq.Operation, formatter: QuilFormatter) -> str:
 
 
 def _xxpow_gate(op: cirq.Operation, formatter: QuilFormatter) -> str:
-    gate = cast(cirq.XPowGate, op.gate)
+    gate = cast(cirq.XXPowGate, op.gate)
     if gate._exponent == 1:
         return formatter.format("X {0}\nX {1}\n", op.qubits[0], op.qubits[1])
+    # XX**t = (H (x) H) . ZZ**t . (H (x) H), with ZZ**t = diag(1, e^{i pi t},
+    # e^{i pi t}, 1) realized exactly (including global phase) by single-qubit
+    # PHASE gates and a CPHASE.
     return formatter.format(
-        "RX({0}) {1}\nRX({2}) {3}\n",
-        gate._exponent * np.pi,
+        "H {0}\nH {1}\n"
+        "PHASE({2}) {0}\nPHASE({2}) {1}\nCPHASE({3}) {0} {1}\n"
+        "H {0}\nH {1}\n",
         op.qubits[0],
-        gate._exponent * np.pi,
         op.qubits[1],
+        gate._exponent * np.pi,
+        -2 * gate._exponent * np.pi,
     )
 
 
@@ -334,12 +339,19 @@ def _yypow_gate(op: cirq.Operation, formatter: QuilFormatter) -> str:
     if gate._exponent == 1:
         return formatter.format("Y {0}\nY {1}\n", op.qubits[0], op.qubits[1])
 
+    # YY**t = (RX(pi/2) (x) RX(pi/2)) . ZZ**t . (RX(-pi/2) (x) RX(-pi/2)); the
+    # RX conjugation rotates the Y eigenbasis onto the Z eigenbasis and cancels
+    # exactly, so the global phase of ZZ**t is preserved.
     return formatter.format(
-        "RY({0}) {1}\nRY({2}) {3}\n",
-        gate._exponent * np.pi,
+        "RX({4}) {0}\nRX({4}) {1}\n"
+        "PHASE({2}) {0}\nPHASE({2}) {1}\nCPHASE({3}) {0} {1}\n"
+        "RX({5}) {0}\nRX({5}) {1}\n",
         op.qubits[0],
-        gate._exponent * np.pi,
         op.qubits[1],
+        gate._exponent * np.pi,
+        -2 * gate._exponent * np.pi,
+        np.pi / 2,
+        -np.pi / 2,
     )
 
 
@@ -355,12 +367,14 @@ def _zzpow_gate(op: cirq.Operation, formatter: QuilFormatter) -> str:
     if gate._exponent == 1:
         return formatter.format("Z {0}\nZ {1}\n", op.qubits[0], op.qubits[1])
 
+    # ZZ**t = diag(1, e^{i pi t}, e^{i pi t}, 1) is realized exactly (including
+    # global phase) by a PHASE on each qubit and a compensating CPHASE.
     return formatter.format(
-        "RZ({0}) {1}\nRZ({2}) {3}\n",
-        gate._exponent * np.pi,
+        "PHASE({2}) {0}\nPHASE({2}) {1}\nCPHASE({3}) {0} {1}\n",
         op.qubits[0],
-        gate._exponent * np.pi,
         op.qubits[1],
+        gate._exponent * np.pi,
+        -2 * gate._exponent * np.pi,
     )
 
 

--- a/tests/transpiler/pyquil/test_conversions_pyquil.py
+++ b/tests/transpiler/pyquil/test_conversions_pyquil.py
@@ -159,3 +159,21 @@ def test_cirq_to_quil_output_rzz():
     cirq_circuit = qasm2_to_cirq(qasm)
     p_test: Program = cirq_to_pyquil(cirq_circuit)
     assert p_test.out().replace("pi/2", f"{np.pi/2}") == p.out()
+
+
+@pytest.mark.parametrize(
+    "gate",
+    [cirq_ops.XXPowGate, cirq_ops.YYPowGate, cirq_ops.ZZPowGate],
+)
+@pytest.mark.parametrize("exponent", [0.5, 1.0, 0.75, -0.8, 2.0, 0.0])
+def test_cirq_to_pyquil_ising_gate_roundtrip(gate, exponent):
+    """Cirq XX/YY/ZZ interaction gates round-trip through pyQuil exactly.
+
+    Regression test for https://github.com/qBraid/qBraid/issues/386, where the
+    non-integer-exponent cases were decomposed into single-qubit rotations that
+    did not preserve the two-qubit unitary.
+    """
+    q0, q1 = LineQubit.range(2)
+    cirq_in = Circuit(gate(exponent=exponent).on(q0, q1))
+    cirq_out = pyquil_to_cirq(cirq_to_pyquil(cirq_in))
+    assert circuits_allclose(cirq_in, cirq_out, strict_gphase=True)

--- a/tests/transpiler/pyquil/test_conversions_pyquil.py
+++ b/tests/transpiler/pyquil/test_conversions_pyquil.py
@@ -177,3 +177,17 @@ def test_cirq_to_pyquil_ising_gate_roundtrip(gate, exponent):
     cirq_in = Circuit(gate(exponent=exponent).on(q0, q1))
     cirq_out = pyquil_to_cirq(cirq_to_pyquil(cirq_in))
     assert circuits_allclose(cirq_in, cirq_out, strict_gphase=True)
+
+
+@pytest.mark.parametrize("exponent", [0.5, 1.0, 0.75, -0.8, 2.0, 0.0])
+def test_cirq_to_pyquil_swappow_roundtrip(exponent):
+    """Cirq SwapPowGate round-trips through pyQuil exactly.
+
+    Non-integer powers were previously emitted as ``PSWAP(pi*t)``, a parametric
+    swap-with-phase whose unitary differs from a fractional ``SWAP**t``. They now
+    fall back to cirq's CNOT / RY / CPHASE decomposition.
+    """
+    q0, q1 = LineQubit.range(2)
+    cirq_in = Circuit(cirq_ops.SwapPowGate(exponent=exponent).on(q0, q1))
+    cirq_out = pyquil_to_cirq(cirq_to_pyquil(cirq_in))
+    assert circuits_allclose(cirq_in, cirq_out, strict_gphase=True)

--- a/tests/transpiler/pyquil/test_quil_output.py
+++ b/tests/transpiler/pyquil/test_quil_output.py
@@ -326,7 +326,11 @@ CPHASE({np.pi / 2}) 0 1
 RY({np.pi / 2}) 1
 SWAP 0 1
 SWAP 1 0
-PSWAP({3 * np.pi / 4}) 0 1
+CNOT 0 1
+RY({-np.pi / 2}) 0
+CPHASE({3 * np.pi / 4}) 1 0
+RY({np.pi / 2}) 0
+CNOT 0 1
 H 2
 CCNOT 0 1 2
 H 2

--- a/tests/transpiler/pyquil/test_quil_output.py
+++ b/tests/transpiler/pyquil/test_quil_output.py
@@ -366,16 +366,27 @@ H 2
 CSWAP 0 1 2
 X 0
 X 1
-RX({3 * np.pi / 4}) 0
-RX({3 * np.pi / 4}) 1
+H 0
+H 1
+PHASE({0.75 * np.pi}) 0
+PHASE({0.75 * np.pi}) 1
+CPHASE({-2 * 0.75 * np.pi}) 0 1
+H 0
+H 1
 Y 0
 Y 1
-RY({3 * np.pi / 4}) 0
-RY({3 * np.pi / 4}) 1
+RX({np.pi / 2}) 0
+RX({np.pi / 2}) 1
+PHASE({0.75 * np.pi}) 0
+PHASE({0.75 * np.pi}) 1
+CPHASE({-2 * 0.75 * np.pi}) 0 1
+RX({-np.pi / 2}) 0
+RX({-np.pi / 2}) 1
 Z 0
 Z 1
-RZ({3 * np.pi / 4}) 0
-RZ({3 * np.pi / 4}) 1
+PHASE({0.75 * np.pi}) 0
+PHASE({0.75 * np.pi}) 1
+CPHASE({-2 * 0.75 * np.pi}) 0 1
 I 0
 I 0
 I 1


### PR DESCRIPTION
## Summary

Fixes #386.

Cirq → pyQuil transpilation of the two-qubit interaction gates `XXPowGate`, `YYPowGate`, and `ZZPowGate` was incorrect for non-integer exponents. The fallback branch (inherited from `cirq_rigetti`) decomposed e.g. `XX**t` into two *independent* single-qubit rotations (`RX(πt) 0; RX(πt) 1`), which does not reproduce the two-qubit unitary. Reproduced on `main` — all three round-trip to `False`.

## Fix

`ZZPowGate(t) = diag(1, e^{iπt}, e^{iπt}, 1)` factors **exactly** (including global phase, since the (0,0) entry is a true `1`) into supported Quil primitives:

- **ZZ**: `PHASE(πt)` on each qubit + `CPHASE(-2πt)`
- **XX**: `H⊗H` · ZZ-core · `H⊗H`
- **YY**: `RX(π/2)⊗RX(π/2)` · ZZ-core · `RX(-π/2)⊗RX(-π/2)`

The integer-exponent fast paths (`X⊗X`, `Y⊗Y`, `Z⊗Z`) were already correct and are preserved.

Two constraints shaped the design:
- The pipeline is `cirq → Quil string → parse`, and the Quil input parser's `SUPPORTED_GATES` has no `RZZ`/`RXX`/`RYY`, so only `PHASE`/`CPHASE`/`H`/`RX` are usable.
- Raw `* np.pi` floats are emitted rather than the `exponent_to_pi_string` helper, which does `limit_denominator(12)` and would silently approximate arbitrary exponents (e.g. `0.37 → 3/8`).

All three gates now round-trip **exactly with `strict_gphase=True`**.

## Testing

- Added parametrized regression test `test_cirq_to_pyquil_ising_gate_roundtrip` (3 gates × 6 exponents) asserting `strict_gphase=True`.
- Updated the `test_all_operations` golden-string test to the corrected output.
- pyQuil suite: 63 passed. Combined pyQuil + cirq: 203 passed, 4 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Cirq → pyQuil transpilation for XX, YY, ZZ, and Swap power gates with non-integer exponents. Gates now correctly preserve unitary behavior during transpilation.

* **Tests**
  * Added regression tests validating Cirq-to-pyQuil round-trip conversions for the affected gates across various exponents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->