### PR TITLE
build: allow qbraid-core 0.4.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 rustworkx>=0.15.0
 numpy>=1.17
 openqasm3[parser]>=0.4.0
-qbraid-core>=0.3.9,<0.4.0
+qbraid-core>=0.3.9,<0.5.0
 pydantic>2.0.0
 pydantic-core
 typing-extensions>=4.0.0


### PR DESCRIPTION
## Why

`qbraid-core` **0.4.0** shipped the CodeQ→pi swap ([qbraid-core#295](https://github.com/qBraid/qbraid-core/pull/295)). The `<0.4.0` cap in `requirements.txt` excludes it, so **every environment with this SDK installed holds `qbraid-core` at 0.3.11** and never receives that release — which is every Lab pod.

Observed on a live pod after the release:

```
qbraid-cli   0.13.3   ← reached latest, nothing caps it
qbraid-core  0.3.11   ← held back by this pin
```

```python
>>> Version('0.4.0') in SpecifierSet('<0.4.0,>=0.3.3')
False
```

## Why this is safe

The cap was doing its job — 0.4.0 is a deliberate minor bump for a breaking change. But the break is confined to `qbraid_core.services.agents`: the OpenCode HTTP surface was removed and the permission protocol rewritten. **This SDK does not import that module at all.**

Verified rather than assumed. I extracted every `qbraid_core` import the SDK performs — 12 distinct statements across 61 files — and resolved all of them against core 0.4.0:

| area | resolves on 0.4.0 |
|---|---|
| `QbraidClientV1`, `QbraidSessionV1`, `Session`, `deprecated` | ✅ |
| `_compat.check_version`, `_import.LazyLoader` | ✅ |
| `decimal.USD`, `exceptions.*`, `sessions.Session` | ✅ |
| `services.runtime` client + full schema tree (`job`, `group`, `result`) | ✅ |
| `services.agents` | **not used** |

**12/12 resolve.**

## Choice of bound

Widened to `<0.5.0` rather than pinning `>=0.4.0`, so existing 0.3.x installs keep resolving and the change stays minimal. Matches the `>=X,<Y` style used by the other pins in this file.

Note there's an open dependabot branch (`dependabot/pip/qbraid-core-gte-0.3.10-and-lt-0.4.0`) that raises the floor while keeping the `<0.4.0` ceiling — it would not unblock this.

## Rollout context

This is the missing link in the qbraid-core 0.4.0 chain. The downstream order in qbraid-core#295 lists lex, jlab, api, Dstacks and infra, but not this repo — yet without this pin change, pods can't receive 0.4.0 at all.

Deployed pods stay working across the jump via the deprecated shims core 0.4.0 kept (`opencode_api`, `install_opencode_hooks`) for already-published `qbraid-lex` and `qbraid-cli`.