### PR TITLE
Clarify sparse pyQuil unitary errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Writing an entry:
 ### Removed
 
 ### Fixed
+- Sparse-indexed pyQuil programs now raise an actionable unitary error that points to the supported qubit-compaction options instead of leaking a low-level permutation failure.
 - Fixed `openqasm3_to_pyquil` raising `AttributeError` for programs addressing physical qubits (`x $0;`) rather than a declared register. Physical qubit indices now pass through verbatim and are not identity-padded, since such a program is already mapped to specific hardware ([#1286](https://github.com/qBraid/qBraid/pull/1286))
 - Fixed OpenQuantum `prepare_job` / `get_preparation_result` / `create_job` failing without a clear message when the API rejected the request. Responses are now parsed for the error `type`, mapping `TERMS_OF_USE_REQUIRED` to a `QbraidRuntimeError` pointing at https://www.openquantum.com, and other failures to a message including HTTP status, error type, and API detail ([#1282](https://github.com/qBraid/qBraid/pull/1282))
 - Fixed `RigettiJob.status()` discarding the reason a job failed, leaving callers that persist failure reasons with nothing to store. A non-timeout `QpuApiError` from `retrieve_results` is now logged, and its message recorded on the returned status and on a new `RigettiJob.status_message` property that is safe to read under concurrent polling ([#1278](https://github.com/qBraid/qBraid/pull/1278))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ Writing an entry:
 ### Removed
 
 ### Fixed
-- Sparse-indexed pyQuil programs now raise an actionable unitary error that points to the supported qubit-compaction options instead of leaking a low-level permutation failure.
+- Sparse-indexed pyQuil programs now raise an actionable unitary error that points to the supported qubit-compaction options instead of leaking a low-level permutation failure ([#1291](https://github.com/qBraid/qBraid/pull/1291))
 - Fixed `openqasm3_to_pyquil` raising `AttributeError` for programs addressing physical qubits (`x $0;`) rather than a declared register. Physical qubit indices now pass through verbatim and are not identity-padded, since such a program is already mapped to specific hardware ([#1286](https://github.com/qBraid/qBraid/pull/1286))
 - Fixed OpenQuantum `prepare_job` / `get_preparation_result` / `create_job` failing without a clear message when the API rejected the request. Responses are now parsed for the error `type`, mapping `TERMS_OF_USE_REQUIRED` to a `QbraidRuntimeError` pointing at https://www.openquantum.com, and other failures to a message including HTTP status, error type, and API detail ([#1282](https://github.com/qBraid/qBraid/pull/1282))
 - Fixed `RigettiJob.status()` discarding the reason a job failed, leaving callers that persist failure reasons with nothing to store. A non-timeout `QpuApiError` from `retrieve_results` is now logged, and its message recorded on the returned status and on a new `RigettiJob.status_message` property that is safe to read under concurrent polling ([#1278](https://github.com/qBraid/qBraid/pull/1278))

--- a/qbraid/programs/gate_model/pyquil.py
+++ b/qbraid/programs/gate_model/pyquil.py
@@ -104,6 +104,13 @@ class PyQuilProgram(GateModelProgram):
     def _unitary(self) -> np.ndarray:
         """Return the unitary of a pyQuil program."""
         program_copy = self.remove_measurements(self.program)
+        qubits = sorted(program_copy.get_qubits())
+        if qubits and qubits != list(range(len(qubits))):
+            raise ValueError(
+                "PyQuilProgram.unitary() requires contiguous qubit indices starting at 0; "
+                f"got {qubits}. Call remove_idle_qubits() first or use "
+                "circuits_allclose(..., index_contig=True)."
+            )
         return program_unitary(program_copy, n_qubits=self.num_qubits)
 
     def serialize(self) -> Program:

--- a/qbraid/programs/gate_model/pyquil.py
+++ b/qbraid/programs/gate_model/pyquil.py
@@ -105,7 +105,7 @@ class PyQuilProgram(GateModelProgram):
         """Return the unitary of a pyQuil program."""
         program_copy = self.remove_measurements(self.program)
         qubits = sorted(program_copy.get_qubits())
-        if qubits and qubits != list(range(len(qubits))):
+        if qubits and max(qubits) >= self.num_qubits:
             raise ValueError(
                 "PyQuilProgram.unitary() requires contiguous qubit indices starting at 0; "
                 f"got {qubits}. Call remove_idle_qubits() first or use "

--- a/tests/programs/test_program_circuits_pyquil.py
+++ b/tests/programs/test_program_circuits_pyquil.py
@@ -82,6 +82,14 @@ def test_remove_idle_qubits_noop_when_contiguous():
     assert sorted(program.program.get_qubits()) == [0, 1]
 
 
+def test_sparse_qubit_unitary_error_is_actionable():
+    """Sparse qubit indices raise an error that explains how to compact them."""
+    program = PyQuilProgram(Program(H(0), CNOT(0, 2)))
+
+    with pytest.raises(ValueError, match=r"got \[0, 2\].*index_contig=True"):
+        program.unitary()
+
+
 def test_reverse_qubit_order():
     """Reversing qubit order swaps the qubit indices of every instruction."""
     program = PyQuilProgram(Program(H(0), CNOT(0, 1)))

--- a/tests/programs/test_program_circuits_pyquil.py
+++ b/tests/programs/test_program_circuits_pyquil.py
@@ -21,7 +21,8 @@ import pytest
 
 try:
     from pyquil import Program
-    from pyquil.gates import CNOT, MEASURE, H
+    from pyquil.gates import CNOT, CZ, MEASURE, H
+    from pyquil.quilbase import Declare
     from qbraid_core.services.runtime.schemas import Program as RuntimeProgram
 
     from qbraid.programs.exceptions import ProgramTypeError
@@ -88,6 +89,16 @@ def test_sparse_qubit_unitary_error_is_actionable():
 
     with pytest.raises(ValueError, match=r"got \[0, 2\].*index_contig=True"):
         program.unitary()
+
+
+def test_unitary_allows_measured_only_qubits():
+    """A qubit that is measured but never gated still counts toward num_qubits."""
+    quil = Program(Declare("ro", "BIT", 3), H(0), CZ(0, 2))
+    for qubit in range(3):
+        quil += MEASURE(qubit, ("ro", qubit))
+    program = PyQuilProgram(quil)
+
+    assert program.unitary().shape == (8, 8)
 
 
 def test_reverse_qubit_order():


### PR DESCRIPTION
Closes #1287

## Summary of changes

Sparse pyQuil programs now fail before pyQuil's low-level permutation logic and explain both supported qubit-compaction options. The regression test fails with `Permutation SWAP index not valid` before the fix and passes with the actionable error; all 8 focused pyQuil program tests and Ruff checks pass.
