### PR TITLE
ci: drop contents and actions read from the scorecard job

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -27,11 +27,9 @@ jobs:
     permissions:
       security-events: write   # upload SARIF to code scanning
       id-token: write          # publish results to the public Scorecard API
-      contents: read
-      # Lets Scorecard read workflow definitions and run history. Documented by the
-      # upstream starter workflow as required for private repositories; this repo is
-      # public, so it is retained only as a safeguard should that ever change.
-      actions: read
+      # `contents: read` and `actions: read` are deliberately absent. Upstream ships both
+      # commented out, needed only for private repositories, and OSSF runs Scorecard on its
+      # own public repos with exactly the two permissions above.
 
     # Actions are pinned to full commit SHAs: a tag is mutable and can be repointed at
     # other code, which is what Scorecard's own Pinned-Dependencies check looks for.


### PR DESCRIPTION
Follow-up to #1343, which merged before this came up in review on qBraid/pyqasm#412. Same change is open there and needed on qbraid-algorithms.

### Both permissions are private-repository only

`contents: read` and `actions: read` do nothing on a public repository. Evidence, strongest last:

1. **The only Actions API call Scorecard makes is publicly readable.** `ListWorkflowRunsByFileName` (`checks/raw/github/packaging.go`, `checks/raw/binary_artifact.go`) hits `GET /repos/{owner}/{repo}/actions/workflows/{file}/runs`. Requesting that for this repo with **no authentication at all** returns `200` with `total_count=706`; `/user` returns `401` in the same session, confirming the request really was anonymous.

2. **Upstream ships both commented out.** `actions/starter-workflows` `code-scanning/scorecard.yml`:
   ```yaml
         # Uncomment the permissions below if installing in a private repository.
         # contents: read
         # actions: read
   ```

3. **OSSF dogfoods exactly this.** `ossf/scorecard` and `ossf/scorecard-action` are both public and run with `security-events: write` and `id-token: write` alone. Their last five runs are green, and the checks that touch the Actions API score **Packaging 10, Binary-Artifacts 10, CI-Tests 10**. That is also the evidence for dropping `contents: read` — their `actions/checkout` step works without it.

### Risk

Low but not zero. Both affected checks return an error rather than degrading if the API call fails, so a wrong call here would show as a check erroring rather than silently scoring low — visible, not silent. The run that merged with #1343 succeeded, so we have a known-good baseline to compare the next run against.

Worth noting `Token-Permissions` scores 9 rather than 10 on `ossf/scorecard` because they keep `permissions: read-all` at workflow level; ours is `permissions: {}`, which is stricter.
