### PR TITLE
fix(qperfect): surface MIMIQ's failure reason and wrap unknown job ids

### DIFF
--- a/qbraid/runtime/qperfect/job.py
+++ b/qbraid/runtime/qperfect/job.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from qbraid.runtime.enums import JobStatus
-from qbraid.runtime.exceptions import QbraidRuntimeError
+from qbraid.runtime.exceptions import QbraidRuntimeError, ResourceNotFoundError
 from qbraid.runtime.job import QuantumJob
 from qbraid.runtime.result import Result
 from qbraid.runtime.result_data import GateModelResultData, MeasCount
@@ -80,6 +80,20 @@ class QPerfectJob(QuantumJob):
         """Return the MIMIQ connection used by this job."""
         return self._connection
 
+    def _request_info(self) -> Any:
+        """Return MIMIQ's execution record for this job.
+
+        Raises:
+            ResourceNotFoundError: If MIMIQ cannot return the record. An unknown job id surfaces
+                here as a server error rather than a 404, so the vendor error is not inspected.
+        """
+        try:
+            return self._connection.connection.requestInfo(self.id)
+        except Exception as err:  # pylint: disable=broad-except
+            raise ResourceNotFoundError(
+                f"Could not retrieve execution details for job {self.id}: {err}"
+            ) from err
+
     def status(self) -> JobStatus:
         """Return the current status of the QPerfect job.
 
@@ -88,8 +102,9 @@ class QPerfectJob(QuantumJob):
 
         Raises:
             QPerfectJobError: If MIMIQ reports a status outside the known mapping.
+            ResourceNotFoundError: If MIMIQ has no execution record for this job id.
         """
-        info = self._connection.connection.requestInfo(self.id)
+        info = self._request_info()
         if info.status not in _STATUS_MAP:
             # ``RequestInfo.status`` falls back to the literal string "Unknown" when the payload
             # omits the field, so the message says "unrecognized" to keep that case readable.
@@ -112,13 +127,25 @@ class QPerfectJob(QuantumJob):
             raise QPerfectJobError(f"Failed to cancel job {self.id}: {err}") from err
 
     def result(self) -> Result:
-        """Wait for the QPerfect job to finish and return its result."""
+        """Wait for the QPerfect job to finish and return its result.
+
+        A circuit carrying no measurement instructions still returns counts: the emulator samples
+        the final state over every qubit rather than rejecting the job.
+
+        Raises:
+            QPerfectJobError: If the job reached a terminal state other than ``COMPLETED``. MIMIQ's
+                own explanation (e.g. a backend that ran out of memory) is included when it gives
+                one, since it usually names the fix.
+        """
         self.wait_for_final_state()
         status = self.status()
         if status != JobStatus.COMPLETED:
-            raise QPerfectJobError(
-                f"Job {self.id} did not complete successfully (status={status.name})."
-            )
+            # Only FAILED and CANCELLED reach here: wait_for_final_state polls status(), which
+            # rejects any state outside _STATUS_MAP before this point.
+            outcome = "was cancelled" if status == JobStatus.CANCELLED else "failed"
+            reason = self._request_info().get("errorMessage", None)
+            detail = f": {reason}" if reason else "."
+            raise QPerfectJobError(f"Job {self.id} {outcome}{detail}")
 
         results = self._connection.get_results(self.id)
         if not isinstance(results, list):

--- a/tests/runtime/qperfect/conftest.py
+++ b/tests/runtime/qperfect/conftest.py
@@ -47,12 +47,17 @@ else:
         ``submit`` returns a fixed execution id; the nested ``.connection`` (the ``mimiqlink``
         layer) stubs ``isOpen`` (device health), ``requestInfo`` (job status, ``.status`` string),
         and cancel. Defaults describe an open connection and a completed (``DONE``) job.
