### PR TITLE
perf(tests): parallelize unit tests with pytest-xdist

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,8 +48,10 @@ jobs:
         python3 -m pip install --upgrade pip setuptools
         python3 -m pip install tox
     - name: Tests
+      # Coverage is only uploaded from the 3.11 job, so only that job pays the
+      # instrumentation overhead; the rest run with --no-cov.
       run: |
-        tox -e unit-tests
+        tox -e unit-tests ${{ matrix.python-version != '3.11' && '-- --no-cov' || '' }}
       env:
         QBRAID_RUN_REMOTE_TESTS: False
     - name: Upload coverage to Codecov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Writing an entry:
 - Added `QbraidDevice.get_calibrations()` and `QbraidDevice.coupling_map`, exposing device calibration data (per-edge two-qubit gate errors, per-qubit metrics, timestamps) and the physical connectivity graph derived from it. Useful for hand-placing circuits on paths that bypass quilc. Both return `None`-equivalents for devices without published calibration data ([#1281](https://github.com/qBraid/qBraid/pull/1281))
 
 ### Improved / Modified
+- Unit tests now run in parallel (`pytest-xdist -n auto`), test collection is made deterministic so xdist workers agree (set-derived `parametrize` inputs are sorted), and CI collects coverage only on the job that uploads to Codecov — roughly halving PR CI wall time with no checks removed
 - Improved the error raised by `OpenQuantumDevice.submit` when the user has no organizations: it now points at accepting the Open Quantum terms of use rather than only reporting "No organization found for user." ([#1279](https://github.com/qBraid/qBraid/pull/1279))
 
 ### Deprecated

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -52,4 +52,5 @@ sympy
 packaging>=20.0
 pytest
 pytest-cov
+pytest-xdist
 pytest-asyncio>=0.21

--- a/tests/transpiler/test_conversion_graph.py
+++ b/tests/transpiler/test_conversion_graph.py
@@ -84,7 +84,7 @@ def bound_method_str(source, target):
     return f"<bound method Conversion.convert of ('{source}', '{target}')>"
 
 
-@pytest.mark.parametrize("func", conversion_functions)
+@pytest.mark.parametrize("func", sorted(conversion_functions))
 def test_conversion_functions_syntax(func):
     """Test that all conversion functions are named correctly."""
     source, target = func.split("_to_")

--- a/tests/transpiler/test_transpiler.py
+++ b/tests/transpiler/test_transpiler.py
@@ -79,7 +79,7 @@ def test_to_cirq_bad_openqasm_program(item):
 
 
 @pytest.mark.parametrize("bell_circuit", ["cirq"], indirect=True)
-@pytest.mark.parametrize("to_type", QPROGRAM_ALIASES)
+@pytest.mark.parametrize("to_type", sorted(QPROGRAM_ALIASES))
 def test_cirq_round_trip(bell_circuit, to_type):
     """Test converting Cirq circuits to other supported types."""
     # Use a single graph for both the path check and the transpile calls so the
@@ -274,9 +274,9 @@ braket_gate_set = set(braket_gates_dict.keys())
 qiskit_gate_set = set(qiskit_gates_dict.keys())
 cirq_gate_set = set(cirq_gates_dict.keys())
 
-intersect_braket_qiskit = list(braket_gate_set.intersection(list(qiskit_gate_set)))
-intersect_qiskit_cirq = list(qiskit_gate_set.intersection(list(cirq_gate_set)))
-intersect_cirq_braket = list(cirq_gate_set.intersection(list(braket_gate_set)))
+intersect_braket_qiskit = sorted(braket_gate_set.intersection(list(qiskit_gate_set)))
+intersect_qiskit_cirq = sorted(qiskit_gate_set.intersection(list(cirq_gate_set)))
+intersect_cirq_braket = sorted(cirq_gate_set.intersection(list(braket_gate_set)))
 
 # skipping
 intersect_braket_qiskit.remove("RXX")
@@ -335,12 +335,12 @@ def test_gate_intersect_braket_cirq(gate_str):
     assert_allclose_up_to_global_phase(braket_u, braket_transpile_u, atol=1e-7)
 
 
-yes_braket_no_qiskit = list(set(braket_gates_dict).difference(qiskit_gates_dict))
-yes_qiskit_no_braket = list(set(qiskit_gates_dict).difference(braket_gates_dict))
-yes_braket_no_cirq = list(set(braket_gates_dict).difference(cirq_gates_dict))
-yes_cirq_no_braket = list(set(cirq_gates_dict).difference(braket_gates_dict))
-yes_cirq_no_qiskit = list(set(cirq_gates_dict).difference(qiskit_gates_dict))
-yes_qiskit_no_cirq = list(set(qiskit_gates_dict).difference(cirq_gates_dict))
+yes_braket_no_qiskit = sorted(set(braket_gates_dict).difference(qiskit_gates_dict))
+yes_qiskit_no_braket = sorted(set(qiskit_gates_dict).difference(braket_gates_dict))
+yes_braket_no_cirq = sorted(set(braket_gates_dict).difference(cirq_gates_dict))
+yes_cirq_no_braket = sorted(set(cirq_gates_dict).difference(braket_gates_dict))
+yes_cirq_no_qiskit = sorted(set(cirq_gates_dict).difference(qiskit_gates_dict))
+yes_qiskit_no_cirq = sorted(set(qiskit_gates_dict).difference(cirq_gates_dict))
 
 # Gates that cannot currently be transpiled from Qiskit to Braket/Cirq (e.g. due
 # to missing decompositions). Previously held ["RCCX", "RXX", "RYY", "RZX",

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ envlist =
 skip_missing_interpreter = true
 
 [testenv]
-commands_pre = python -m pip install .
 basepython = python3
 deps = -r{toxinidir}/requirements-dev.txt
 pass_env =
@@ -37,9 +36,16 @@ pass_env =
 
 [testenv:unit-tests]
 description = Run pytests for main package and generate coverage report.
+setenv =
+    # xdist workers must collect identical test lists; several parametrize
+    # inputs are set-derived, so pin hash randomization as a second line of
+    # defense behind the sorted() calls in the tests themselves.
+    PYTHONHASHSEED = 0
 commands =
     python3 -c "import qbraid; qbraid.about()"
     pytest tests \
+        -n auto \
+        --dist worksteal \
         --cov=qbraid \
         --cov-config=pyproject.toml \
         --cov-report=term \


### PR DESCRIPTION
## Summary

Parallelizes the unit test suite with `pytest-xdist` and stops collecting coverage on matrix jobs that never upload it. Together with the determinism fixes below, this should roughly halve PR CI wall time with no checks removed.

## Measurements

CI's test step today (py3.12 job, from run logs): 95s dependency install + ~35s pytest boot + **428s test run** = 574s. Local benchmark of this change (full deps, `--remote false`, coverage on):

| Configuration | Wall time | Result set |
| --- | --- | --- |
| serial (current CI config) | 271.5s | 2618 passed / 126 skipped |
| `-n 4 --dist worksteal` | **98.3s (2.8x)** | identical |
| `-n auto`, no cov | 66.6s (4.1x) | identical |

Applying the measured 2.8x to CI's 428s run projects **~155s**, i.e. the test step drops from ~9.6 to ~4 minutes. Ratio was measured on Apple Silicon at 4 workers; CI's 4 vCPUs should transfer approximately, and this PR's own run is the confirmation.

## Why collection had to be fixed first

`pytest-xdist` requires every worker to collect an identical, identically-ordered test list. Eleven `parametrize` inputs were derived from unordered set operations — `intersection`/`difference` gate lists and `QPROGRAM_ALIASES` in `test_transpiler.py`, `conversion_functions` in `test_conversion_graph.py` — so workers (separate processes, randomized string hashing) collected in different orders and xdist aborted with `Different tests were collected between gw0 and gwN`. Each input is now `sorted()`; `PYTHONHASHSEED=0` is also pinned in the tox env as a second line of defense. Verified: three consecutive full-suite runs at `-n auto` and `-n 4` collect cleanly with a pass/fail/skip set identical to serial.

## Coverage only where it is uploaded

Codecov receives coverage exclusively from the 3.11 job, but all five matrix jobs paid the instrumentation overhead (measured at +43-76% depending on subset). Non-3.11 jobs now append `--no-cov`, which cleanly overrides the `--cov` flags in the tox command. The 3.11 job and its Codecov upload are unchanged, and `parallel = true` was already set in the coverage config, so xdist and coverage compose without further changes.

## Also

- Removes `commands_pre = python -m pip install .` from `[testenv]`: tox already builds and installs the package for every non-`skip_install` env (visible as `install_package>` in CI logs), so the package was installed twice per job.
- `ci-daily.yml` calls the same tox env and inherits the parallelization automatically.

## Risk notes

- `--dist worksteal` suits this suite's shape (a long tail of 2-12s transpiler tests, no test above ~12s locally).
- Mocked-socket and env-mutating tests were reviewed for parallel safety; workers are separate processes, and the full-suite runs above are the empirical check.
- If a future set-derived `parametrize` input reintroduces nondeterminism, `PYTHONHASHSEED=0` already masks hash-order cases; genuinely dynamic inputs (e.g. capability probing) should be sorted at the definition site as done here.
