### PR TITLE
build(tox): give each linter its own envdir and bound the unpinned tools

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -58,36 +58,37 @@ deps = -r{toxinidir}/docs/requirements.txt
 commands =
     sphinx-build -W -b html docs/ docs/build/html {posargs}
 
+# Every linter env below gets its own envdir (tox's default). They used to share
+# .tox/linters, which meant tox tore the directory down and reinstalled it on
+# every switch between stages, and each stage saw whatever the previous one had
+# left behind. Upper bounds are on all five tools for the same reason black and
+# ruff already carry them: an unpinned linter silently changes what CI enforces.
+
 [testenv:isort]
-envdir = .tox/linters
 skip_install = true
-deps = isort
+deps = isort<9
 commands =
     isort . {posargs} qbraid bin tests
 
 [testenv:pylint]
-envdir = .tox/linters
 skip_install = true
-deps = pylint
+deps = pylint<5
 commands =
     pylint {posargs} qbraid bin tests
 
 [testenv:black]
-envdir = .tox/linters
 skip_install = true
 deps = black<=25.12.0
 commands =
     black qbraid bin tests {posargs}
 
 [testenv:mypy]
-envdir = .tox/linters
 skip_install = true
-deps = mypy
+deps = mypy<3
 commands =
     mypy qbraid tests bin {posargs}
 
 [testenv:ruff]
-envdir = .tox/linters
 skip_install = true
 # ruff 0.16.0 changed default lint rules and flags ~742 pre-existing issues
 # repo-wide; pin until we adopt its defaults (or write an explicit select).
@@ -96,7 +97,6 @@ commands =
     ruff check qbraid tests bin {posargs}
 
 [testenv:headers]
-envdir = .tox/linters
 skip_install = true
 deps = qbraid-cli>=0.12.0
 commands =
@@ -104,7 +104,6 @@ commands =
 
 [testenv:linters]
 allowlist_externals = qbraid
-envdir = .tox/linters
 skip_install = true
 deps =
     {[testenv:isort]deps}
@@ -117,7 +116,6 @@ commands =
 
 [testenv:format-check]
 allowlist_externals = qbraid
-envdir = .tox/linters
 skip_install = true
 deps =
     {[testenv:pylint]deps}


### PR DESCRIPTION
All six linter envs shared `envdir = .tox/linters` while declaring different deps. tox keys an envdir to the dep set that built it, so switching stages tears the directory down and rebuilds it.

## Two consequences

**Stages reinstall each other.** Measured, running `headers` after `pylint`:

| | setup time |
|---|---|
| shared envdir (before) | 4.28 s |
| own envdir (after) | 0.05 s |

**Each tool's inputs depend on the entry point.** `tox -e pylint` installs pylint alone, so pylint cannot import `qbraid_core` and never infers types from it. The pylint stage inside `tox -e format-check` runs with `qbraid_core` present, pulled in by the `qbraid-cli` that `headers` needs:

```
after tox -e pylint         ->  qbraid_core in env: absent
after tox -e format-check   ->  qbraid_core in env: present
```

Same `pylint qbraid bin tests`, two different dependency sets. A reused `.tox/linters` carries whichever set landed there last, which is enough for a local run to disagree with CI, since CI always builds the directory fresh. I hit exactly that: a local `format-check` reporting four `E1101: ... has no 'status_code' member` errors that do not reproduce on a clean env or in CI.

## Also: bound the unpinned tools

`pylint`, `isort` and `mypy` were unpinned. `black` and `ruff` already carry upper bounds with comments naming the incidents that put them there, most recently ruff 0.16.0 changing default rules and surfacing ~742 pre-existing issues repo-wide (#1296). An unpinned linter changes what CI enforces without a commit, so all five are bounded now.

Resolved versions today are `pylint 4.0.7`, `isort 8.0.1`, `mypy 2.3.0`, all inside the new bounds, so this pins the status quo rather than moving anything.

## Trade-off

Six small tool envs instead of one shared directory, so more disk locally. CI is unaffected on cold install since it starts empty either way, and warm local runs get faster because switching stages no longer reinstalls.

## Verification

`tox -e format-check` from a cold `.tox`: **10.00/10**, all five stages pass. The `headers -> pylint -> headers` sequence reuses both envs instead of rebuilding.
