### PR TITLE
Support all releases from 0.12 onward in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ qBraid is committed to the security of our software and actively supports securi
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.7.x   | :white_check_mark: |
+| >=0.7.x | :white_check_mark: |
 | < 0.7   | :x:                |
 
 ## Reporting a Vulnerability

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ qBraid is committed to the security of our software and actively supports securi
 
 | Version | Supported          |
 | ------- | ------------------ |
-| >=0.7.x | :white_check_mark: |
-| < 0.7   | :x:                |
+| >=0.12.x | :white_check_mark: |
+| < 0.12   | :x:                |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
`SECURITY.md` listed `0.12.x` as the only supported series. The current release is
`v0.12.2`, so the table has been out of date since the 0.8 series shipped, and it
was last touched in May 2024.

Changing it to `>=0.12.x` states the intended policy — every release from 0.12
onward — and does not need revisiting each time a minor version ships.