+
+        ``requestInfo().get`` follows ``RequestInfo.get`` in returning the caller's default for an
+        absent key; a bare ``MagicMock`` would hand back a truthy mock for every field instead.
         """
         conn = MagicMock()
         conn.submit.return_value = "exec-1"
         conn.connection = MagicMock()
         conn.connection.isOpen.return_value = True
-        conn.connection.requestInfo.return_value = MagicMock(status="DONE")
+        info = MagicMock(status="DONE")
+        info.get.side_effect = lambda key, default: default
+        conn.connection.requestInfo.return_value = info
         return conn
 
     @pytest.fixture

--- a/tests/runtime/qperfect/test_job.py
+++ b/tests/runtime/qperfect/test_job.py
@@ -22,6 +22,7 @@ from unittest.mock import patch
 import pytest
 
 from qbraid.runtime.enums import JobStatus
+from qbraid.runtime.exceptions import ResourceNotFoundError
 from qbraid.runtime.qperfect import QPerfectJob, QPerfectJobError
 
 
@@ -102,6 +103,44 @@ def test_result_incomplete_raises(mock_connection):
     mock_connection.connection.requestInfo.return_value.status = "ERROR"
     with pytest.raises(QPerfectJobError):
         _job(mock_connection).result()
+
+
+def test_result_failure_includes_mimiq_error_message(mock_connection):
+    """MIMIQ's own explanation reaches the caller; it usually names the fix."""
+    info = mock_connection.connection.requestInfo.return_value
+    info.status = "ERROR"
+    info.get.side_effect = lambda key, default: (
+        "SVS: Not enough memory to execute circuit 1." if key == "errorMessage" else default
+    )
+    with pytest.raises(QPerfectJobError, match=r"^Job exec-1 failed: SVS: Not enough memory"):
+        _job(mock_connection).result()
+
+
+def test_result_cancelled_names_the_state_once(mock_connection):
+    """A cancelled job says so in one clause, with no redundant status= suffix."""
+    mock_connection.connection.requestInfo.return_value.status = "CANCELED"
+    with pytest.raises(QPerfectJobError, match=r"^Job exec-1 was cancelled\.$"):
+        _job(mock_connection).result()
+
+
+def test_result_propagates_unrecognized_status(mock_connection):
+    """An unmapped status surfaces from the status() poll, not from the failure branch."""
+    mock_connection.connection.requestInfo.return_value.status = "SOMETHING_ELSE"
+    with pytest.raises(QPerfectJobError, match="unrecognized job status 'SOMETHING_ELSE'"):
+        _job(mock_connection).result()
+
+
+def test_unknown_job_id_raises_resource_not_found(mock_connection):
+    """An unknown job id surfaces as a qBraid error, not a raw mimiqlink ConnectionError.
+
+    MIMIQ answers a lookup for a nonexistent execution with a 500, so there is no 404 to
+    distinguish; any lookup failure becomes ResourceNotFoundError.
+    """
+    mock_connection.connection.requestInfo.side_effect = ConnectionError(
+        "Failed to retrieve execution details for exec-1. Server responded with 500"
+    )
+    with pytest.raises(ResourceNotFoundError, match="Could not retrieve execution details"):
+        _job(mock_connection).status()
 
 
 def test_default_connection_is_built_lazily(mock_connection):

