### PR TITLE
fix(transpiler): declare cirq cregs in key order, not moment order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Writing an entry:
 ### Removed
 
 ### Fixed
+- Fixed measurement results coming back permuted when a Cirq circuit reaches pyQuil through `qasm2`. Cirq declares one `creg` per measurement key in scheduling order, so a measurement on an idle qubit was declared first; flattening those registers into one readout region then followed declaration order and moved qubit 2's result into bit 0. Registers are now declared in key order ([#1345](https://github.com/qBraid/qBraid/pull/1345))
 - Fixed Cirq → pyQuil conversion failing with `ProgramConversionError` for circuits containing `cirq.reset` / `cirq.ResetChannel`. Resets now convert directly to Quil `RESET` on the target qubit; qudit resets (dimension > 2) still raise, since Quil `RESET` is qubit-only ([#1333](https://github.com/qBraid/qBraid/pull/1333))
 - Fixed `test_qrisp_coverage[pytket]` flipping between pass and fail on identical commits. Four qrisp → pytket gate conversions are broken upstream and one of them fails only in certain contexts, leaving the threshold straddling the pass/fail line. Those four are now skipped by name, and the pytket baseline rises to 0.95 to match the other targets ([#1337](https://github.com/qBraid/qBraid/pull/1337))
 - Fixed batch result counts padding every circuit to the widest register. Each circuit now

--- a/qbraid/transpiler/conversions/cirq/cirq_to_qasm2.py
+++ b/qbraid/transpiler/conversions/cirq/cirq_to_qasm2.py
@@ -65,7 +65,7 @@ def _order_cregs_by_key(qasm: str) -> str:
         return (0, match["register"], int(match["index"]), index)
 
     reordered = [lines[i] for i in sorted(positions, key=sort_key)]
-    for slot, line in zip(positions, reordered):
+    for slot, line in zip(positions, reordered, strict=True):
         lines[slot] = line
     return "".join(lines)
 

--- a/qbraid/transpiler/conversions/cirq/cirq_to_qasm2.py
+++ b/qbraid/transpiler/conversions/cirq/cirq_to_qasm2.py
@@ -18,6 +18,7 @@ Module for conversions between Cirq Circuits and QASM strings
 """
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, Optional
 
 import cirq
@@ -29,6 +30,44 @@ from qbraid.transpiler.annotations import weight
 
 if TYPE_CHECKING:
     from qbraid.programs.typer import Qasm2StringType
+
+
+_CREG = re.compile(r"^creg\s+(?P<name>\w+)\s*\[(?P<size>\d+)\]\s*;\s*$")
+_BIT_INDEX = re.compile(r"^(?P<register>.+)_(?P<index>\d+)$")
+
+
+def _order_cregs_by_key(qasm: str) -> str:
+    """Emit ``creg`` declarations in measurement-key order rather than moment order.
+
+    Cirq writes one ``creg`` per measurement key in the order the measurements are
+    scheduled, so an idle qubit whose measurement packs into an earlier moment gets its
+    register declared first. Nothing is wrong with the QASM -- each register is named and
+    its ``measure`` is correct -- but consumers that flatten the registers into one
+    readout region do so in declaration order (``openqasm3_to_pyquil``, matching how
+    ``RigettiJob`` reads them back, #1314). Declaration order therefore has to reflect the
+    keys, or the flattened bits come out permuted relative to the source.
+
+    Registers are sorted the way ``cirq_to_pyquil`` orders its merged measurements: by the
+    ``(register, index)`` parsed from the key, so ``m_c_0`` precedes ``m_c_2``. Names that
+    do not carry an index keep their relative order, and the declarations are rewritten in
+    place so surrounding statements are untouched.
+    """
+    lines = qasm.splitlines(keepends=True)
+    positions = [i for i, line in enumerate(lines) if _CREG.match(line)]
+    if len(positions) < 2:
+        return qasm
+
+    def sort_key(index: int) -> tuple:
+        name = _CREG.match(lines[index])["name"]
+        match = _BIT_INDEX.match(name)
+        if match is None:
+            return (1, "", 0, index)
+        return (0, match["register"], int(match["index"]), index)
+
+    reordered = [lines[i] for i in sorted(positions, key=sort_key)]
+    for slot, line in zip(positions, reordered):
+        lines[slot] = line
+    return "".join(lines)
 
 
 @value.value_equality
@@ -111,6 +150,6 @@ def cirq_to_qasm2(
         Qasm2StringType: QASM string equivalent to the input Cirq circuit.
     """
     circuit = map_zpow_and_unroll(circuit)
-    qasm = str(_to_qasm_output(circuit, header, precision, qubit_order))
+    qasm = _order_cregs_by_key(str(_to_qasm_output(circuit, header, precision, qubit_order)))
     # format the qasm before returning
     return pyqasm.dumps(pyqasm.loads(qasm))

--- a/tests/transpiler/cirq/test_conversions_cirq.py
+++ b/tests/transpiler/cirq/test_conversions_cirq.py
@@ -25,6 +25,8 @@ import pytest
 from qbraid.interface.circuit_equality import circuits_allclose
 from qbraid.programs import NATIVE_REGISTRY, load_program
 from qbraid.transpiler.conversions import conversion_functions
+from qbraid.transpiler.conversions.cirq import cirq_to_qasm2
+from qbraid.transpiler.conversions.qasm2 import qasm2_to_pyquil
 from qbraid.transpiler.converter import transpile
 from qbraid.transpiler.graph import ConversionGraph
 
@@ -88,3 +90,45 @@ def test_convert_circuit_with_global_phase_from_cirq(frontend):
         pytest.skip(f"Unitary calculation not implemented for {frontend}")
 
     assert circuits_allclose(cirq_circuit, test_circuit)
+
+
+def test_cirq_to_qasm2_declares_cregs_in_key_order():
+    """Classical registers follow the measurement keys, not the moments.
+
+    Cirq schedules a measurement on an idle qubit into an earlier moment and declares its
+    register first, so ``c_2`` preceded ``c_0``. Consumers that flatten the registers into
+    one readout region do so in declaration order, which then permutes the bits relative
+    to the keys.
+    """
+    q = cirq.LineQubit.range(3)
+    circuit = cirq.Circuit(
+        cirq.ops.X(q[0]),
+        cirq.ops.X(q[1]),  # q[2] is idle, so its measurement packs into moment 0
+        [cirq.ops.measure(qb, key=f"c_{i}") for i, qb in enumerate(q)],
+    )
+    cregs = [line for line in cirq_to_qasm2(circuit).splitlines() if line.startswith("creg")]
+    assert cregs == ["creg m_c_0[1];", "creg m_c_1[1];", "creg m_c_2[1];"]
+
+
+def test_cirq_to_pyquil_via_qasm2_keeps_readout_bit_order():
+    """The composed route lands qubit i in bit i, as the direct edge does.
+
+    Regression test for the readout permutation: preparing the asymmetric pattern (1,1,0)
+    read back as (0,1,1) through this route, because the flattened register followed
+    declaration order and cirq had declared the registers out of key order.
+    """
+    q = cirq.LineQubit.range(3)
+    circuit = cirq.Circuit(
+        cirq.ops.X(q[0]),
+        cirq.ops.X(q[1]),
+        [cirq.ops.measure(qb, key=f"c_{i}") for i, qb in enumerate(q)],
+    )
+    program = qasm2_to_pyquil(cirq_to_qasm2(circuit))
+    # Statement order still follows the moments; what matters is which bit each qubit
+    # lands in, so assert the mapping rather than the order the MEASUREs appear in.
+    bit_to_qubit = {}
+    for line in program.out().splitlines():
+        if line.startswith("MEASURE"):
+            _, qubit, register = line.split()
+            bit_to_qubit[int(register.split("[")[1].rstrip("]"))] = int(qubit)
+    assert bit_to_qubit == {0: 0, 1: 1, 2: 2}

--- a/tests/transpiler/cirq/test_conversions_cirq.py
+++ b/tests/transpiler/cirq/test_conversions_cirq.py
@@ -26,7 +26,6 @@ from qbraid.interface.circuit_equality import circuits_allclose
 from qbraid.programs import NATIVE_REGISTRY, load_program
 from qbraid.transpiler.conversions import conversion_functions
 from qbraid.transpiler.conversions.cirq import cirq_to_qasm2
-from qbraid.transpiler.conversions.qasm2 import qasm2_to_pyquil
 from qbraid.transpiler.converter import transpile
 from qbraid.transpiler.graph import ConversionGraph
 
@@ -117,12 +116,17 @@ def test_cirq_to_pyquil_via_qasm2_keeps_readout_bit_order():
     read back as (0,1,1) through this route, because the flattened register followed
     declaration order and cirq had declared the registers out of key order.
     """
+    pytest.importorskip("pyquil")  # capped below Python 3.13
     q = cirq.LineQubit.range(3)
     circuit = cirq.Circuit(
         cirq.ops.X(q[0]),
         cirq.ops.X(q[1]),
         [cirq.ops.measure(qb, key=f"c_{i}") for i, qb in enumerate(q)],
     )
+    from qbraid.transpiler.conversions.qasm2 import (  # pylint: disable=import-outside-toplevel
+        qasm2_to_pyquil,
+    )
+
     program = qasm2_to_pyquil(cirq_to_qasm2(circuit))
     # Statement order still follows the moments; what matters is which bit each qubit
     # lands in, so assert the mapping rather than the order the MEASUREs appear in.

--- a/tests/transpiler/cirq/test_conversions_cirq.py
+++ b/tests/transpiler/cirq/test_conversions_cirq.py
@@ -136,3 +136,28 @@ def test_cirq_to_pyquil_via_qasm2_keeps_readout_bit_order():
             _, qubit, register = line.split()
             bit_to_qubit[int(register.split("[")[1].rstrip("]"))] = int(qubit)
     assert bit_to_qubit == {0: 0, 1: 1, 2: 2}
+
+
+def test_cirq_to_qasm2_leaves_unindexed_creg_names_in_place():
+    """Keys without a trailing index keep their relative order and their own register.
+
+    Reordering only makes sense for keys that name a bit position (``c_0``, ``c_1``).
+    A key like ``alpha`` carries no index, so there is nothing to sort it by and the
+    declaration it produced is left where cirq put it -- each qubit still measures into
+    its own register, which is what the reorder must not disturb.
+    """
+    q = cirq.LineQubit.range(3)
+    keys = ["alpha", "beta", "gamma"]
+    circuit = cirq.Circuit(
+        cirq.ops.X(q[0]),
+        cirq.ops.X(q[1]),
+        [cirq.ops.measure(qb, key=key) for qb, key in zip(q, keys)],
+    )
+    qasm = cirq_to_qasm2(circuit)
+    cregs = [line for line in qasm.splitlines() if line.startswith("creg")]
+    assert sorted(cregs) == sorted(f"creg m_{key}[1];" for key in keys)
+
+    # every qubit still lands in its own register, one bit each
+    measures = [line for line in qasm.splitlines() if line.startswith("measure")]
+    assert len(measures) == len(keys)
+    assert len({line.split("->")[1].strip() for line in measures}) == len(keys)


### PR DESCRIPTION
## Summary of changes

Closes #1344.

A measured Cirq circuit converted to pyQuil **through `qasm2`** came back with its readout permuted. Preparing the asymmetric pattern `(1,1,0)` read back as `(0,1,1)`.

```python
q = LineQubit.range(3)
circuit = Circuit(ops.X(q[0]), ops.X(q[1]),          # q[2] idle
                  [ops.measure(qb, key=f"c_{i}") for i, qb in enumerate(q)])
qasm2_to_pyquil(cirq_to_qasm2(circuit))   # MEASURE 2 ro[0]  <- q2 in bit 0
```

## Why the fix is here and not downstream

Cirq writes one `creg` per measurement key in **scheduling** order. Because `q[2]` is idle its measurement packs into moment 0, so `m_c_2` is declared ahead of `m_c_0`. The QASM is not wrong — every register is named and its `measure` is correct.

The permutation appears where `openqasm3_to_pyquil` flattens those registers into a single `ro` region **in declaration order**. That behaviour is deliberate: #1301 routed `qasm2 -> pyquil` through `openqasm3` to get one contiguous register, and #1314 made `RigettiJob` read registers back in DECLARE order after a confirmed production corruption. Changing the flattening would overturn a convention two prior PRs established, so the fix belongs upstream — declaration order has to reflect the keys.

Registers are now sorted the way `cirq_to_pyquil` orders its merged measurements: by the `(register, index)` parsed from the key. Names without an index keep their relative order, and single-register programs return early untouched.

## Scope

Already reachable on `main` for the eight pairs that route through `qasm2 -> pyquil` — `cudaq`, `pennylane`, `pyqpanda3`, `pytket`, `qasm2`, `qibo`, `qiskit`, `qrisp`. Not introduced by #1312, though that PR routes `cirq`, `braket` and `stim` onto the same path, which is how it surfaced.

## Testing

Two regression tests, both verified to fail without the change: one asserts the `creg` declaration order, one asserts the composed route lands qubit *i* in bit *i*. The second checks the bit **mapping** rather than statement order, since `MEASURE` statements still follow the moments — only the register assignment matters.

Full suite green apart from `test_cirq_pytket_direct_conversions`, which fails on `main` too.

## Why it survived this long

It is moment-structure dependent. `Circuit(X, X, [measures])` reproduces it; `Circuit(X, X) + Circuit([measures])` does not, because the measurements then occupy their own moment and the registers come out in key order anyway. Circuits where every qubit is gated before measurement are unaffected — which is what the existing benchmarks use.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Cirq-to-pyQuil QASM2 conversions so measurement results preserve the correct qubit and readout-bit ordering.
  - Ensured classical register declarations follow measurement-key order during conversion.

- **Tests**
  - Added regression coverage for classical-register ordering and measurement readout mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->