### PR TITLE
build: loosen the qbraid-core cap to <1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 rustworkx>=0.15.0
 numpy>=1.17
 openqasm3[parser]>=0.4.0
-qbraid-core>=0.3.9,<0.5.0
+qbraid-core>=0.3.9,<1.0
 pydantic>2.0.0
 pydantic-core
 typing-extensions>=4.0.0


### PR DESCRIPTION
## Why

The upper cap on `qbraid-core` has fired twice — core 0.4.0 (fixed by #1355, `<0.4.0` → `<0.5.0`) and now core 0.5.0 (qBraid/qbraid-core#298) — and both times it did the opposite of protecting anything: every Lab pod held core at the last admitted version while the CLI moved on, and a chase-the-cap PR was needed to unblock the rollout.

**It has never caught a break.** The SDK's entire surface from core is `runtime`, `sessions` and `exceptions` — none of which has changed incompatibly across any release. It never imports `services.compute`, which is where core's breaking changes have been.

## Change

```diff
- qbraid-core>=0.3.9,<0.5.0
+ qbraid-core>=0.3.9,<1.0
```

Keeps a guard against a true major; ends the per-minor churn.

## Verified

Every `qbraid_core` import the SDK performs, executed against core 0.5.0 at its PR head: all resolve. (Same method as #1355.)

## Context

Companion: qBraid/qbraid-Dstacks issue on the lab image re-resolving the SDK at pod start and in the Dockerfile in a way that silently downgrades core — that is the architectural fix; this PR makes the metadata truthful in the meantime. Rollout order for the compute redesign: **this → core 0.5.0 → CLI pin → CLI 0.14.0**.