--- a/tests/runtime/qperfect/test_qperfect_remote.py
+++ b/tests/runtime/qperfect/test_qperfect_remote.py
@@ -17,6 +17,7 @@ Remote integration tests for the QPerfect (MIMIQ) provider, device, and job clas
 
 These submit real jobs to the MIMIQ cloud emulator and verify end-to-end result flow.
 """
+
 from __future__ import annotations
 
 import os
@@ -30,7 +31,13 @@ pytest.importorskip("mimiq_qiskit")
 from qiskit import QuantumCircuit  # noqa: E402
 
 from qbraid.runtime.enums import DeviceStatus, JobStatus  # noqa: E402
-from qbraid.runtime.qperfect import QPerfectDevice, QPerfectJob, QPerfectProvider  # noqa: E402
+from qbraid.runtime.exceptions import ResourceNotFoundError  # noqa: E402
+from qbraid.runtime.qperfect import (  # noqa: E402
+    QPerfectDevice,
+    QPerfectJob,
+    QPerfectJobError,
+    QPerfectProvider,
+)
 from qbraid.runtime.result import Result  # noqa: E402
 
 DEVICE_ID = "mimiq-emulator"
@@ -116,3 +123,84 @@ def test_batch_run_returns_counts_per_circuit():
     assert isinstance(counts, list)
     assert len(counts) == 2
     assert set(counts[0]) <= {"00", "11"}
+
+
+@pytest.mark.remote
+def test_result_retrieved_from_job_id_alone():
+    """A job rebuilt from its id — no run() handle — returns the same counts."""
+    provider = _get_provider()
+    device = provider.get_device(DEVICE_ID)
+    circuit = QuantumCircuit(3, 3)
+    circuit.x(1)
+    circuit.measure([0, 1, 2], [0, 1, 2])
+    submitted = device.run(circuit, shots=SHOTS)
+    submitted.result()
+
+    rebuilt = QPerfectJob(
+        job_id=submitted.id, connection=provider.connection, device=device, shots=SHOTS
+    )
+    assert rebuilt.status() == JobStatus.COMPLETED
+    assert rebuilt.result().data.get_counts() == {"010": SHOTS}
+
+
+@pytest.mark.remote
+def test_cancel_running_job():
+    """A cancelled job reports CANCELLED, and result() refuses to invent data for it.
+
+    The circuit is sized so it is still queued or running when the cancel lands; MIMIQ rejects a
+    cancel once the job is terminal.
+    """
+    device = _get_provider().get_device(DEVICE_ID)
+    circuit = QuantumCircuit(30, 30)
+    for _ in range(40):
+        for qubit in range(30):
+            circuit.h(qubit)
+        for qubit in range(29):
+            circuit.cx(qubit, qubit + 1)
+    circuit.measure(range(30), range(30))
+
+    job = device.run(circuit, shots=1000, algorithm="statevector")
+    job.cancel()
+
+    with pytest.raises(QPerfectJobError, match="was cancelled"):
+        job.result()
+    assert job.status() == JobStatus.CANCELLED
+
+
+@pytest.mark.remote
+def test_cancel_completed_job_raises():
+    """MIMIQ rejects cancelling a terminal job, and the vendor 400 is wrapped."""
+    device = _get_provider().get_device(DEVICE_ID)
+    job = device.run(_bell(), shots=SHOTS)
+    job.result()
+
+    with pytest.raises(QPerfectJobError, match="Failed to cancel job"):
+        job.cancel()
+
+
+@pytest.mark.remote
+def test_failed_job_reports_mimiq_reason():
+    """A job the backend cannot run fails with MIMIQ's explanation, not a bare status.
+
+    40 qubits exceeds the state vector backend's memory, which is the cheapest reproducible
+    server-side failure: it errors within a second of starting.
+    """
+    device = _get_provider().get_device(DEVICE_ID)
+    circuit = QuantumCircuit(40, 40)
+    circuit.h(range(40))
+    circuit.measure(range(40), range(40))
+
+    job = device.run(circuit, shots=SHOTS, algorithm="statevector")
+    with pytest.raises(QPerfectJobError, match=r"failed: .*memory"):
+        job.result()
+    assert job.status() == JobStatus.FAILED
+
+
+@pytest.mark.remote
+def test_unknown_job_id_raises_resource_not_found():
+    """An id MIMIQ has no record of raises a qBraid error, not a mimiqlink ConnectionError."""
+    provider = _get_provider()
+    job = QPerfectJob(job_id="not-a-real-job-id", connection=provider.connection)
+
+    with pytest.raises(ResourceNotFoundError, match="Could not retrieve execution details"):
+        job.status()


### PR DESCRIPTION
Follow-up to #1299, found by running the provider against the live MIMIQ cloud rather than the mocks.

### Problem

Two error paths threw away what the caller needed.

A failed job reported `did not complete successfully (status=FAILED)` while MIMIQ's explanation sat unread in the execution payload. A 40-qubit statevector run returns `errorMessage: "SVS: Not enough memory to execute circuit 1."` — that names the fix (`algorithm="mps"`); the old message left the user guessing.

`status()` on an unknown job id leaked a raw `mimiqlink.ConnectionError`, outside the qBraid hierarchy, so code catching `QbraidRuntimeError` around a lookup missed it.

### Any lookup failure becomes ResourceNotFoundError

MIMIQ answers a lookup for a nonexistent execution with a **500, not a 404**, so there is nothing in the response to distinguish "no such job" from a genuine outage. `_request_info()` therefore maps every `requestInfo` failure to `ResourceNotFoundError` (matching `oqc/job.py:190`). A transport error during a valid lookup will report as not-found; the alternative was parsing vendor error strings, which I'd rather not pin behavior to.

### Fixture change worth a look

`mock_connection` now gives `requestInfo().get` the real `RequestInfo` semantics of returning the caller's default. A bare `MagicMock` hands back a truthy mock for *every* key, so the new `errorMessage` assertions would have passed against a `<MagicMock …>` string in the message rather than a real value.

### Deliberately unchanged

`device.status()` still collapses a bad token into `OFFLINE` (`device.py:85`) — auth failure and unreachable service stay indistinguishable. Documented rather than fixed; say the word if that should change.

### Verified

Against the live cloud on 3.11: 11 remote passed (~20 jobs, all small except one 30-qubit circuit submitted to be cancelled), 52 offline passed / 11 skipped, pylint 10.00/10. Endianness was re-confirmed against qiskit's own simulator on four asymmetric circuits — qubit 0 last, matching the direction in #1327.

The 5 new remote tests need `--remote true` and `QPERFECT_API_TOKEN`, so CI will not exercise them; they ran locally only.
