### PR TITLE
fix(native): expose batch programs and give the submitted program a typed accessor

### DIFF
--- a/qbraid/runtime/native/job.py
+++ b/qbraid/runtime/native/job.py
@@ -54,7 +54,7 @@ class QbraidJob(QuantumJob):
         super().__init__(job_id, device, **kwargs)
         self._device = device
         self._client = client
-        self._compiled_program: Program | None = None
+        self._compiled_program: Program | list[Program] | None = None
 
     @property
     def client(self) -> qbraid_core.services.runtime.QuantumRuntimeClient:
@@ -86,20 +86,36 @@ class QbraidJob(QuantumJob):
             self._cache_metadata.update({**job_data, "status": status})
         return self._cache_metadata["status"]
 
+    def program(self) -> Program | list[Program]:
+        """Return the program submitted with the job.
+
+        For a batch job, returns one ``Program`` per circuit, positionally aligned
+        with the circuits. Single-circuit jobs return a bare ``Program``.
+
+        This is the same object ``metadata()["program"]`` holds, exposed with the
+        schema type ``qbraid_core`` already returns rather than only through the
+        untyped metadata dict.
+        """
+        if self._cache_metadata.get("program") is None:
+            self._cache_metadata["program"] = self.client.get_job_program(self.id)
+        return self._cache_metadata["program"]
+
     def metadata(self) -> dict[str, Any]:
         """Return the metadata regarding the job."""
         self._cache_metadata.pop("job_id", None)
-        if self._cache_metadata.get("program") is None:
-            self._cache_metadata["program"] = self.client.get_job_program(self.id)
+        self.program()
         return super().metadata()
 
-    def compiled_program(self) -> Program | None:
+    def compiled_program(self) -> Program | list[Program] | None:
         """Return the vendor-compiled program that executed on the QPU.
 
         Reveals the physical qubits selected and the logical-to-physical mapping
         chosen by the vendor's compiler — information not recoverable from
         measurement counts. ``format`` is ``"qasm3"`` for IQM and ``"quil"`` for
         Rigetti.
+
+        A batch job compiles one program per circuit, so this returns a list
+        positionally aligned with the circuits, matching :meth:`program`.
 
         Returns ``None`` when the job has no compiled program: the device does
         not report one (simulators), the job has not completed, or it predates

--- a/tests/runtime/native/test_runtime.py
+++ b/tests/runtime/native/test_runtime.py
@@ -17881,6 +17881,69 @@ def test_compiled_program_returns_program():
     assert "MEASURE 81 ro[0]" in compiled.data
 
 
+def test_compiled_program_batch_returns_one_per_circuit():
+    """A batch job compiles one program per circuit, so a list comes back intact."""
+    programs = [Program(format="qasm2", data=f"OPENQASM 2.0; // circuit {i}") for i in range(3)]
+    client = MockClientCompiledProgram(result=programs)
+    job = QbraidJob(job_id=RIGETTI_GET_JOB.jobQrn, client=client)
+
+    compiled = job.compiled_program()
+
+    assert isinstance(compiled, list)
+    assert [p.data for p in compiled] == [p.data for p in programs]
+
+
+def test_compiled_program_single_is_not_wrapped_in_a_list():
+    """Widening the return type must not make single jobs return a one-element list."""
+    program = Program(format="quil", data=COMPILED_QUIL)
+    client = MockClientCompiledProgram(result=program)
+    job = QbraidJob(job_id=RIGETTI_GET_JOB.jobQrn, client=client)
+
+    assert not isinstance(job.compiled_program(), list)
+
+
+def test_program_accessor_returns_schema_object():
+    """`program()` exposes what the client returned, not a raw dict."""
+    program = Program(format="qasm2", data="OPENQASM 2.0;")
+    client = MockClientCompiledProgram(result=None)
+    client.get_job_program = lambda job_qrn: program  # type: ignore[method-assign]
+    job = QbraidJob(job_id=RIGETTI_GET_JOB.jobQrn, client=client)
+
+    assert job.program() is program
+    assert job.metadata()["program"] is program
+
+
+def test_program_accessor_returns_list_for_batch():
+    """A batch job's submitted programs come back as a list, matching compiled_program()."""
+    programs = [Program(format="qasm2", data=f"OPENQASM 2.0; // circuit {i}") for i in range(2)]
+    client = MockClientCompiledProgram(result=None)
+    client.get_job_program = lambda job_qrn: programs  # type: ignore[method-assign]
+    job = QbraidJob(job_id=RIGETTI_GET_JOB.jobQrn, client=client)
+
+    assert job.program() == programs
+    assert job.metadata()["program"] == programs
+
+
+def test_program_is_fetched_once():
+    """`program()` and `metadata()` share one cache slot, so the call is not repeated."""
+    calls = []
+    program = Program(format="qasm2", data="OPENQASM 2.0;")
+    client = MockClientCompiledProgram(result=None)
+
+    def _get(job_qrn):
+        calls.append(job_qrn)
+        return program
+
+    client.get_job_program = _get  # type: ignore[method-assign]
+    job = QbraidJob(job_id=RIGETTI_GET_JOB.jobQrn, client=client)
+
+    job.program()
+    job.metadata()
+    job.program()
+
+    assert len(calls) == 1
+
+
 def test_compiled_program_none_when_absent():
     """A 404 means no compiled program exists, which is not an error."""
     client = MockClientCompiledProgram(error=_service_error(404))


