### PR TITLE
fix(tests): unskip the OQC suite, silently dead since schemas moved to qbraid-core

### DIFF
--- a/tests/runtime/oqc/test_oqc_runtime.py
+++ b/tests/runtime/oqc/test_oqc_runtime.py
@@ -44,7 +44,7 @@ try:
     from qbraid.runtime.exceptions import ResourceNotFoundError
     from qbraid.runtime.oqc import OQCDevice, OQCJob, OQCProvider
     from qbraid.runtime.postprocess import counts_to_probabilities
-    from qbraid.runtime.schemas.base import USD
+    from qbraid_core.decimal import USD
 
     FIXTURE_COUNT = sum(key in NATIVE_REGISTRY for key in ["qiskit", "braket", "cirq"])
 

--- a/tests/runtime/oqc/test_oqc_runtime.py
+++ b/tests/runtime/oqc/test_oqc_runtime.py
@@ -36,6 +36,7 @@ from qbraid.runtime.enums import DeviceStatus
 from qbraid.runtime.exceptions import ResourceNotFoundError
 
 try:
+    from qbraid_core.decimal import USD
     from qcaas_client.client import OQCClient, QPUTask, QPUTaskErrors, QPUTaskResult  # type: ignore
 
     from qbraid.programs import NATIVE_REGISTRY, ExperimentType, ProgramSpec
@@ -44,7 +45,6 @@ try:
     from qbraid.runtime.exceptions import ResourceNotFoundError
     from qbraid.runtime.oqc import OQCDevice, OQCJob, OQCProvider
     from qbraid.runtime.postprocess import counts_to_probabilities
-    from qbraid_core.decimal import USD
 
     FIXTURE_COUNT = sum(key in NATIVE_REGISTRY for key in ["qiskit", "braket", "cirq"])
 


### PR DESCRIPTION
### All 35 OQC tests have been skipping — in CI as well as locally

The reported reason is *"qcaas_client not installed"*. That reason is wrong: CI installs `oqc-qcaas-client 3.22.1`, and it appears in the dependency freeze of every passing run.

The real cause is a stale import inside the module's `try`/`except` guard:

```python
from qbraid.runtime.schemas.base import USD
```

`qbraid.runtime.schemas` no longer exists — the only copy left in the tree is a `build/lib` artifact. `USD` moved to `qbraid_core.decimal`, which is where `qbraid/runtime/oqc/provider.py` already imports it from.

That `ImportError` was caught by the guard written for a missing `qcaas_client`, so the module reported the wrong reason and nobody looked again. **A broad `except ImportError` in a skip guard turns an unrelated breakage into a silent skip** — the suite stayed green while covering nothing.

### Effect of the one-line fix

```
tests/runtime   before   1222 passed,  60 skipped
                after    1259 passed,  25 skipped
```

Same 10 pre-existing failures (3 Azure remote needing credentials, 6 `compiled_program`, 1 `test_loader`), no new ones. **Every one of the 35 passes as written** — none needed updating, which is itself worth noting: the coverage was correct all along, just never executed.

### Why it is separate

Found while investigating a `codecov/patch` failure on #1327, where a newly added OQC test appeared to run and did not. Kept out of that PR because it is worth having regardless of which bit-order convention wins, and because 35 silently-dead tests deserve their own visibility rather than being a footnote in a breaking change.

Once this lands, #1327's OQC coverage becomes real.

### Verification

`tests/runtime/oqc`: **36 passed** (was 34 skipped). Repo-wide isort back to `main`'s 8 pre-existing errors; pylint on the file unchanged from `main` at 9.84/10.
