### PR TITLE
fix: circuits_allclose returns False instead of IndexError on dimension mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ print(result.data.get_counts())
 ### Removed
 
 ### Fixed
-- Fixed `circuits_allclose` raising `IndexError` instead of returning `False` when the two programs' unitaries have different dimensions (e.g. comparing a measurement-only circuit against a target that drops measurements, yielding an empty unitary). The comparison now short-circuits to `False` on a shape mismatch and only computes the qubit-reversed unitary when `allow_rev_qubits=True`; `unitary_rev_qubits` also raises its documented `ValueError` for non-2D matrices ([#PRNUM](https://github.com/qBraid/qBraid/pull/PRNUM))
+- Fixed `circuits_allclose` raising `IndexError` instead of returning `False` when the two programs' unitaries have different dimensions (e.g. comparing a measurement-only circuit against a target that drops measurements, yielding an empty unitary). The comparison now short-circuits to `False` on a shape mismatch and only computes the qubit-reversed unitary when `allow_rev_qubits=True`; `unitary_rev_qubits` also raises its documented `ValueError` for non-2D matrices ([#1218](https://github.com/qBraid/qBraid/pull/1218))
 - Fixed `qasm2_to_cirq` corrupting cirq's shared OpenQASM lexer: the QASM 2 parser assigned a reduced token list onto `cirq.contrib.qasm_import._lexer.QasmLexer.tokens` at import time, stripping the OpenQASM 3 tokens (e.g. `STDGATESINC`) process-wide and causing `qasm3_to_cirq` to raise a ply `LexError` on any QASM 3 parse that followed a `qasm2_to_cirq` call. The reduced token set now lives on a local `QasmLexer` subclass, leaving cirq's class intact ([#1214](https://github.com/qBraid/qBraid/pull/1214))
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ print(result.data.get_counts())
 ### Removed
 
 ### Fixed
+- Fixed `circuits_allclose` raising `IndexError` instead of returning `False` when the two programs' unitaries have different dimensions (e.g. comparing a measurement-only circuit against a target that drops measurements, yielding an empty unitary). The comparison now short-circuits to `False` on a shape mismatch and only computes the qubit-reversed unitary when `allow_rev_qubits=True`; `unitary_rev_qubits` also raises its documented `ValueError` for non-2D matrices ([#PRNUM](https://github.com/qBraid/qBraid/pull/PRNUM))
 - Fixed `qasm2_to_cirq` corrupting cirq's shared OpenQASM lexer: the QASM 2 parser assigned a reduced token list onto `cirq.contrib.qasm_import._lexer.QasmLexer.tokens` at import time, stripping the OpenQASM 3 tokens (e.g. `STDGATESINC`) process-wide and causing `qasm3_to_cirq` to raise a ply `LexError` on any QASM 3 parse that followed a `qasm2_to_cirq` call. The reduced token set now lives on a local `QasmLexer` subclass, leaving cirq's class intact ([#1214](https://github.com/qBraid/qBraid/pull/1214))
 
 ### Dependencies

--- a/qbraid/interface/circuit_equality.py
+++ b/qbraid/interface/circuit_equality.py
@@ -135,6 +135,17 @@ def circuits_allclose(  # pylint: disable=too-many-arguments
 
     unitary0 = program0.unitary()
     unitary1 = program1.unitary()
-    unitary_rev = program1.unitary_rev_qubits()
+
+    # Unitaries of different dimensions cannot be equivalent. Guarding here also
+    # avoids a broadcasting error in the np.allclose comparison below and an
+    # IndexError in unitary_rev_qubits when a circuit has no operating qubits
+    # (e.g. a measurement-only circuit converted to a target that drops
+    # measurements, yielding an empty unitary).
+    if unitary0.shape != unitary1.shape:
+        return False
+
+    # unitary_rev is only consulted when allow_rev_qubits is set, so skip the
+    # (expensive) qubit-reversal permutation otherwise.
+    unitary_rev = program1.unitary_rev_qubits() if allow_rev_qubits else None
 
     return unitary_equivalence_check(unitary0, unitary1, unitary_rev)

--- a/qbraid/programs/gate_model/_model.py
+++ b/qbraid/programs/gate_model/_model.py
@@ -79,7 +79,11 @@ class GateModelProgram(QuantumProgram, ABC):
             ValueError: If the input matrix is not square or its size is not a power of 2.
         """
         matrix = self._unitary()
-        if matrix.shape[0] != matrix.shape[1] or (matrix.shape[0] & (matrix.shape[0] - 1)) != 0:
+        if (
+            matrix.ndim != 2
+            or matrix.shape[0] != matrix.shape[1]
+            or (matrix.shape[0] & (matrix.shape[0] - 1)) != 0
+        ):
             raise ValueError("Input matrix must be a square matrix of size 2^N for some integer N.")
 
         # Determine the number of qubits from the matrix size

--- a/tests/programs/test_program_equality.py
+++ b/tests/programs/test_program_equality.py
@@ -117,3 +117,33 @@ def test_assert_allclose_up_to_global_phase_fail():
     b = np.array([10 + 10j, 20 + 20j])
     with pytest.raises(AssertionError):
         assert_allclose_up_to_global_phase(a, b, atol=1e-10)
+
+
+def test_circuits_allclose_mismatched_dimensions_returns_false():
+    """Circuits whose unitaries have different dimensions are not equivalent and
+    must compare False rather than raising during the comparison."""
+    cirq = pytest.importorskip("cirq")
+    from qbraid.interface import circuits_allclose  # pylint: disable=import-outside-toplevel
+
+    q = cirq.LineQubit.range(2)
+    two_qubit = cirq.Circuit([cirq.X(q[0]), cirq.X(q[1])])
+    one_qubit = cirq.Circuit([cirq.X(q[0])])
+
+    assert circuits_allclose(two_qubit, one_qubit) is False
+    assert circuits_allclose(two_qubit, one_qubit, allow_rev_qubits=True) is False
+
+
+def test_circuits_allclose_empty_target_unitary_returns_false():
+    """A measurement-only circuit converts to an empty Braket circuit (no operating
+    qubits), whose unitary has shape ``(0,)``. ``circuits_allclose`` must return
+    False instead of raising an ``IndexError`` in ``unitary_rev_qubits``."""
+    cirq = pytest.importorskip("cirq")
+    pytest.importorskip("braket")
+    from qbraid.interface import circuits_allclose  # pylint: disable=import-outside-toplevel
+    from qbraid.transpiler import transpile  # pylint: disable=import-outside-toplevel
+
+    q = cirq.LineQubit.range(3)
+    source = cirq.Circuit(cirq.measure(*q, key="m"))
+    target = transpile(source, "braket")
+
+    assert circuits_allclose(source, target) is False


### PR DESCRIPTION
## What

`circuits_allclose` raised `IndexError: tuple index out of range` instead of returning `False` when the two programs' unitaries have different dimensions.

## Repro

A measurement-only Cirq circuit converts to an **empty** Braket circuit (Braket drops measurements, leaving no operating qubits), whose `to_unitary()` returns an array of shape `(0,)`:

```python
import cirq
from qbraid.transpiler import transpile
from qbraid.interface import circuits_allclose

q = cirq.LineQubit.range(3)
source = cirq.Circuit(cirq.measure(*q, key="m"))   # 8x8 identity unitary
target = transpile(source, "braket")               # empty circuit -> unitary shape (0,)

circuits_allclose(source, target)                  # IndexError before this PR
```

`circuits_allclose` eagerly called `program1.unitary_rev_qubits()`, which does `matrix.shape[1]` on the `(0,)` array → `IndexError`. (Surfaced while triaging cirq→braket coverage; `MeasurementGate` was the failing case.)

## Fix

- **Short-circuit to `False` when the two unitaries have different shapes** — different-dimension unitaries can't be equivalent, and this also avoids the `np.allclose` broadcast error in the comparison path.
- **Compute `unitary_rev` lazily** — it is only consulted when `allow_rev_qubits=True` (default `False`), so the expensive O(4^N) qubit-reversal permutation (and the crash) is skipped otherwise.
- **Harden `unitary_rev_qubits`** to raise its documented `ValueError` for non-2D matrices instead of a cryptic `IndexError`.

Behavior is otherwise unchanged: the previously-crashing mismatch cases now return `False`; equal-dimension comparisons are unaffected.

## Tests

Added regression tests for the mismatched-dimension case (cirq, always run) and the empty-Braket-unitary case (guarded by `braket`). Full `tests/programs` + `tests/transpiler` suites pass (1114 passed, 90 skipped locally with cirq/qiskit/braket/pytket/pyquil installed).