### PR TITLE
fix: make program type registry thread-safe (#787)

### DIFF
--- a/qbraid/programs/registry.py
+++ b/qbraid/programs/registry.py
@@ -17,6 +17,7 @@ Module for registering custom program types and aliases
 
 """
 import sys
+import threading
 from typing import Any, Optional, Type, TypeVar, Union
 
 from qbraid._entrypoints import get_entrypoints
@@ -31,6 +32,14 @@ QPROGRAM_ALIASES = _QPROGRAM_ALIASES
 QPROGRAM_TYPES = _QPROGRAM_TYPES
 
 QPROGRAM = TypeVar("QPROGRAM", bound=Any)
+
+# Serializes concurrent mutations of the shared global registry structures
+# (QPROGRAM_REGISTRY, QPROGRAM_ALIASES, QPROGRAM_TYPES). Reentrant so that a
+# locked function may safely call another locked function. This prevents
+# data-structure corruption (e.g. "dictionary changed size during iteration")
+# under concurrent (un)registration; it does not impose any ordering on which
+# competing writer "wins" a contested alias.
+_REGISTRY_LOCK = threading.RLock()
 
 
 def derive_program_type_alias(program_type: Type[Any], use_submodule: bool = False) -> str:
@@ -100,45 +109,49 @@ def register_program_type(
 
     normalized_alias = alias.lower()
 
-    # Check if the alias is already used and if it maps to a different type
-    if normalized_alias in QPROGRAM_REGISTRY:
-        registered_type = QPROGRAM_REGISTRY[normalized_alias]
-        if registered_type != program_type and overwrite is False:
-            if (
-                isinstance(registered_type, QbraidMetaType)
-                and program_type == registered_type.__bound__
-            ):
-                program_type = registered_type
+    with _REGISTRY_LOCK:
+        # Check if the alias is already used and if it maps to a different type
+        if normalized_alias in QPROGRAM_REGISTRY:
+            registered_type = QPROGRAM_REGISTRY[normalized_alias]
+            if registered_type != program_type and overwrite is False:
+                if (
+                    isinstance(registered_type, QbraidMetaType)
+                    and program_type == registered_type.__bound__
+                ):
+                    program_type = registered_type
+                else:
+                    raise ValueError(
+                        f"Alias '{alias}' is already registered with a different type."
+                    )
+
+        # Check if the type is already registered under any other alias
+        existing_alias = next((k for k, v in QPROGRAM_REGISTRY.items() if v == program_type), None)
+        if existing_alias and existing_alias != normalized_alias and overwrite is False:
+            if program_type is str:
+                str_types = [
+                    k
+                    for k, v in QPROGRAM_REGISTRY.items()
+                    if v is str and k not in ("qasm2", "qasm3", "qasm2_kirin")
+                ]
+                if (
+                    len(str_types) >= 1
+                    and normalized_alias not in str_types
+                    and normalized_alias not in ("qasm2", "qasm3", "qasm2_kirin")
+                ):
+                    raise ValueError(
+                        "Cannot register more than one additional 'str' type beyond "
+                        "'qasm2', 'qasm3', and 'qasm2_kirin'."
+                    )
             else:
-                raise ValueError(f"Alias '{alias}' is already registered with a different type.")
-
-    # Check if the type is already registered under any other alias
-    existing_alias = next((k for k, v in QPROGRAM_REGISTRY.items() if v == program_type), None)
-    if existing_alias and existing_alias != normalized_alias and overwrite is False:
-        if program_type is str:
-            str_types = [
-                k
-                for k, v in QPROGRAM_REGISTRY.items()
-                if v is str and k not in ("qasm2", "qasm3", "qasm2_kirin")
-            ]
-            if (
-                len(str_types) >= 1
-                and normalized_alias not in str_types
-                and normalized_alias not in ("qasm2", "qasm3", "qasm2_kirin")
-            ):
                 raise ValueError(
-                    "Cannot register more than one additional 'str' type beyond "
-                    "'qasm2', 'qasm3', and 'qasm2_kirin'."
+                    f"Program type '{program_type}' already registered under "
+                    f"alias '{existing_alias}'."
                 )
-        else:
-            raise ValueError(
-                f"Program type '{program_type}' already registered under alias '{existing_alias}'."
-            )
 
-    # Register the new type and alias
-    QPROGRAM_REGISTRY[normalized_alias] = program_type
-    QPROGRAM_ALIASES.add(normalized_alias)
-    QPROGRAM_TYPES.add(program_type)
+        # Register the new type and alias
+        QPROGRAM_REGISTRY[normalized_alias] = program_type
+        QPROGRAM_ALIASES.add(normalized_alias)
+        QPROGRAM_TYPES.add(program_type)
 
 
 def unregister_program_type(alias: str, raise_error: bool = True) -> None:
@@ -154,17 +167,18 @@ def unregister_program_type(alias: str, raise_error: bool = True) -> None:
     """
     normalized_alias = alias.lower()
 
-    QPROGRAM_ALIASES.discard(normalized_alias)
+    with _REGISTRY_LOCK:
+        QPROGRAM_ALIASES.discard(normalized_alias)
 
-    if normalized_alias not in QPROGRAM_REGISTRY:
-        if raise_error:
-            raise KeyError(f"No program type registered under the alias '{alias}'.")
-        return
+        if normalized_alias not in QPROGRAM_REGISTRY:
+            if raise_error:
+                raise KeyError(f"No program type registered under the alias '{alias}'.")
+            return
 
-    program_type = QPROGRAM_REGISTRY.pop(normalized_alias)
+        program_type = QPROGRAM_REGISTRY.pop(normalized_alias)
 
-    if not any(pt == program_type for pt in QPROGRAM_REGISTRY.values()):
-        QPROGRAM_TYPES.discard(program_type)
+        if not any(pt == program_type for pt in QPROGRAM_REGISTRY.values()):
+            QPROGRAM_TYPES.discard(program_type)
 
 
 def is_registered_alias_native(alias: str) -> bool:

--- a/tests/programs/test_program_type_registry.py
+++ b/tests/programs/test_program_type_registry.py
@@ -21,6 +21,7 @@ Unit test for quantum program registry
 import random
 import string
 import sys
+import threading
 import unittest.mock
 
 import pytest
@@ -272,3 +273,60 @@ def test_get_native_experiment_type_not_found():
     with pytest.raises(ValueError) as excinfo:
         get_native_experiment_type("not_found")
     assert "Entry point 'not_found' not found in 'qbraid.programs'." in str(excinfo.value)
+
+
+def test_concurrent_registration_thread_safe():
+    """Registering/unregistering concurrently must not corrupt the shared registry.
+
+    Regression test for #787: the (un)register functions iterate over
+    ``QPROGRAM_REGISTRY`` while it may be mutated by another thread, which
+    previously raised ``RuntimeError: dictionary changed size during iteration``.
+    """
+    errors: list[Exception] = []
+    stop = threading.Event()
+    # Dedicated "churn" aliases rapidly change the registry's size, widening the
+    # window for another thread to iterate the dict mid-mutation.
+    churn_aliases = [generate_unique_key(QPROGRAM_REGISTRY) for _ in range(50)]
+    reg_aliases = [generate_unique_key(QPROGRAM_REGISTRY) for _ in range(8)]
+
+    def churner() -> None:
+        i = 0
+        while not stop.is_set():
+            alias = churn_aliases[i % len(churn_aliases)]
+            try:
+                register_program_type(int, alias=alias, overwrite=True)
+                unregister_program_type(alias, raise_error=False)
+            except Exception as err:  # pylint: disable=broad-except
+                errors.append(err)
+            i += 1
+
+    def registrar(alias: str) -> None:
+        # A distinct program type so the "type already registered under another
+        # alias" iteration path over QPROGRAM_REGISTRY is exercised every call.
+        program_type = type(f"Custom_{alias}", (), {})
+        try:
+            for _ in range(2000):
+                register_program_type(program_type, alias=alias, overwrite=True)
+                assert QPROGRAM_REGISTRY.get(alias) is program_type
+                unregister_program_type(alias, raise_error=False)
+        except Exception as err:  # pylint: disable=broad-except
+            errors.append(err)
+
+    churn_threads = [threading.Thread(target=churner) for _ in range(4)]
+    reg_threads = [threading.Thread(target=registrar, args=(alias,)) for alias in reg_aliases]
+    try:
+        for thread in churn_threads:
+            thread.start()
+        for thread in reg_threads:
+            thread.start()
+        for thread in reg_threads:
+            thread.join()
+        stop.set()
+        for thread in churn_threads:
+            thread.join()
+
+        assert not errors, f"Concurrent registration raised: {errors[:3]}"
+    finally:
+        stop.set()
+        for alias in churn_aliases + reg_aliases:
+            unregister_program_type(alias, raise_error=False)


### PR DESCRIPTION
## Summary

Fixes #787. The program type registry (`qbraid/programs/registry.py`) stored its state in three unsynchronized module globals (`QPROGRAM_REGISTRY`, `QPROGRAM_ALIASES`, `QPROGRAM_TYPES`). Under concurrent use, `register_program_type` / `unregister_program_type` could iterate the registry dict while another thread mutated it, raising:

```
RuntimeError: dictionary changed size during iteration
```

This is reachable in practice because `ProgramSpec.__init__` calls `register_program_type`, so a multithreaded service constructing devices/specs per request can hit it.

## Changes

- Add a module-level `threading.RLock()` (`_REGISTRY_LOCK`) and wrap the mutating bodies of `register_program_type` and `unregister_program_type` — including the `QPROGRAM_REGISTRY.items()` iteration that was the corruption source. Reentrant so a locked function can call another.
- Reads (e.g. `QPROGRAM_REGISTRY["qiskit"]` in device code, `is_registered_alias_native`) are left lock-free — single dict reads are atomic in CPython, so the hot runtime path is unaffected.
- Add `test_concurrent_registration_thread_safe`, which reliably reproduces the race using dedicated churn threads (rapid size changes) plus registrar threads (hitting the iteration path).

I deliberately kept the existing public globals rather than introducing the `ProgramRegistry` singleton sketched in the issue — those names are imported across `transpiler/` and `runtime/`, and the lock fixes the real defect without an API break.

## Scope note

The lock eliminates data-structure corruption (library-internal exceptions users can't avoid). It does **not** change last-writer-wins semantics when two threads register the *same* alias with *different* types — that's inherent to shared mutable global state and not something a lock resolves.

## Testing

- New regression test fails 5/5 against unpatched code, passes 5/5 with the fix.
- Full registry suite: 22 passed.
- Full unit suite: 2278 passed, 422 skipped. The 9 failures are pre-existing cudaq/pytket environment issues, confirmed by reproducing them on a clean checkout with these changes stashed out.
- `tox -e format-check` clean: pylint 10.00/10, isort, black, ruff, headers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when program types and aliases are added or removed at the same time.
  * Prevented registry inconsistencies that could occur during concurrent registration and cleanup.
  * Added a regression test to verify thread-safe behavior under heavy concurrent registry changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->