### PR TITLE
fix(transpiler): treat extras with a missing parent package as unsupported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Types of changes:
 
 ### Fixed
 
+- Fixed `ModuleNotFoundError` raised when building a `ConversionGraph` in an environment where a conversion's extras have an uninstalled parent package. `importlib.util.find_spec` imports each ancestor of a dotted module path and raises if one is missing, so `Conversion._is_conversion_supported` raised instead of reporting the conversion unsupported. Most visibly, `qbraid.transpiler` could not be imported at all with `pytket` installed but no `pytket` extensions, since the `pytket.extensions.qiskit` / `pytket.extensions.cirq` conversions added in 0.12.0 declare those extras. Such conversions are now correctly marked unsupported and excluded from the graph ([#1258](https://github.com/qBraid/qBraid/pull/1258))
+
 ### Dependencies
 
 ## [0.12.2] - 2026-07-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Types of changes:
 
 ### Fixed
 
-- Fixed `ModuleNotFoundError` raised when building a `ConversionGraph` in an environment where a conversion's extras have an uninstalled parent package. `importlib.util.find_spec` imports each ancestor of a dotted module path and raises if one is missing, so `Conversion._is_conversion_supported` raised instead of reporting the conversion unsupported. Most visibly, `qbraid.transpiler` could not be imported at all with `pytket` installed but no `pytket` extensions, since the `pytket.extensions.qiskit` / `pytket.extensions.cirq` conversions added in 0.12.0 declare those extras. Such conversions are now correctly marked unsupported and excluded from the graph ([#1258](https://github.com/qBraid/qBraid/pull/1258))
+- Fixed `ModuleNotFoundError` raised when building a `ConversionGraph` in an environment where a conversion's extras have an uninstalled parent package. `importlib.util.find_spec` imports each ancestor of a dotted module path and raises if one is missing, so `Conversion._is_conversion_supported` raised instead of reporting the conversion unsupported. Most visibly, `qbraid.transpiler` could not be imported at all with `pytket` installed but no `pytket` extensions, since the `pytket.extensions.qiskit` / `pytket.extensions.cirq` conversions added in 0.12.0 declare those extras. Such conversions are now correctly marked unsupported and excluded from the graph ([#1264](https://github.com/qBraid/qBraid/pull/1264))
 
 ### Dependencies
 

--- a/qbraid/transpiler/edge.py
+++ b/qbraid/transpiler/edge.py
@@ -24,10 +24,35 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 import numpy as np
 
+from qbraid._logging import logger
 from qbraid.programs import QPROGRAM_REGISTRY, get_program_type_alias
 
 if TYPE_CHECKING:
     import qbraid.programs
+
+
+def _is_module_installed(module: str) -> bool:
+    """
+    Determine whether a module is installed and importable.
+
+    ``importlib.util.find_spec`` only returns None for the *leaf* of a dotted path; it
+    imports each ancestor along the way, and raises ModuleNotFoundError if one of them is
+    missing. A conversion requiring ``pytket.extensions.qiskit`` therefore raises, rather
+    than reporting unavailable, whenever pytket is installed without any of its extensions.
+
+    Args:
+        module (str): The (possibly dotted) name of the module to look for.
+
+    Returns:
+        bool: True if the module can be located, otherwise False.
+    """
+    try:
+        return importlib.util.find_spec(module) is not None
+    except (ImportError, ValueError) as err:
+        # ImportError: an ancestor package is not installed.
+        # ValueError: the module is in sys.modules, but has no __spec__.
+        logger.debug("Module '%s' is not available: %s", module, err)
+        return False
 
 
 class Conversion:
@@ -176,7 +201,7 @@ class Conversion:
         """
         if self._native:
             return True
-        return all(importlib.util.find_spec(m) is not None for m in self._extras)
+        return all(_is_module_installed(m) for m in self._extras)
 
     def convert(self, program: qbraid.programs.QPROGRAM) -> Union[qbraid.programs.QPROGRAM, Any]:
         """

