### PR TITLE
perf(ci): build tox environments with uv via tox-uv

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Install dependencies
       run: |
         python3 -m pip install --upgrade pip setuptools
-        python3 -m pip install tox
+        python3 -m pip install tox tox-uv
     - name: Tests
       run: |
         tox -e unit-tests

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install dependencies
       run: |
         python3 -m pip install --upgrade pip setuptools
-        python3 -m pip install tox
+        python3 -m pip install tox tox-uv
     - name: Build docs
       run: |
         tox -e docs

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install dependencies
       run: |
         python3 -m pip install --upgrade pip setuptools
-        python3 -m pip install tox
+        python3 -m pip install tox tox-uv
     - name: Check isort, pylint, black, headers
       run: |
         tox -e format-check

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install tox>=4.2.0
+          pip install "tox>=4.2.0" tox-uv
 
       - name: Build Sphinx documentation
         run: tox -e docs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Install dependencies
       run: |
         python3 -m pip install --upgrade pip setuptools
-        python3 -m pip install tox
+        python3 -m pip install tox tox-uv
     - name: Tests
       run: |
         tox -e unit-tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Writing an entry:
 
 ### Improved / Modified
 - Improved the error raised by `OpenQuantumDevice.submit` when the user has no organizations: it now points at accepting the Open Quantum terms of use rather than only reporting "No organization found for user." ([#1279](https://github.com/qBraid/qBraid/pull/1279))
+- CI workflows install `tox-uv`, so tox environments are built with the much faster `uv` installer instead of pip; local tox usage is unaffected unless `tox-uv` is installed
 
 ### Deprecated
 


### PR DESCRIPTION
## Summary

Installs `tox-uv` alongside `tox` in the five workflows that build tox environments (`main`, `format`, `docs`, `ci-daily`, `gh-pages`), so environment creation uses the `uv` installer instead of pip. One-line change per workflow; no `tox.ini` changes; contributors' local tox behavior is unchanged unless they install `tox-uv` themselves.

## Depends on #1289 — merge that first

This PR's first CI run failed on every tox job with:

```
unit-tests: commands_pre[0]> python -m pip install .
.tox/unit-tests/bin/python: No module named pip
```

uv-created virtualenvs do not bundle pip, and the failing line is exactly the redundant `commands_pre = python -m pip install .` that **#1289 removes** (tox already installs the package itself). Once #1289 is on `main`, re-running this PR's checks will pick up the fix via the merge ref — no rebase needed.

The run was still informative: the full `unit-tests` env build (dependency resolution + install of requirements-dev.txt + package) completed in **13.6 seconds** under uv, versus ~107s under pip on the same runners with a warm wheel cache (~8x). uv's resolution differs slightly within allowed ranges (e.g. `pulser-core` 1.7.2 -> 1.8.0), which is expected for unpinned lower/upper-bound specs.

## Why

From CI run logs, each test job spends ~95 seconds in `pip install -r requirements-dev.txt` plus ~12s of package build/install — pure resolve/unpack work (the `setup-python` wheel cache was confirmed hot). This PR cuts that to ~14s per job, and similarly accelerates the format, docs, and daily workflows.

## Rollback

If uv's stricter resolution ever surfaces a dependency conflict pip tolerated, revert by removing `tox-uv` from the five install lines.
