### PR TITLE
Add OpenSSF Scorecard workflow to publish a public security score

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,7 +8,17 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
-permissions: read-all
+# Four triggers can overlap, and Scorecard reports current repository state, so a
+# superseded run has nothing to contribute. Cancelling keeps the published SARIF and the
+# public API entry in trigger order.
+concurrency:
+  group: scorecard
+  cancel-in-progress: true
+
+# Least privilege by default: `analysis` names everything it needs below, and a job added
+# later gets nothing until it does the same. Job-level permissions replace this block
+# rather than adding to it.
+permissions: {}
 
 jobs:
   analysis:
@@ -18,29 +28,34 @@ jobs:
       security-events: write   # upload SARIF to code scanning
       id-token: write          # publish results to the public Scorecard API
       contents: read
+      # Lets Scorecard read workflow definitions and run history. Documented by the
+      # upstream starter workflow as required for private repositories; this repo is
+      # public, so it is retained only as a safeguard should that ever change.
       actions: read
 
+    # Actions are pinned to full commit SHAs: a tag is mutable and can be repointed at
+    # other code, which is what Scorecard's own Pinned-Dependencies check looks for.
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload to code scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@42947a340483f03ba47bb1a039b2c519aab3df85 # v3.37.8
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,46 @@
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '31 5 * * 1'
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # upload SARIF to code scanning
+      id-token: write          # publish results to the public Scorecard API
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Adds the OpenSSF Scorecard action, which grades a repository against a set of
supply-chain security checks and publishes the result publicly.

`qBraid/qBraid` has no published Scorecard today (`api.securityscorecards.dev` returns
nothing for it), so there is currently no third-party measure of the project's security
posture. After the first run there will be a score at
`https://api.securityscorecards.dev/projects/github.com/qBraid/qBraid`, and a badge is
available if we want one in the README.

### What it does

Runs weekly and on pushes to `main`, checks things like branch protection, signed
releases, dependency pinning, token permissions, fuzzing and CI tests, uploads SARIF to
code scanning, and publishes the aggregate score.

### Notes

- `publish_results: true` is what makes the score publicly visible. It reports only the
  check results, not source.
- This complements the CodeQL default setup already enabled here. CodeQL analyzes code for
  vulnerabilities; Scorecard grades the project's practices around that code.
- Expect the initial score to be middling. Several checks will fail on things we already
  know about, including the long-lived PyPI token in `publish.yml` and the absence of
  signed releases. That is the point of establishing a baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated security posture analysis for branch protection changes, weekly runs, main-branch updates, and manual requests.
  * Security findings are now published to code scanning, with short-term result retention for review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->