### PR TITLE
Bump amazon-braket-sdk upper bound to <1.121.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ print(result.data.get_counts())
 - Fixed `qasm2_to_cirq` corrupting cirq's shared OpenQASM lexer: the QASM 2 parser assigned a reduced token list onto `cirq.contrib.qasm_import._lexer.QasmLexer.tokens` at import time, stripping the OpenQASM 3 tokens (e.g. `STDGATESINC`) process-wide and causing `qasm3_to_cirq` to raise a ply `LexError` on any QASM 3 parse that followed a `qasm2_to_cirq` call. The reduced token set now lives on a local `QasmLexer` subclass, leaving cirq's class intact ([#1214](https://github.com/qBraid/qBraid/pull/1214))
 
 ### Dependencies
+- Bumped the `amazon-braket-sdk` upper bound from `<1.111.0` to `<1.121.0` (latest tested: `1.120.0`) in both `pyproject.toml` (`braket` extra) and `requirements-dev.txt` ([#1243](https://github.com/qBraid/qBraid/pull/1243))
 - Added `sympy` to the `cirq` extra, since `cirq_qasm_parser` now imports it directly for conditional (`if`) statement parsing (previously only available transitively via `cirq-core`). Left unpinned to mirror `cirq-core`'s own `sympy` requirement ([#1183](https://github.com/qBraid/qBraid/pull/1183))
 - Replaced `qiskit-qir` dependency with `qbraid-qir[qiskit]>=0.6.0`; the `qiskit_to_pyqir` conversion now uses `qbraid_qir.qiskit.qiskit_to_qir` instead of the archived `qiskit-qir` package ([#1132](https://github.com/qBraid/qBraid/pull/1132))
 - Updated `qbraid-core` requirement from `>=0.3.2,<0.4.0` to `>=0.3.3,<0.4.0` ([#1201](https://github.com/qBraid/qBraid/pull/1201))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ Discord = "https://discord.gg/TPBU2sa8Et"
 [project.optional-dependencies]
 azure = ["azure-quantum>=3.6.0,<4.0"]
 bloqade = ["bloqade-analog>=0.16.1,<0.17.0"]
-braket = ["amazon-braket-sdk>=1.83.0,<1.111.0", "pytket-braket>=0.30,<0.47"]
+braket = ["amazon-braket-sdk>=1.83.0,<1.121.0", "pytket-braket>=0.30,<0.47"]
 cirq = ["cirq-core>=1.3,<1.7", "cirq-ionq>=1.3,<1.7", "ply>=3.6", "sympy", "attrs>=21.3.0"]
 cudaq = ["cudaq>=0.9.0,<0.14.0"]
 ionq = ["qiskit-ionq>=0.5.12"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # optional program types
-amazon-braket-sdk>=1.83.0,<1.111.0
+amazon-braket-sdk>=1.83.0,<1.121.0
 cirq-core>=1.3,<1.7
 cudaq>=0.9.0,<0.14.0; python_version < "3.13"
 pennylane>=0.43; python_version >= "3.11"


### PR DESCRIPTION
## Summary

Bumps the `amazon-braket-sdk` upper bound from `<1.111.0` to `<1.121.0` to allow the latest release (`1.120.0`). Updated in both places:

- `pyproject.toml` — `braket` optional-dependency extra
- `requirements-dev.txt`

A `Dependencies` entry was added to the changelog.

## Testing

Verified against `amazon-braket-sdk==1.120.0` in the `sdk311` (Python 3.11) environment with an editable qBraid install:

- All **365** braket-keyed tests pass (`pytest tests -k braket`).
- Ran the broader `tests/transpiler`, `tests/programs`, and `tests/runtime/aws` suites. The only 9 failures are **pre-existing and braket-independent** — cudaq/pytket local-environment issues that fail identically when reverting to the previously pinned `amazon-braket-sdk==1.110.1`.

No qBraid source changes were required; this is a dependency-bound bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
