### PR TITLE
docs: fix qrisp type path in README QPROGRAM_REGISTRY example [no ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Below, `QPROGRAM_REGISTRY` maps shorthand identifiers for supported quantum prog
  'pulser': pulser.sequence.sequence.Sequence,
  'pyqpanda3': pyqpanda3.core.QProg,
  'autoqasm': autoqasm.program.program.Program,
- 'qrisp': qrisp.circuit.circuit.QuantumCircuit,
+ 'qrisp': qrisp.circuit.quantum_circuit.QuantumCircuit,
  'qat': qat.core.wrappers.circuit.Circuit}
 ```
 


### PR DESCRIPTION
One-line README fix: the `QPROGRAM_REGISTRY` example mapped `'qrisp'` to `qrisp.circuit.circuit.QuantumCircuit`, but the actual registered type is `qrisp.circuit.quantum_circuit.QuantumCircuit` (verified against the live registry via `from qbraid import QPROGRAM_REGISTRY` with qrisp installed — `qrisp.circuit.circuit` is not a real module path).

Docs-only; no changelog entry, committed with `[no ci]`. Caught while aligning the docs-site SDK overview with the README (qBraid/docs#267).