### PR DESCRIPTION
Two changes, both taking the shape `qbraid-core` already returns.

> [!NOTE]
> Depends on qBraid/qbraid-core#288. Without it the client raises a `ValidationError` before either accessor here sees a list.

## `compiled_program()` handles batch

It was typed `Program | None` and handled only a 404. A batch job compiles one program per circuit, so the backend serves a list; that reached the caller as a raw pydantic `ValidationError` from the client rather than anything this method models. Now `Program | list[Program] | None`.

## `program()` is new

The submitted program was only reachable through `metadata()["program"]`, an untyped `dict[str, Any]` slot, even though the client has returned `Program | list[Program]` for some time. That is why `program` never hit the bug `compiled_program` did: nothing narrowed it, so a list flowed through unnoticed. It also meant there was no typed way to ask a job for its program.

```python
job.program()           # Program | list[Program]
job.compiled_program()  # Program | list[Program] | None
```

`metadata()` now delegates to `program()` and the two share one cache slot, so the call is still made at most once and `metadata()["program"]` keeps working for existing callers.

## Verification

Chained against the real client with a mocked session, list payload in:

```
core  -> list ['Program', 'Program', 'Program']
SDK   -> list ['OPENQASM 2.0; // compiled 0', ...]
single-> Program | is list: False
```

Five tests added: batch and single for `compiled_program`, batch and typed-return for `program`, and one asserting `program()`/`metadata()` fetch once between them. 1226 passing across `tests/runtime`.
## Local test failures seen while developing this, both environment-only

Recorded because they cost time to rule out, not because anything here needs changing. CI is green on this branch (Format, CI, Docs, PR Compliance).

- `tests/runtime/test_loader.py::test_get_providers` — the installed dist metadata in the dev env predates #1262, so `get_providers()` reads entry points listing a `qudora` provider that no longer exists and missing `aqt`. `get_providers()` reads installed entry points, not the source tree, so an editable install left stale by a branch switch fails this. `pip install -e .` clears it.
- `tox -e format-check` reporting `E1101: ... has no 'status_code' member` — a stale shared `.tox/linters` envdir. That dir is reused across the pylint, isort, black, ruff and headers stages, so `qbraid-cli` pulled in for headers leaves `qbraid_core` behind, and pylint then tries to statically infer the `HttpStatusMixin.status_code` property. `tox --recreate` gives 10.00/10.
