### PR TITLE
test(braket): unpin qasm3_to_braket error test from pyqasm's gate inventory

### DIFF
--- a/tests/transpiler/braket/test_braket_qasm3.py
+++ b/tests/transpiler/braket/test_braket_qasm3.py
@@ -227,15 +227,24 @@ def test_qasm3_to_braket_prior_errors_included_in_final_error(match_substring):
 
 
 def test_qasm3_to_braket_error_includes_detail():
-    """Verify that QasmError includes the specific failure reason from the Braket parser."""
+    """Verify that QasmError includes the specific failure reason from the Braket parser.
+
+    The gate is deliberately one no QASM library will ever define. This test
+    previously used `c3x`, relying on pyqasm leaving it alone so Braket's parser
+    would reject it — but pyqasm 1.0.4 learned to decompose `c3x` during unroll,
+    so the conversion started succeeding and the test broke. Any real-but-exotic
+    gate is a moving target; a fake one is not. pyqasm's own rejection of the
+    unknown gate is caught into `prior_errors`, the original program flows to
+    Braket's parser, and its "not defined" detail must surface in the QasmError.
+    """
     qasm_input = textwrap.dedent(
         """
         OPENQASM 3.0;
         include "stdgates.inc";
         qubit[4] q;
         h q[0];
-        c3x q[0], q[1], q[2], q[3];
+        notarealgate q[0], q[1];
         """
     ).strip()
-    with pytest.raises(QasmError, match="c3x is not defined"):
+    with pytest.raises(QasmError, match="notarealgate is not defined"):
         qasm3_to_braket(qasm_input)


### PR DESCRIPTION
## Problem

`tests/transpiler/braket/test_braket_qasm3.py::test_qasm3_to_braket_error_includes_detail` fails on every fresh CI run since **2026-07-15** — on `main` and on all open PRs (first seen on #1258, where it failed the 3.14 job and fail-fast cancelled the rest). Nothing in any PR caused it.

**Root cause:** the test feeds `qasm3_to_braket` a program using `c3x` and expects Braket's parser to raise `QasmError("c3x is not defined")`. That relied on pyqasm leaving `c3x` alone during `unroll()`. **pyqasm 1.0.4** (released 2026-07-15) learned to decompose `c3x`, so Braket now receives only defined gates, the conversion succeeds, and the expected error never raises. Reproduced locally: the test passes with `pyqasm==1.0.3` and fails with `pyqasm==1.0.4`, on the same interpreter.

## Fix

The test's purpose is to pin that **Braket's parser detail surfaces in the `QasmError`** — not that `c3x` specifically is unsupported. Any real-but-exotic gate is a moving target for exactly this failure mode. Switched to a gate no QASM library will ever define (`notarealgate`): pyqasm rejects it (captured into `prior_errors`), the original program flows to Braket's parser, and its "is not defined" detail must appear in the raised `QasmError` — same assertion, no dependency on any library's gate inventory.

Verified: 8/8 tests in the file pass on both `pyqasm==1.0.3` and `pyqasm==1.0.4`.

Test-only change; no changelog entry.
