### PR TITLE
fix(openquantum): point the no-organization submit error at terms-of-use acceptance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Types of changes:
 ### Added
 
 ### Improved / Modified
+- Improved the error raised by `OpenQuantumDevice.submit` when the user has no organizations: "No organization found for user." now reads "No organization found -- please accept Open Quantum terms of use to continue.", pointing at the actual remediation
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Types of changes:
 ### Added
 
 ### Improved / Modified
-- Improved the error raised by `OpenQuantumDevice.submit` when the user has no organizations: "No organization found for user." now reads "No organization found -- please accept Open Quantum terms of use to continue.", pointing at the actual remediation ([#1279](https://github.com/qBraid/qBraid/pull/1279))
+- Improved the error raised by `OpenQuantumDevice.submit` when the user has no organizations: "No organization found for user." now reads "No organization found. Please accept the Open Quantum terms of use to continue.", pointing at the actual remediation ([#1279](https://github.com/qBraid/qBraid/pull/1279))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Types of changes:
 ### Added
 
 ### Improved / Modified
-- Improved the error raised by `OpenQuantumDevice.submit` when the user has no organizations: "No organization found for user." now reads "No organization found -- please accept Open Quantum terms of use to continue.", pointing at the actual remediation
+- Improved the error raised by `OpenQuantumDevice.submit` when the user has no organizations: "No organization found for user." now reads "No organization found -- please accept Open Quantum terms of use to continue.", pointing at the actual remediation ([#1279](https://github.com/qBraid/qBraid/pull/1279))
 
 ### Deprecated
 

--- a/qbraid/runtime/openquantum/device.py
+++ b/qbraid/runtime/openquantum/device.py
@@ -95,7 +95,8 @@ class OpenQuantumDevice(QuantumDevice):
             orgs = self.session.get_user_organizations()
             if not orgs:
                 raise QbraidRuntimeError(
-                    "No organization found -- please accept Open Quantum terms of use to continue."
+                    "No organization found. Please accept the Open Quantum "
+                    "terms of use to continue."
                 )
             organization_id = orgs[0]["id"]
 

--- a/qbraid/runtime/openquantum/device.py
+++ b/qbraid/runtime/openquantum/device.py
@@ -94,7 +94,9 @@ class OpenQuantumDevice(QuantumDevice):
         if organization_id is None:
             orgs = self.session.get_user_organizations()
             if not orgs:
-                raise QbraidRuntimeError("No organization found for user.")
+                raise QbraidRuntimeError(
+                    "No organization found -- please accept Open Quantum terms of use to continue."
+                )
             organization_id = orgs[0]["id"]
 
         # Encode QASM

--- a/tests/runtime/openquantum/test_openquantum_runtime.py
+++ b/tests/runtime/openquantum/test_openquantum_runtime.py
@@ -602,7 +602,10 @@ def test_device_submit_no_orgs(provider):
     """Test submitting a job when user has no organizations."""
     provider.session.get_user_organizations.return_value = []
     device = provider.get_device("oq-sim")
-    with pytest.raises(QbraidRuntimeError, match="No organization found for user."):
+    with pytest.raises(
+        QbraidRuntimeError,
+        match="No organization found -- please accept Open Quantum terms of use to continue.",
+    ):
         device.submit("OPENQASM 3.0; h q[0];")
 
 

--- a/tests/runtime/openquantum/test_openquantum_runtime.py
+++ b/tests/runtime/openquantum/test_openquantum_runtime.py
@@ -604,7 +604,7 @@ def test_device_submit_no_orgs(provider):
     device = provider.get_device("oq-sim")
     with pytest.raises(
         QbraidRuntimeError,
-        match="No organization found -- please accept Open Quantum terms of use to continue.",
+        match="No organization found. Please accept the Open Quantum terms of use to continue.",
     ):
         device.submit("OPENQASM 3.0; h q[0];")
 


### PR DESCRIPTION
## Changes

`OpenQuantumDevice.submit` auto-selects the user's first organization when none is specified. When the user has no organizations, the error said what was wrong but not what to do about it:

> No organization found for user.

Open Quantum creates the user's organization when they accept the terms of use, so the message now directs them to the remediation:

> No organization found. Please accept the Open Quantum terms of use to continue.

Updated the corresponding test match and added a changelog entry.

## Tests

`tests/runtime/openquantum/`: 34 passed, 1 skipped. `tox -e linters` clean.
