### PR TITLE
docs(readme): list aqt_connector in the QPROGRAM_REGISTRY example

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Below, `QPROGRAM_REGISTRY` maps shorthand identifiers for supported quantum prog
  'pyqpanda3': pyqpanda3.core.QProg,
  'autoqasm': autoqasm.program.program.Program,
  'qrisp': qrisp.circuit.quantum_circuit.QuantumCircuit,
+ 'aqt_connector': aqt_connector.models.circuits.QuantumCircuit,
  'qat': qat.core.wrappers.circuit.Circuit}
 ```
 


### PR DESCRIPTION
## Summary of changes

The AQT provider ([#1262](https://github.com/qBraid/qBraid/pull/1262)) registers `aqt_connector` as a native program type, and [#1305](https://github.com/qBraid/qBraid/pull/1305) settled it on the package-derived alias. The README's `QPROGRAM_REGISTRY` example never picked it up, so the one place a reader looks for "what can I transpile to?" omits AQT.

One line:

```diff
  'qrisp': qrisp.circuit.quantum_circuit.QuantumCircuit,
+ 'aqt_connector': aqt_connector.models.circuits.QuantumCircuit,
  'qat': qat.core.wrappers.circuit.Circuit}
```

**Placement.** Before `qat`, matching the real registry order: `aqt_connector` closes `dynamic_type_registry`, while `qat` comes from `dynamic_non_native`, which `_QPROGRAM_REGISTRY` merges in afterward.

