### PR TITLE
test: suite cleanup — re-enable stale skips and harden test infra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,8 +116,10 @@ log_file_date_format = "%Y-%m-%d %H:%M:%S"
 testpaths = [
   "tests",
 ]
+asyncio_mode = "strict"
 markers = [
   "remote: mark a test as requiring a remote connection",
+  "asyncio: mark an async test to be run via pytest-asyncio",
 ]
 filterwarnings = [
     "ignore::DeprecationWarning",

--- a/tests/runtime/azure/conftest.py
+++ b/tests/runtime/azure/conftest.py
@@ -20,12 +20,16 @@ import os
 from typing import Optional
 
 import pytest
-from azure.identity import ClientSecretCredential
-from azure.quantum import Workspace
-from azure.quantum._constants import ConnectionConstants, EnvironmentVariables
-from qiskit import QuantumCircuit
 
-from qbraid.runtime.azure import AzureQuantumProvider
+pytest.importorskip("azure.quantum", reason="azure-quantum not installed")
+
+# pylint: disable=wrong-import-position
+from azure.identity import ClientSecretCredential  # noqa: E402
+from azure.quantum import Workspace  # noqa: E402
+from azure.quantum._constants import ConnectionConstants, EnvironmentVariables  # noqa: E402
+from qiskit import QuantumCircuit  # noqa: E402
+
+from qbraid.runtime.azure import AzureQuantumProvider  # noqa: E402
 
 
 @pytest.fixture

--- a/tests/runtime/azure/test_azure_remote.py
+++ b/tests/runtime/azure/test_azure_remote.py
@@ -26,9 +26,13 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
-from azure.quantum import Workspace
 
-from qbraid.runtime import (
+pytest.importorskip("azure.quantum", reason="azure-quantum not installed")
+
+# pylint: disable=wrong-import-position
+from azure.quantum import Workspace  # noqa: E402
+
+from qbraid.runtime import (  # noqa: E402
     AnalogResultData,
     AzureQuantumProvider,
     DeviceStatus,

--- a/tests/runtime/azure/test_azure_runtime.py
+++ b/tests/runtime/azure/test_azure_runtime.py
@@ -25,9 +25,13 @@ from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from azure.core.exceptions import ResourceExistsError
-from azure.quantum import Job, JobDetails, Workspace
-from azure.quantum.target.target import Target
+
+pytest.importorskip("azure.quantum", reason="azure-quantum not installed")
+
+# pylint: disable=wrong-import-position
+from azure.core.exceptions import ResourceExistsError  # noqa: E402
+from azure.quantum import Job, JobDetails, Workspace  # noqa: E402
+from azure.quantum.target.target import Target  # noqa: E402
 
 from qbraid.programs import QPROGRAM_REGISTRY, ExperimentType, ProgramSpec
 from qbraid.runtime import (

--- a/tests/transpiler/openqasm3/test_conversions_openqasm3.py
+++ b/tests/transpiler/openqasm3/test_conversions_openqasm3.py
@@ -53,7 +53,7 @@ def test_openqasm3_to_pyquil_bell():
     """
     result = openqasm3_to_pyquil(qasm)
     expected = Program(H(0), CNOT(0, 1))
-    assert circuits_allclose(result, expected, strict_gphase=False)
+    assert circuits_allclose(result, expected, strict_gphase=True)
 
 
 def test_openqasm3_to_pyquil_parameterized():
@@ -119,7 +119,7 @@ def test_openqasm3_to_pyquil_idle_qubits_padded():
     # q[1] is idle; without padding the program would be 3-qubit and mismatch the
     # 4-qubit reference operator.
     expected = Program(X(0), X(2), X(3), I(1))
-    assert circuits_allclose(result, expected, strict_gphase=False)
+    assert circuits_allclose(result, expected, strict_gphase=True)
 
 
 def test_openqasm3_to_pyquil_reset():
@@ -259,7 +259,7 @@ def test_openqasm3_to_pyquil_two_qubit_registers():
     x b[0];
     """
     result = openqasm3_to_pyquil(qasm)
-    assert circuits_allclose(result, Program(X(0), X(1)), strict_gphase=False)
+    assert circuits_allclose(result, Program(X(0), X(1)), strict_gphase=True)
 
 
 def test_openqasm3_to_pyquil_measure_without_target():

--- a/tests/transpiler/qasm/test_qasm_to_cudaq.py
+++ b/tests/transpiler/qasm/test_qasm_to_cudaq.py
@@ -162,7 +162,6 @@ def test_openqasm3_to_cudaq_u3_gate():
     _check_output(qasm3_str_in, kernel, method="state")
 
 
-@pytest.mark.skip(reason="pyqasm don't support ctrl modifiers")
 def test_openqasm3_to_cudaq_ctrl_modifier():
     """OpenQASM3 -> CUDA-Q: Test a ctrl modifier on an x gate."""
 

--- a/tests/transpiler/qasm/test_qasm_to_ionq.py
+++ b/tests/transpiler/qasm/test_qasm_to_ionq.py
@@ -587,7 +587,6 @@ def test_extract_params_index_error_caught():
     assert extract_params(statement) == []
 
 
-@pytest.mark.skip(reason="To validate in pyqasm through definition of ms gate")
 @pytest.mark.parametrize(
     "program_text",
     [

--- a/tests/transpiler/test_transpiler.py
+++ b/tests/transpiler/test_transpiler.py
@@ -340,7 +340,11 @@ yes_cirq_no_braket = list(set(cirq_gates_dict).difference(braket_gates_dict))
 yes_cirq_no_qiskit = list(set(cirq_gates_dict).difference(qiskit_gates_dict))
 yes_qiskit_no_cirq = list(set(qiskit_gates_dict).difference(cirq_gates_dict))
 
-NOT_SUPPORTED = ["RCCX", "RXX", "RYY", "RZX", "CSX", "CRX", "CRY", "U"]
+# Gates that cannot currently be transpiled from Qiskit to Braket/Cirq (e.g. due
+# to missing decompositions). Previously held ["RCCX", "RXX", "RYY", "RZX",
+# "CSX", "CRX", "CRY", "U"], all of which now transpile correctly, so the test
+# coverage they were gating is re-enabled. Keep the guard for future gaps.
+NOT_SUPPORTED: list[str] = []
 
 
 @pytest.mark.parametrize("gate_str", yes_braket_no_qiskit)


### PR DESCRIPTION
Combines the two test-suite cleanup drafts (supersedes #1222 and #1223). Test/config-only — no library code touched. All items verified locally.

## Re-enable stale skips (was #1222)

- **`NOT_SUPPORTED` gate list** (`test_transpiler.py`) held `["RCCX", "RXX", "RYY", "RZX", "CSX", "CRX", "CRY", "U"]`, skipping those in `test_yes_qiskit_no_braket` / `test_yes_qiskit_no_cirq`. All 8 now transpile from Qiskit to both Cirq and Braket and match the source unitary up to global phase. Emptied the list (kept the guard for future gaps), re-enabling ~14 cases.
- **`test_ionq_ms_gate_wrong_number_params`** — `ms`-gate parameter validation is implemented now and raises the expected `ValueError`. Un-skipped.
- **`test_openqasm3_to_cudaq_ctrl_modifier`** — pyqasm now supports the `ctrl` modifier (`ctrl @ x` unrolls to `cx`). Un-skipped; verified with `cuda-quantum-cu12==0.13.0` (full cudaq suite passed).

## Harden test infrastructure (was #1223)

- **Azure tests skip cleanly** when `azure-quantum` is absent: added `pytest.importorskip("azure.quantum")` to the conftest + two test modules (same pattern as the pasqal tests), so a partial environment no longer aborts collection with `ModuleNotFoundError`.
- **Explicit asyncio config**: registered the `asyncio` marker and set `asyncio_mode = "strict"` in `pyproject.toml` (four `@pytest.mark.asyncio` job tests rely on `pytest-asyncio`, a dev dependency).
- **Tighter assertions**: three phase-free openqasm3->pyquil tests (Bell `H;CX`, `X/X/X/I`, `X/X`) compared against explicit basis-gate references but asserted only `strict_gphase=False`; tightened to `True` to catch future global-phase regressions.

## Verification
331 passed across the affected suites; azure dir skips cleanly when azure is absent; black/isort/ruff clean; pylint uses the established `importorskip` + `# pylint: disable=wrong-import-position` pattern (W0718 warnings in the azure files are pre-existing).