### PR TITLE
refactor: remove redundant cirq round-trip fallback from transpile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ print(result.data.get_counts())
 - Replaced `logging.getLogger(__name__)` with centralized `from qbraid._logging import logger` in Rigetti, Origin Quantum, and Quantinuum runtime modules ([#1197](https://github.com/qBraid/qBraid/pull/1197))
 - Modified `get_devices` and `get_device` methods in `IonQProvider` to use public endpoint access instead of authenticated requests ([#1194](https://github.com/qBraid/qBraid/pull/1194))
 - Updated `QbraidProvider.get_devices` method to accept `**kwargs` and pass them through to the underlying `client.list_devices` call ([#1201](https://github.com/qBraid/qBraid/pull/1201))
-- Removed the cirq-specific fallback in `transpile` that, on a failed conversion step, round-tripped the cirq intermediate through QASM (`circuit_from_qasm(circuit.to_qasm())`) and retried. This flatten-and-retry is already provided generically by the conversion graph's `cirq -> qasm2 -> target` paths combined with the multi-path retry, making the hardcoded special case redundant (cirq conversion coverage is unchanged) ([#PRNUM](https://github.com/qBraid/qBraid/pull/PRNUM))
+- Removed the cirq-specific fallback in `transpile` that, on a failed conversion step, round-tripped the cirq intermediate through QASM (`circuit_from_qasm(circuit.to_qasm())`) and retried. This flatten-and-retry is already provided generically by the conversion graph's `cirq -> qasm2 -> target` paths combined with the multi-path retry, making the hardcoded special case redundant (cirq conversion coverage is unchanged) ([#1217](https://github.com/qBraid/qBraid/pull/1217))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ print(result.data.get_counts())
 - Replaced `logging.getLogger(__name__)` with centralized `from qbraid._logging import logger` in Rigetti, Origin Quantum, and Quantinuum runtime modules ([#1197](https://github.com/qBraid/qBraid/pull/1197))
 - Modified `get_devices` and `get_device` methods in `IonQProvider` to use public endpoint access instead of authenticated requests ([#1194](https://github.com/qBraid/qBraid/pull/1194))
 - Updated `QbraidProvider.get_devices` method to accept `**kwargs` and pass them through to the underlying `client.list_devices` call ([#1201](https://github.com/qBraid/qBraid/pull/1201))
+- Removed the cirq-specific fallback in `transpile` that, on a failed conversion step, round-tripped the cirq intermediate through QASM (`circuit_from_qasm(circuit.to_qasm())`) and retried. This flatten-and-retry is already provided generically by the conversion graph's `cirq -> qasm2 -> target` paths combined with the multi-path retry, making the hardcoded special case redundant (cirq conversion coverage is unchanged) ([#PRNUM](https://github.com/qBraid/qBraid/pull/PRNUM))
 
 ### Deprecated
 

--- a/qbraid/transpiler/converter.py
+++ b/qbraid/transpiler/converter.py
@@ -23,8 +23,6 @@ import warnings
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
-from qbraid_core._import import LazyLoader
-
 from qbraid._logging import logger
 from qbraid.programs import QPROGRAM_ALIASES
 from qbraid.programs.alias_manager import (
@@ -139,22 +137,13 @@ def transpile(
                     temp_program = convert_func(temp_program)
                 except Exception as err:  # pylint: disable=broad-exception-caught
                     alias = get_program_type_alias(temp_program, safe=True)
-
-                    if alias == "cirq":
-                        cirq_qasm_import = LazyLoader(
-                            "cirq_qasm_import", globals(), "cirq.contrib.qasm_import"
-                        )
-                        qasm: str = temp_program.to_qasm()  # type: ignore[attr-defined]
-                        temp_program = cirq_qasm_import.circuit_from_qasm(qasm)
-                        temp_program = convert_func(temp_program)  # Retry conversion
-                    else:
-                        error_detail = (
-                            f"Conversion {path_details} failed due to "
-                            f"exception raised while converting from '{alias}'."
-                        )
-                        error_messages.append(error_detail)
-                        error_messages.append(_format_exception(err))
-                        raise
+                    error_detail = (
+                        f"Conversion {path_details} failed due to "
+                        f"exception raised while converting from '{alias}'."
+                    )
+                    error_messages.append(error_detail)
+                    error_messages.append(_format_exception(err))
+                    raise
 
             logger.info("Successfully transpiled using conversions: %s", path_details)
             return temp_program


### PR DESCRIPTION
## What

Removes the cirq-specific fallback in `transpile` (`qbraid/transpiler/converter.py`):

```python
if alias == "cirq":
    qasm = temp_program.to_qasm()
    temp_program = cirq_qasm_import.circuit_from_qasm(qasm)
    temp_program = convert_func(temp_program)  # Retry conversion
```

On a failed conversion step where the intermediate program was a cirq circuit, this flattened the circuit via a QASM round-trip and retried the failing edge.

## Why it was there

Historically (it began life as `decompose(circuit, strategy="qasm")`, which is literally `circuit_from_qasm(circuit.to_qasm())`) the intent was to **flatten** a cirq circuit containing composite/multi-qubit gates into a basic gate set that a direct `cirq -> target` converter could handle, then retry.

## Why it's redundant now

The conversion graph already encodes that exact flatten as first-class edges: `cirq -> qasm2` *is* `circuit.to_qasm()`, so `cirq -> qasm2 -> target` performs the same normalization. The `transpile` loop already tries the top-N shortest paths and falls back to the next on failure, so when a direct `cirq -> target` edge fails the graph routes through the QASM-mediated path on its own. The special case duplicated this in a hardcoded program-type branch inside the otherwise graph-driven loop.

## Verification

Measured `cirq -> target` coverage with and without the fallback (full dev deps incl. cirq, qiskit, braket, pytket, pyquil, stim) — **identical accuracy and identical failure sets**:

| target | accuracy | baseline |
|--------|----------|----------|
| braket | 0.859 | 0.85 |
| pyquil | 0.766 | 0.74 |
| pytket | 0.875 | 0.87 |
| qiskit | 0.875 | 0.87 |

The remaining failures (noise channels, a few pyquil gates) fail identically with or without the fallback — the QASM round-trip never actually rescued them. Full transpiler / programs / passes / visualization suites pass (1281 passed, 90 skipped). No test depends on the removed branch.

## Better way

Rely on the conversion graph + multi-path retry, which already model the flatten-via-QASM fallback as ordinary edges. If a flatten-on-failure step is ever wanted as a general feature, it belongs in the graph as edges, not as a per-program-type branch in the generic converter loop.