### PR TITLE
fix(runtime): reject unrecognized job statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Writing an entry:
 ### Removed
 
 ### Fixed
+- Fixed AWS and IBM jobs silently returning `UNKNOWN` when a vendor reports an unrecognized status ([#1351](https://github.com/qBraid/qBraid/pull/1351)).
 - Fixed Open Quantum provider and job discovery through `get_providers()`, `load_provider()`, and `load_job()` ([#1347](https://github.com/qBraid/qBraid/pull/1347))
 - Fixed measurement results coming back permuted when a Cirq circuit reaches pyQuil through `qasm2`. Cirq declares one `creg` per measurement key in scheduling order, so a measurement on an idle qubit was declared first; flattening those registers into one readout region then followed declaration order and moved qubit 2's result into bit 0. Registers are now declared in key order ([#1345](https://github.com/qBraid/qBraid/pull/1345))
 - Fixed Cirq → pyQuil conversion failing with `ProgramConversionError` for circuits containing `cirq.reset` / `cirq.ResetChannel`. Resets now convert directly to Quil `RESET` on the target qubit; qudit resets (dimension > 2) still raise, since Quil `RESET` is qubit-only ([#1333](https://github.com/qBraid/qBraid/pull/1333))

--- a/qbraid/runtime/aws/job.py
+++ b/qbraid/runtime/aws/job.py
@@ -68,7 +68,12 @@ class BraketQuantumTask(QuantumJob):
     def status(self):
         """Returns status from Braket QuantumTask object metadata."""
         state = self._task.state()
-        status = AWS_TASK_STATUS_MAP.get(state, JobStatus.UNKNOWN)
+        if state not in AWS_TASK_STATUS_MAP:
+            raise ValueError(
+                f"Unknown AWS task status '{state}'. "
+                f"Expected one of: {', '.join(AWS_TASK_STATUS_MAP)}"
+            )
+        status = AWS_TASK_STATUS_MAP[state]
         self._cache_metadata["status"] = status
         return status
 

--- a/qbraid/runtime/ibm/job.py
+++ b/qbraid/runtime/ibm/job.py
@@ -96,7 +96,12 @@ class QiskitJob(QuantumJob):
         """Returns status from Qiskit Job object."""
         job_status = self._job.status()
         job_status = job_status if isinstance(job_status, str) else job_status.name
-        status = IBM_JOB_STATUS_MAP.get(job_status, JobStatus.UNKNOWN)
+        if job_status not in IBM_JOB_STATUS_MAP:
+            raise ValueError(
+                f"Unknown IBM job status '{job_status}'. "
+                f"Expected one of: {', '.join(IBM_JOB_STATUS_MAP)}"
+            )
+        status = IBM_JOB_STATUS_MAP[job_status]
         self._cache_metadata["status"] = status
         return status
 

--- a/tests/runtime/aws/test_braket_ahs.py
+++ b/tests/runtime/aws/test_braket_ahs.py
@@ -541,6 +541,7 @@ def test_get_counts_error():
 def test_ahs_task_result(ahs_result):
     """Test result method for an AHS task."""
     mock_task = Mock(spec=AwsQuantumTask)
+    mock_task.state.return_value = "COMPLETED"
     mock_task.result.return_value = ahs_result
     mock_task.metadata.return_value = {
         "status": "COMPLETED",

--- a/tests/runtime/aws/test_braket_runtime.py
+++ b/tests/runtime/aws/test_braket_runtime.py
@@ -696,6 +696,24 @@ def test_job_load_completed(mock_aws_quantum_task, mock_partial_measurements):
     assert data.measurements is not None
 
 
+def test_job_status_rejects_unknown_state():
+    """Test that an unrecognized Braket task state raises a clear error."""
+    task = Mock()
+    task.state.return_value = "PAUSED"
+    job = BraketQuantumTask("task_arn", task)
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Unknown AWS task status 'PAUSED'. Expected one of: "
+            "CREATED, QUEUED, RUNNING, CANCELLING, CANCELLED, COMPLETED, FAILED"
+        ),
+    ):
+        job.status()
+
+    assert "status" not in job._cache_metadata
+
+
 @pytest.mark.parametrize("position,expected", [(10, 10), (">2000", 2000)])
 @patch("qbraid.runtime.aws.job.AwsQuantumTask")
 def test_job_queue_position(mock_aws_quantum_task, position, expected):

--- a/tests/runtime/ibm/test_qiskit_runtime.py
+++ b/tests/runtime/ibm/test_qiskit_runtime.py
@@ -362,7 +362,9 @@ def test_job_retrieval_failure(mock_service):
 @pytest.fixture
 def mock_runtime_job():
     """Fixture to create a mock QiskitRuntimeJob object."""
-    return MagicMock()
+    job = MagicMock()
+    job.status.return_value = "DONE"
+    return job
 
 
 def test_job_queue_position(mock_runtime_job):
@@ -370,6 +372,23 @@ def test_job_queue_position(mock_runtime_job):
     job = QiskitJob(job_id="123", job=mock_runtime_job)
     with pytest.raises(NotImplementedError):
         job.queue_position()
+
+
+def test_job_status_rejects_unknown_state(mock_runtime_job):
+    """Test that an unrecognized IBM job state raises a clear error."""
+    mock_runtime_job.status.return_value = "PAUSED"
+    job = QiskitJob(job_id="123", job=mock_runtime_job)
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Unknown IBM job status 'PAUSED'. Expected one of: "
+            "INITIALIZING, QUEUED, VALIDATING, RUNNING, CANCELLED, DONE, ERROR"
+        ),
+    ):
+        job.status()
+
+    assert "status" not in job._cache_metadata
 
 
 def test_cancel_job_in_terminal_state(mock_runtime_job):


### PR DESCRIPTION
## Summary of changes

Closes #1335.

Raises clear errors when AWS Braket or IBM Runtime reports a job status outside the SDK’s known values. This prevents newly added vendor states from being silently exposed as `UNKNOWN`.

Adds public `status()` tests for both providers. The shared IBM job fixture now returns `DONE`, matching `RuntimeJobV2`.

## Testing

- `python -m pytest -q tests/runtime/aws/test_braket_runtime.py tests/runtime/ibm/test_qiskit_runtime.py`
- `python -m black --check qbraid/runtime/aws/job.py qbraid/runtime/ibm/job.py tests/runtime/aws/test_braket_runtime.py tests/runtime/ibm/test_qiskit_runtime.py`
- `python -m ruff check qbraid/runtime/aws/job.py qbraid/runtime/ibm/job.py tests/runtime/aws/test_braket_runtime.py tests/runtime/ibm/test_qiskit_runtime.py`
- targeted mypy check