### PR TITLE
test(qrisp): cover the RYYGate qrisp 0.9.8 added

### DIFF
--- a/tests/transpiler/qrisp/test_coverage_from_qrisp.py
+++ b/tests/transpiler/qrisp/test_coverage_from_qrisp.py
@@ -69,6 +69,7 @@ gates_param_map = {
     "SGate": {"qubits": [0]},
     "TGate": {"qubits": [0]},
     "RXXGate": {"qubits": [0, 1], "phi": np.random.rand() * 2 * np.pi},
+    "RYYGate": {"qubits": [0, 1], "phi": np.random.rand() * 2 * np.pi},
     "RZZGate": {"qubits": [0, 1], "phi": np.random.rand() * 2 * np.pi},
     "SXGate": {"qubits": [0]},
     "SXDGGate": {"qubits": [0]},
@@ -178,6 +179,12 @@ def convert_from_qrisp_to_x(target, circuit_name, circuits, graph):
     target program type, and check equivalence.
     """
     source_circuit = circuits[circuit_name]
+    # A gate enumerated from qrisp but absent from gates_param_map (or whose entry no
+    # longer matches its constructor) never got a circuit built. Name that directly
+    # instead of letting transpile(None) surface as an opaque NoneType error.
+    assert (
+        source_circuit is not None
+    ), f"no circuit was built for {circuit_name}; add or update its gates_param_map entry"
     target_circuit = transpile(source_circuit, target, conversion_graph=graph)
     assert circuits_allclose(source_circuit, target_circuit, strict_gphase=False)
 


### PR DESCRIPTION
### Problem

Main CI has been red since this morning: qrisp 0.9.8 (released 2026-09-04, 10:55 UTC; `requirements-dev.txt` floats `qrisp>=0.8`) adds `RYYGate` to `standard_operations`. The coverage fixture enumerates that module with `dir()`, so the new gate is picked up — but it has no `gates_param_map` entry, the builder's `KeyError` is swallowed by the broad except, the circuit stays `None`, and all three `test_qrisp_coverage` targets fail with an opaque `Program of type 'NoneType'` error.

### Fix

One map entry: `"RYYGate": {"qubits": [0, 1], "phi": …}` (0.9.8's rotation gates all take `phi`). That is the whole fix — the qrisp → cirq/pytket/qiskit conversions of `RYYGate` pass `circuits_allclose` on all three targets, so no `KNOWN_BAD_CONVERSIONS` entry and no version cap is needed.

Also adds a guard so a `None` circuit fails naming the missing map entry — the next gate qrisp adds gets diagnosed from the assertion text instead of the NoneType error.

### Verified

`tests/transpiler/qrisp`: 5 passed against qrisp 0.9.8 with the CI dependency set; lint clean at the pinned tool versions.
