### PR TITLE
feat(rigetti): expose quilc-compiled program on RigettiJob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Writing an entry:
 ## [Unreleased]
 
 ### Added
+- Added `RigettiJob.compiled_program`, exposing the native Quil program produced by quilc for the job. It reveals the physical qubits selected and the compiler's final rewiring — information not recoverable from measurement counts. Populated on jobs returned by `RigettiDevice.run`/`submit`; `None` for jobs rehydrated by ID, since QCS does not expose compilation output after submission. When known, it is also included in `Result.details["compiled_program"]`
 - Added `qbraid.visualization.plot_connectivity_graph`, rendering a device's connectivity graph colored by live calibration data (edges by two-qubit gate error, nodes by readout error). Layout follows the device's `topology` config, with a force-directed fallback for unknown types. The `lattice_positions` helper is exported for custom plots ([#1281](https://github.com/qBraid/qBraid/pull/1281), [#1283](https://github.com/qBraid/qBraid/pull/1283))
 - Added `QbraidDevice.get_calibrations()` and `QbraidDevice.coupling_map`, exposing device calibration data (per-edge two-qubit gate errors, per-qubit metrics, timestamps) and the physical connectivity graph derived from it. Useful for hand-placing circuits on paths that bypass quilc. Both return `None`-equivalents for devices without published calibration data ([#1281](https://github.com/qBraid/qBraid/pull/1281))
 

--- a/qbraid/runtime/rigetti/device.py
+++ b/qbraid/runtime/rigetti/device.py
@@ -417,6 +417,7 @@ class RigettiDevice(QuantumDevice):
             qcs_client=self._qcs_client,
             ro_sources=translation_result.ro_sources,
             execution_options=execution_options,
+            compiled_program=run_input,
         )
 
     # pylint: disable-next=arguments-differ

--- a/qbraid/runtime/rigetti/job.py
+++ b/qbraid/runtime/rigetti/job.py
@@ -67,6 +67,7 @@ class RigettiJob(QuantumJob):
         qcs_client: QCSClient | None = None,
         ro_sources: dict[str, str] | None = None,
         execution_options: ExecutionOptions | None = None,
+        compiled_program: str | None = None,
         **kwargs: Any,
     ):
         """Initialize a RigettiJob.
@@ -87,12 +88,17 @@ class RigettiJob(QuantumJob):
             execution_options: The ``ExecutionOptions`` used at submission
                 time. Reused for ``cancel`` and ``retrieve_results`` so the
                 job hits the same gRPC endpoint that accepted it.
+            compiled_program: The native Quil program produced by quilc that
+                was submitted for translation and execution. ``None`` when
+                rehydrating a job by ID, since compilation output is not
+                retrievable from QCS after submission.
         """
         super().__init__(job_id=job_id, device=device, **kwargs)
         self._qcs_client = qcs_client
         self._num_shots = num_shots
         self._ro_sources = ro_sources or {}
         self._execution_options = execution_options
+        self._compiled_program = compiled_program
         self._status = JobStatus.INITIALIZING
         self._status_message: str | None = None
         self._cached_results: ExecutionResults | None = None
@@ -111,6 +117,17 @@ class RigettiJob(QuantumJob):
         raise RigettiJobError(
             f"RigettiJob {self.id} has no QCSClient: pass qcs_client= or device=."
         )
+
+    @property
+    def compiled_program(self) -> str | None:
+        """The native Quil program produced by quilc for this job, if known.
+
+        Reveals the physical qubits selected and the final rewiring chosen by
+        the compiler — information not recoverable from measurement counts.
+        ``None`` for jobs rehydrated by ID (e.g. on a later status poll),
+        since QCS does not expose compilation output after submission.
+        """
+        return self._compiled_program
 
     @property
     def status_message(self) -> str | None:
@@ -284,6 +301,9 @@ class RigettiJob(QuantumJob):
             raise RigettiJobError(f"Failed to parse execution results for job {self.id}.") from exc
 
         self._status = JobStatus.COMPLETED
+        extra_details: dict[str, Any] = {}
+        if self._compiled_program is not None:
+            extra_details["compiled_program"] = self._compiled_program
         return Result[GateModelResultData](
             device_id=self.device.id,
             job_id=self.id,
@@ -291,4 +311,5 @@ class RigettiJob(QuantumJob):
             data=result_data,
             execution_duration_microseconds=(self._cached_results.execution_duration_microseconds),
             ro_sources=dict(self._ro_sources),
+            **extra_details,
         )

--- a/tests/runtime/rigetti/test_rigetti_device.py
+++ b/tests/runtime/rigetti/test_rigetti_device.py
@@ -797,6 +797,13 @@ class TestRigettiDeviceSubmit:
 
         assert job._ro_sources == ro_sources
 
+    def test_submit_stores_compiled_program_on_job(self, rigetti_device: RigettiDevice) -> None:
+        """The RigettiJob returned by _submit must carry the native Quil it submitted."""
+        quil_str, shots = self._make_quil(shots=2)
+        job, _, _ = _mock_submit_pipeline(rigetti_device, quil_str, shots)
+
+        assert job.compiled_program == quil_str
+
     def test_submit_list_returns_list_of_jobs(self, rigetti_device: RigettiDevice) -> None:
         """Submitting a list of Quil strings must return a list of RigettiJobs."""
         quil_strings = [self._make_quil(shots=3)[0], self._make_quil(shots=3)[0]]

--- a/tests/runtime/rigetti/test_rigetti_job.py
+++ b/tests/runtime/rigetti/test_rigetti_job.py
@@ -169,6 +169,19 @@ class TestRigettiJobProperties:
         job = RigettiJob(job_id="x", num_shots=1, device=rigetti_device)
         assert job._ro_sources == {}
 
+    def test_compiled_program_stored_correctly(self, rigetti_device: RigettiDevice) -> None:
+        """A compiled_program kwarg must be exposed via the compiled_program property."""
+        native_quil = "DECLARE ro BIT[1]\nRX(pi) 0\nMEASURE 0 ro[0]\n"
+        job = RigettiJob(
+            job_id="x", num_shots=1, device=rigetti_device, compiled_program=native_quil
+        )
+        assert job.compiled_program == native_quil
+
+    def test_compiled_program_defaults_to_none(self, rigetti_device: RigettiDevice) -> None:
+        """A rehydrated job (no compiled_program kwarg) must report None."""
+        job = RigettiJob(job_id="x", num_shots=1, device=rigetti_device)
+        assert job.compiled_program is None
+
     def test_execution_options_stored_at_submission_time(
         self, rigetti_device: RigettiDevice
     ) -> None:
@@ -720,6 +733,42 @@ class TestRigettiJobResult:
             res = job.result()
 
         assert isinstance(res, Result)
+
+    def test_result_includes_compiled_program_in_details(
+        self, rigetti_device: RigettiDevice
+    ) -> None:
+        """result() must surface the compiled program in Result.details when known."""
+        exec_results, ro_sources = _make_simple_execution_results([[0, 1], [1, 0]])
+        native_quil = "DECLARE ro BIT[2]\nRX(pi) 0\nMEASURE 0 ro[0]\nMEASURE 1 ro[1]\n"
+        job = RigettiJob(
+            job_id=DUMMY_JOB_ID,
+            device=rigetti_device,
+            num_shots=2,
+            ro_sources=ro_sources,
+            compiled_program=native_quil,
+        )
+
+        with patch(
+            "qbraid.runtime.rigetti.job.retrieve_results",
+            return_value=exec_results,
+        ):
+            res = job.result()
+
+        assert res.details["compiled_program"] == native_quil
+
+    def test_result_omits_compiled_program_when_unknown(
+        self, rigetti_device: RigettiDevice
+    ) -> None:
+        """A rehydrated job (compiled_program=None) must not add a None detail."""
+        job, exec_results = self._make_job_with_results(rigetti_device, [[0, 1], [1, 0]])
+
+        with patch(
+            "qbraid.runtime.rigetti.job.retrieve_results",
+            return_value=exec_results,
+        ):
+            res = job.result()
+
+        assert "compiled_program" not in res.details
 
     def test_result_success_true_on_happy_path(self, rigetti_device: RigettiDevice) -> None:
         """result() must report success=True when get_result() does not raise."""

--- a/tests/runtime/rigetti/test_rigetti_job.py
+++ b/tests/runtime/rigetti/test_rigetti_job.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: disable=no-name-in-module,redefined-outer-name,possibly-used-before-assignment,ungrouped-imports
+# pylint: disable=no-name-in-module,redefined-outer-name,possibly-used-before-assignment,ungrouped-imports,too-many-lines
 
 """Unit tests for RigettiJob."""
 


### PR DESCRIPTION
## Summary

Expose the native Quil program produced by quilc on `RigettiJob`, so callers can recover the physical qubits selected and the compiler's final rewiring for a submitted job — information that is otherwise lost the moment `device.run()` returns, since QCS does not expose compilation output after submission.

- `RigettiDevice._submit` now passes the serialized native Quil (`run_input`, the output of the transform/prepare pipeline) to the `RigettiJob` it constructs.
- `RigettiJob` accepts a `compiled_program: str | None` kwarg, stores it, and exposes it via a new `compiled_program` property. `None` for jobs rehydrated by ID (e.g. later status polls), which is documented on the property.
- When known, `result()` includes it as `Result.details["compiled_program"]`, mirroring how `ro_sources` is surfaced.

This is the SDK half of persisting the compiled circuit into qBraid runtime job results (companion runtime-api change persists it to the GCS `result.json`, following qBraid/qbraid-runtime-api#282 which does the same for Braket-backed devices via `additionalMetadata`).

For Quil-T programs, which bypass quilc, `compiled_program` is the program as submitted to translation — still the native program that executed.

## Testing

- `tests/runtime/rigetti` — 205 passed (5 new: constructor storage/default, `_submit` propagation, `result()` details inclusion/omission).
- `black`/`isort` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
