### PR TITLE
fix(runtime): add missing loader overloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Writing an entry:
 ### Removed
 
 ### Fixed
+- Fixed `load_provider()` and `load_job()` returning only base types to static type checkers for AQT, Pasqal, Quantinuum, QUDORA, and Rigetti ([#1350](https://github.com/qBraid/qBraid/pull/1350)).
 - Fixed Open Quantum provider and job discovery through `get_providers()`, `load_provider()`, and `load_job()` ([#1347](https://github.com/qBraid/qBraid/pull/1347))
 - Fixed measurement results coming back permuted when a Cirq circuit reaches pyQuil through `qasm2`. Cirq declares one `creg` per measurement key in scheduling order, so a measurement on an idle qubit was declared first; flattening those registers into one readout region then followed declaration order and moved qubit 2's result into bit 0. Registers are now declared in key order ([#1345](https://github.com/qBraid/qBraid/pull/1345))
 - Fixed Cirq → pyQuil conversion failing with `ProgramConversionError` for circuits containing `cirq.reset` / `cirq.ResetChannel`. Resets now convert directly to Quil `RESET` on the target qubit; qudit resets (dimension > 2) still raise, since Quil `RESET` is qubit-only ([#1333](https://github.com/qBraid/qBraid/pull/1333))

--- a/qbraid/runtime/loader.py
+++ b/qbraid/runtime/loader.py
@@ -26,6 +26,7 @@ from qbraid.exceptions import QbraidError
 
 if TYPE_CHECKING:
     from qbraid.runtime import QuantumJob, QuantumProvider
+    from qbraid.runtime.aqt import AQTJob, AQTProvider
     from qbraid.runtime.aws import BraketProvider, BraketQuantumTask
     from qbraid.runtime.azure import AzureQuantumJob, AzureQuantumProvider
     from qbraid.runtime.ibm import QiskitJob, QiskitRuntimeProvider
@@ -34,6 +35,10 @@ if TYPE_CHECKING:
     from qbraid.runtime.openquantum import OpenQuantumJob, OpenQuantumProvider
     from qbraid.runtime.oqc import OQCJob, OQCProvider
     from qbraid.runtime.origin import OriginJob, OriginProvider
+    from qbraid.runtime.pasqal import PasqalJob, PasqalProvider
+    from qbraid.runtime.quantinuum import QuantinuumJob, QuantinuumProvider
+    from qbraid.runtime.qudora import QudoraJob, QudoraProvider
+    from qbraid.runtime.rigetti import RigettiJob, RigettiProvider
 
 
 class JobLoaderError(QbraidError):
@@ -42,6 +47,10 @@ class JobLoaderError(QbraidError):
 
 class ProviderLoaderError(QbraidError):
     """Raised when an error occurs while loading a quantum provider."""
+
+
+@overload
+def load_job(job_id: str, provider: Literal["aqt"], **kwargs) -> AQTJob: ...
 
 
 @overload
@@ -74,6 +83,22 @@ def load_job(job_id: str, provider: Literal["oqc"], **kwargs) -> OQCJob: ...
 
 @overload
 def load_job(job_id: str, provider: Literal["origin"], **kwargs) -> OriginJob: ...
+
+
+@overload
+def load_job(job_id: str, provider: Literal["pasqal"], **kwargs) -> PasqalJob: ...
+
+
+@overload
+def load_job(job_id: str, provider: Literal["quantinuum"], **kwargs) -> QuantinuumJob: ...
+
+
+@overload
+def load_job(job_id: str, provider: Literal["qudora"], **kwargs) -> QudoraJob: ...
+
+
+@overload
+def load_job(job_id: str, provider: Literal["rigetti"], **kwargs) -> RigettiJob: ...
 
 
 @overload
@@ -120,6 +145,10 @@ def get_providers() -> list[str]:
 
 
 @overload
+def load_provider(provider_name: Literal["aqt"], **kwargs) -> AQTProvider: ...
+
+
+@overload
 def load_provider(provider_name: Literal["native", "qbraid"], **kwargs) -> QbraidProvider: ...
 
 
@@ -149,6 +178,22 @@ def load_provider(provider_name: Literal["oqc"], **kwargs) -> OQCProvider: ...
 
 @overload
 def load_provider(provider_name: Literal["origin"], **kwargs) -> OriginProvider: ...
+
+
+@overload
+def load_provider(provider_name: Literal["pasqal"], **kwargs) -> PasqalProvider: ...
+
+
+@overload
+def load_provider(provider_name: Literal["quantinuum"], **kwargs) -> QuantinuumProvider: ...
+
+
+@overload
+def load_provider(provider_name: Literal["qudora"], **kwargs) -> QudoraProvider: ...
+
+
+@overload
+def load_provider(provider_name: Literal["rigetti"], **kwargs) -> RigettiProvider: ...
 
 
 @overload

--- a/tests/runtime/test_loader.py
+++ b/tests/runtime/test_loader.py
@@ -17,11 +17,13 @@ Unit tests for loading jobs using entrypoints
 
 """
 
+import ast
 from pathlib import Path
 
 import pytest
 
 import qbraid.runtime
+import qbraid.runtime.loader as runtime_loader
 from qbraid._entrypoints import get_entrypoints
 from qbraid.runtime import (
     PROVIDERS,
@@ -105,6 +107,56 @@ def test_runtime_modules_have_provider_and_job_entrypoints():
 
     assert expected_entrypoints <= set(get_entrypoints("providers"))
     assert expected_entrypoints <= set(get_entrypoints("jobs"))
+
+
+def _literal_overload_names(function_name: str, parameter_name: str) -> set[str]:
+    """Return the string literals accepted by a loader's overloads."""
+    loader_tree = ast.parse(Path(runtime_loader.__file__).read_text(encoding="utf-8"))
+    names: set[str] = set()
+
+    for node in loader_tree.body:
+        if not isinstance(node, ast.FunctionDef) or node.name != function_name:
+            continue
+        if not any(
+            isinstance(decorator, ast.Name) and decorator.id == "overload"
+            for decorator in node.decorator_list
+        ):
+            continue
+
+        parameters = dict(zip((arg.arg for arg in node.args.args), node.args.args))
+        annotation = parameters[parameter_name].annotation
+        if not (
+            isinstance(annotation, ast.Subscript)
+            and isinstance(annotation.value, ast.Name)
+            and annotation.value.id == "Literal"
+        ):
+            continue
+
+        values = (
+            annotation.slice.elts if isinstance(annotation.slice, ast.Tuple) else [annotation.slice]
+        )
+        names.update(
+            value.value
+            for value in values
+            if isinstance(value, ast.Constant) and isinstance(value.value, str)
+        )
+
+    return names
+
+
+@pytest.mark.parametrize(
+    ("function_name", "parameter_name", "entrypoint_group"),
+    [
+        ("load_provider", "provider_name", "providers"),
+        ("load_job", "provider", "jobs"),
+    ],
+)
+def test_loader_overloads_match_entrypoints(function_name, parameter_name, entrypoint_group):
+    """Test that loader overloads cover every registered provider and legacy alias."""
+    legacy_aliases = {"braket", "native", "qiskit"}
+    expected_names = set(get_entrypoints(entrypoint_group)) | legacy_aliases
+
+    assert _literal_overload_names(function_name, parameter_name) == expected_names
 
 
 def test_load_provider(mock_client):


### PR DESCRIPTION
## Summary of changes

Closes #1334.

Adds concrete `load_provider()` and `load_job()` overloads for AQT, Pasqal, Quantinuum, QUDORA, and Rigetti.

Adds a regression test that compares the loader overload names with the registered provider and job entry points. The existing `braket`, `native`, and `qiskit` aliases remain supported.

## Testing

- `python -m pytest tests/runtime/test_loader.py -q`
- `python -m black --check qbraid/runtime/loader.py tests/runtime/test_loader.py`
- `python -m ruff check qbraid/runtime/loader.py tests/runtime/test_loader.py`
- targeted mypy check