### PR TITLE
fix(ci): pin ruff below 0.16 to unbreak format checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Writing an entry:
 ### Removed
 
 ### Fixed
+- Pinned the format-check `ruff` to `<0.16`: ruff 0.16.0 changed its default lint rules and flags ~742 pre-existing issues repo-wide, breaking CI format checks for every PR
 - Fixed `openqasm3_to_pyquil` raising `AttributeError` for programs addressing physical qubits (`x $0;`) rather than a declared register. Physical qubit indices now pass through verbatim and are not identity-padded, since such a program is already mapped to specific hardware ([#1286](https://github.com/qBraid/qBraid/pull/1286))
 - Fixed OpenQuantum `prepare_job` / `get_preparation_result` / `create_job` failing without a clear message when the API rejected the request. Responses are now parsed for the error `type`, mapping `TERMS_OF_USE_REQUIRED` to a `QbraidRuntimeError` pointing at https://www.openquantum.com, and other failures to a message including HTTP status, error type, and API detail ([#1282](https://github.com/qBraid/qBraid/pull/1282))
 - Fixed `RigettiJob.status()` discarding the reason a job failed, leaving callers that persist failure reasons with nothing to store. A non-timeout `QpuApiError` from `retrieve_results` is now logged, and its message recorded on the returned status and on a new `RigettiJob.status_message` property that is safe to read under concurrent polling ([#1278](https://github.com/qBraid/qBraid/pull/1278))

--- a/tox.ini
+++ b/tox.ini
@@ -89,7 +89,9 @@ commands =
 [testenv:ruff]
 envdir = .tox/linters
 skip_install = true
-deps = ruff
+# ruff 0.16.0 changed default lint rules and flags ~742 pre-existing issues
+# repo-wide; pin until we adopt its defaults (or write an explicit select).
+deps = ruff<0.16
 commands =
     ruff check qbraid tests bin {posargs}
 


### PR DESCRIPTION
## Summary

Pins the tox `ruff` env to `ruff<0.16`. ruff 0.16.0 (released yesterday) changed its default lint rule set, and this repo's `[tool.ruff.lint]` config rides the defaults — so the new version reports **~742 pre-existing issues** across the repo (largely pyupgrade-style `Optional[X]` -> `X | None` rewrites).

Verified both directions on current `main`: `ruff 0.16.0` -> 742 errors; `ruff 0.15.22` -> `All checks passed!`.

## Why every PR is about to go red

`[testenv:ruff]` had `deps = ruff` unpinned, and CI builds the linters env fresh each run, so any format-check run from now on gets 0.16.0. It surfaced via #1294: that PR's check job stopped at an earlier black failure, and fixing the black issue then exposed the ruff stage. Any PR whose format-check reaches the ruff stage will fail identically until this pin (or a repo-wide 0.16 adoption) lands.

Merging this unblocks #1294 (its black fix is already pushed) and every other open PR — their check jobs pick the pin up from the merge ref on re-run, no rebases needed.

## Follow-up (separate PR, not urgent)

Either adopt 0.16's defaults with a repo-wide `ruff check --fix` sweep, or write an explicit `lint.select` so default-set changes stop being able to break CI. Worth noting `pylint`, `isort`, and `mypy` in tox.ini are also unpinned and carry the same class of risk (black is already pinned `<=25.12.0`).
