### PR TITLE
test: test-suite robustness (azure skip guard, asyncio config, tighter asserts)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,8 +116,10 @@ log_file_date_format = "%Y-%m-%d %H:%M:%S"
 testpaths = [
   "tests",
 ]
+asyncio_mode = "strict"
 markers = [
   "remote: mark a test as requiring a remote connection",
+  "asyncio: mark an async test to be run via pytest-asyncio",
 ]
 filterwarnings = [
     "ignore::DeprecationWarning",

--- a/tests/runtime/azure/conftest.py
+++ b/tests/runtime/azure/conftest.py
@@ -20,12 +20,16 @@ import os
 from typing import Optional
 
 import pytest
-from azure.identity import ClientSecretCredential
-from azure.quantum import Workspace
-from azure.quantum._constants import ConnectionConstants, EnvironmentVariables
-from qiskit import QuantumCircuit
 
-from qbraid.runtime.azure import AzureQuantumProvider
+pytest.importorskip("azure.quantum", reason="azure-quantum not installed")
+
+# pylint: disable=wrong-import-position
+from azure.identity import ClientSecretCredential  # noqa: E402
+from azure.quantum import Workspace  # noqa: E402
+from azure.quantum._constants import ConnectionConstants, EnvironmentVariables  # noqa: E402
+from qiskit import QuantumCircuit  # noqa: E402
+
+from qbraid.runtime.azure import AzureQuantumProvider  # noqa: E402
 
 
 @pytest.fixture

--- a/tests/runtime/azure/test_azure_remote.py
+++ b/tests/runtime/azure/test_azure_remote.py
@@ -26,9 +26,13 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
-from azure.quantum import Workspace
 
-from qbraid.runtime import (
+pytest.importorskip("azure.quantum", reason="azure-quantum not installed")
+
+# pylint: disable=wrong-import-position
+from azure.quantum import Workspace  # noqa: E402
+
+from qbraid.runtime import (  # noqa: E402
     AnalogResultData,
     AzureQuantumProvider,
     DeviceStatus,

--- a/tests/runtime/azure/test_azure_runtime.py
+++ b/tests/runtime/azure/test_azure_runtime.py
@@ -25,9 +25,13 @@ from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from azure.core.exceptions import ResourceExistsError
-from azure.quantum import Job, JobDetails, Workspace
-from azure.quantum.target.target import Target
+
+pytest.importorskip("azure.quantum", reason="azure-quantum not installed")
+
+# pylint: disable=wrong-import-position
+from azure.core.exceptions import ResourceExistsError  # noqa: E402
+from azure.quantum import Job, JobDetails, Workspace  # noqa: E402
+from azure.quantum.target.target import Target  # noqa: E402
 
 from qbraid.programs import QPROGRAM_REGISTRY, ExperimentType, ProgramSpec
 from qbraid.runtime import (

--- a/tests/transpiler/openqasm3/test_conversions_openqasm3.py
+++ b/tests/transpiler/openqasm3/test_conversions_openqasm3.py
@@ -53,7 +53,7 @@ def test_openqasm3_to_pyquil_bell():
     """
     result = openqasm3_to_pyquil(qasm)
     expected = Program(H(0), CNOT(0, 1))
-    assert circuits_allclose(result, expected, strict_gphase=False)
+    assert circuits_allclose(result, expected, strict_gphase=True)
 
 
 def test_openqasm3_to_pyquil_parameterized():
@@ -119,7 +119,7 @@ def test_openqasm3_to_pyquil_idle_qubits_padded():
     # q[1] is idle; without padding the program would be 3-qubit and mismatch the
     # 4-qubit reference operator.
     expected = Program(X(0), X(2), X(3), I(1))
-    assert circuits_allclose(result, expected, strict_gphase=False)
+    assert circuits_allclose(result, expected, strict_gphase=True)
 
 
 def test_openqasm3_to_pyquil_reset():
@@ -259,7 +259,7 @@ def test_openqasm3_to_pyquil_two_qubit_registers():
     x b[0];
     """
     result = openqasm3_to_pyquil(qasm)
-    assert circuits_allclose(result, Program(X(0), X(1)), strict_gphase=False)
+    assert circuits_allclose(result, Program(X(0), X(1)), strict_gphase=True)
 
 
 def test_openqasm3_to_pyquil_measure_without_target():


### PR DESCRIPTION
**Draft.** Bundles three small test-suite robustness improvements surfaced by a suite audit. Test/config-only; no library code touched.

## 1. Azure tests skip cleanly when `azure-quantum` is absent
`tests/runtime/azure/{conftest.py,test_azure_runtime.py,test_azure_remote.py}` imported `azure.*` at module top with no guard, so a partial environment hit `ModuleNotFoundError` during collection and aborted the whole run (every other optional backend guards with `importorskip`). Added `pytest.importorskip("azure.quantum")` using the same pattern as the pasqal tests. Verified: with azure absent the dir now reports `Skipped: azure-quantum not installed` instead of erroring.

## 2. Explicit `asyncio` test config
`pytest-asyncio` is a dev dependency and `tests/runtime/test_job.py` has four `@pytest.mark.asyncio` tests, but the marker wasn't registered and `asyncio_mode` was unset. Registered the `asyncio` marker and set `asyncio_mode = "strict"` in `pyproject.toml`. Verified the four async job tests pass with `pytest-asyncio` installed.

## 3. Tighter global-phase assertions
Three openqasm3→pyquil tests compared **phase-free** circuits (Bell `H;CX`, `X/X/X/I`, `X/X`) against explicit basis-gate pyQuil references but asserted only `strict_gphase=False` (also the default). Tightened to `strict_gphase=True` — they match exactly, so this hardens them against future global-phase regressions. (Left the genuinely phase-lossy cases — `cp`, `sxdg`, modifiers — as `False`.)

## Verification
openqasm3 + test_job suites: 37 passed; azure dir skips cleanly; black/isort/ruff clean; pylint neutral vs main (uses the established `importorskip` + `# pylint: disable=wrong-import-position` pattern).