--- a/tests/transpiler/test_conversion_edge.py
+++ b/tests/transpiler/test_conversion_edge.py
@@ -18,7 +18,7 @@
 Unit tests for defining custom conversions
 
 """
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import cirq
 import numpy as np
@@ -230,3 +230,61 @@ def test_conversion_weight_bias(conversions, start, end, expected_path):
     graph = ConversionGraph(conversions=conversions)
     shortest_path = graph.shortest_path(start, end)
     assert shortest_path == expected_path
+
+
+def conversion_requiring(*extras: str) -> Conversion:
+    """Build a Conversion whose function declares the given extras."""
+
+    @requires_extras(*extras)
+    def cirq_to_qasm2(program):
+        return program
+
+    return Conversion("cirq", "qasm2", cirq_to_qasm2)
+
+
+@pytest.mark.parametrize(
+    "extras",
+    [
+        # leaf module missing, parent importable
+        ("qbraid.no_such_module",),
+        # intermediate package missing, e.g. plain pytket with no extensions installed
+        ("qbraid.no_such_package.no_such_module",),
+        # top-level package missing
+        ("no_such_package.no_such_module",),
+        ("no_such_package.no_such_subpackage.no_such_module",),
+        # one available extra is not enough if another is missing
+        ("numpy", "no_such_package.no_such_module"),
+    ],
+)
+def test_conversion_unsupported_when_extras_not_installed(extras):
+    """Uninstalled extras mark a conversion unsupported, regardless of where
+    along the dotted path the missing package sits."""
+    assert conversion_requiring(*extras).supported is False
+
+
+@pytest.mark.parametrize("extras", [("numpy",), ("qbraid.transpiler",), ("numpy", "cirq")])
+def test_conversion_supported_when_extras_installed(extras):
+    """Installed extras mark a conversion supported."""
+    assert conversion_requiring(*extras).supported is True
+
+
+def test_conversion_unsupported_when_extras_spec_lookup_fails():
+    """A module registered without a spec (find_spec raises ValueError) is not available."""
+    with patch("importlib.util.find_spec", side_effect=ValueError("no __spec__")):
+        assert conversion_requiring("weird_module").supported is False
+
+
+def test_conversion_extras_import_errors_are_not_swallowed():
+    """A broken install (parent package raises on import) surfaces rather than
+    silently downgrading the conversion to unsupported."""
+    with patch("importlib.util.find_spec", side_effect=RuntimeError("broken package")):
+        with pytest.raises(RuntimeError, match="broken package"):
+            conversion_requiring("broken_package.submodule")
+
+
+def test_conversion_graph_builds_with_missing_extras_parent():
+    """Building a graph that contains a conversion whose extras have a missing
+    parent package must not raise, and must exclude the unsupported edge."""
+    conversion = conversion_requiring("qbraid.no_such_package.no_such_module")
+    graph = ConversionGraph(conversions=[conversion])
+    assert graph.has_edge("cirq", "qasm2") is False


### PR DESCRIPTION
## Summary

`ConversionGraph()` raises `ModuleNotFoundError` instead of marking a conversion unsupported whenever one of its extras has an **uninstalled parent package**.

`importlib.util.find_spec` only returns `None` for the *leaf* of a dotted module path. It imports each ancestor along the way and raises `ModuleNotFoundError` if one of them is missing. `Conversion._is_conversion_supported` assumed the `None` contract held for the whole path:

```python
return all(importlib.util.find_spec(m) is not None for m in self._extras)
```

Most visibly, this makes **`qbraid.transpiler` unimportable in any environment with `pytket` installed but no pytket extensions**. The `pytket.extensions.qiskit` / `pytket.extensions.cirq` conversions added in 0.12.0 declare those extras, `pytket.extensions` is a namespace package that only exists once some `pytket-*` extension is installed, and `ConversionGraph()` checks every registered edge at construction:

```
>>> import qbraid.transpiler
ModuleNotFoundError: No module named 'pytket.extensions'
```

This is not pytket-specific. Any multi-component entry in `@requires_extras(...)` has the same shape — `qat.interop.*`, `qbraid_qir.qiskit`, `braket.pennylane_plugin`, `pytket.qir` — and fires as soon as the relevant program types are registered without the bridge package present. A second, independent reproduction with pytket nowhere in the picture: install `pyqir` (which registers the QIR node) without `qbraid_qir`, and stock `main` dies with `ModuleNotFoundError: No module named 'qbraid_qir'`.

The other two `find_spec` call sites in the codebase (`visualization/draw_circuit.py`, `runtime/ionq/device.py`) pass single-component names and are unaffected.

## Changes

Route the extras check through a helper that maps both documented `find_spec` failure modes onto "not installed":

- `ImportError` — an ancestor package is not installed.
- `ValueError` — the module is in `sys.modules` but has no `__spec__`.

Other exceptions raised from inside a broken package still surface rather than being silently downgraded to "unsupported"; there is a test pinning that.

## Impact

Affected conversions are now correctly marked unsupported and excluded from the graph, which is the pre-0.12.0 behavior. In a bare-`pytket` environment, `pytket → qiskit` routes via `pytket → qasm2 → qiskit` rather than the direct edge. Nothing changes for environments that do have the extension packages installed.

## Testing

11 new parametrized tests in `tests/transpiler/test_conversion_edge.py` covering: missing leaf (existing behavior, unchanged), missing intermediate package, missing top-level package, mixed installed/missing extras, installed extras, `find_spec` raising `ValueError`, non-import exceptions propagating, and `ConversionGraph` construction with an unsupported edge.

Written test-first: the dotted-path, `ValueError` and graph-construction cases fail against `main` and pass with the fix; the leaf-missing and installed cases pass both before and after, locking in that existing behavior is unchanged.

Verified downstream against [UCC](https://github.com/unitaryfoundation/ucc), which calls `ConversionGraph()` at import time and is currently pinned to `qbraid<1.0.0` at 0.11.1 because its dependabot bump to 0.12.x fails CI ([unitaryfoundation/ucc#695](https://github.com/unitaryfoundation/ucc/pull/695)):

- stock 0.12.2 → `import ucc` raises `ModuleNotFoundError: No module named 'pytket.extensions'`
- with this fix → full UCC suite passes (105 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed conversion graph building when optional dependencies or parent packages are missing.
  * Conversions requiring unavailable modules are now safely marked unsupported instead of causing import errors.
  * Improved handling of module availability checks, including missing package metadata and nested module paths.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->