### PR TITLE
ci: fix Update Changelog workflow — bump retired claude-sonnet-4-20250514 to claude-sonnet-5

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -167,8 +167,9 @@ jobs:
             --arg diff "$PR_DIFF" \
             --arg current "$CURRENT_SECTION" \
             '{
-              model: "claude-sonnet-4-20250514",
+              model: "claude-sonnet-5",
               max_tokens: 4096,
+              thinking: {type: "disabled"},
               messages: [{
                 role: "user",
                 content: ($prompt + "\n\nCURRENT [Unreleased] SECTION:\n" + $current + "\n\nPR #" + $pr_number + ": " + $pr_title + "\n\nDIFF:\n" + $diff)


### PR DESCRIPTION
## Problem

The **Update Changelog** workflow fails at "Call Claude API for changelog entries" with:

```
Claude API error: model: claude-sonnet-4-20250514
```

`.github/workflows/update-changelog.yml` pins `model: "claude-sonnet-4-20250514"`, which **retired on 2026-06-15**. A retired model returns HTTP 404 `not_found_error` whose `error.message` is literally `model: claude-sonnet-4-20250514`; the workflow's error handler logs `.error.message` verbatim, producing the message above. (Every prior run was *skipped* — the API step is gated behind a trigger comment — so this is simply the first invocation since the model retired.)

## Fix

Two changes to the request body:

1. **`model` → `claude-sonnet-5`** — the current drop-in replacement for the retired Sonnet 4.
2. **Add `thinking: {type: "disabled"}`** — required, not cosmetic. On Sonnet 5, **adaptive thinking is ON by default** when `thinking` is omitted, which makes `content[0]` a *thinking* block. The workflow extracts the result with `jq -r '.content[0].text // empty'`, so with thinking on that value is empty and the `if [ -z "$CHANGELOG_CONTENT" ]` guard fails the step **even on a successful API call**. Disabling thinking keeps `content[0]` as the text block and preserves the full 4096-token budget for the changelog output. (Sonnet 4 ran thinking-off, so this preserves the original behavior.)

No other changes needed — the call is raw `curl` (no SDK) and sets no sampling parameters.