### PR TITLE
fix(runtime): ignore empty PASQAL_* env vars; deflake ionq and pasqal tests

### DIFF
--- a/qbraid/runtime/pasqal/provider.py
+++ b/qbraid/runtime/pasqal/provider.py
@@ -142,9 +142,11 @@ class PasqalProvider(QuantumProvider):
         # pylint: disable-next=import-outside-toplevel
         from pasqal_cloud import SDK
 
-        resolved_project_id = project_id or os.getenv("PASQAL_PROJECT_ID")
-        resolved_username = username or os.getenv("PASQAL_USERNAME")
-        resolved_password = password or os.getenv("PASQAL_PASSWORD")
+        # An unset CI secret exports as "", which must read as absent rather than be
+        # forwarded to the SDK as an empty credential.
+        resolved_project_id = project_id or os.getenv("PASQAL_PROJECT_ID") or None
+        resolved_username = username or os.getenv("PASQAL_USERNAME") or None
+        resolved_password = password or os.getenv("PASQAL_PASSWORD") or None
 
         if token_provider is None and not resolved_username:
             raise ValueError(

--- a/tests/runtime/ionq/test_ionq_runtime.py
+++ b/tests/runtime/ionq/test_ionq_runtime.py
@@ -561,7 +561,7 @@ def test_ionq_device_run_submit_job(mock_post, mock_get, circuit, monkeypatch):
 @patch("importlib.util.find_spec", return_value=None)
 def test_ionq_failed_job(_mock_find_spec, mock_post, mock_get, circuit):
     """Test running a fake job."""
-    GET_JOB_RESPONSE["status"] = "failed"
+    failed_job_response = {**GET_JOB_RESPONSE, "status": "failed"}
     simulator_data = next(d for d in DEVICE_DATA if d["backend"] == "simulator")
 
     def mock_get_response_func(url):
@@ -570,7 +570,7 @@ def test_ionq_failed_job(_mock_find_spec, mock_post, mock_get, circuit):
         if "/backends/" in url:
             mock_resp.json.return_value = simulator_data
         else:  # job endpoints
-            mock_resp.json.return_value = GET_JOB_RESPONSE
+            mock_resp.json.return_value = failed_job_response
         return mock_resp
 
     mock_get.side_effect = lambda url, **kwargs: mock_get_response_func(url)

--- a/tests/runtime/pasqal/test_pasqal_runtime.py
+++ b/tests/runtime/pasqal/test_pasqal_runtime.py
@@ -161,9 +161,14 @@ class TestProviderHelpers:
 
 
 class TestPasqalProvider:
-    def test_init_requires_credentials(self, monkeypatch):
+    @pytest.fixture(autouse=True)
+    def _clear_pasqal_env(self, monkeypatch):
+        # CI exports PASQAL_* from repository secrets, so credentials resolved from the
+        # environment would otherwise leak into every constructor assertion below.
         for key in ("PASQAL_USERNAME", "PASQAL_PASSWORD", "PASQAL_PROJECT_ID"):
             monkeypatch.delenv(key, raising=False)
+
+    def test_init_requires_credentials(self):
         with pytest.raises(ValueError, match="Pasqal authentication is required"):
             PasqalProvider()
 


### PR DESCRIPTION
## Summary of changes

Two of the eight failures in the [daily 3.14 run](https://github.com/qBraid/qBraid/actions/runs/34243880752/job/102120736981) came from tests reading state they don't own. Neither is a regression in the SDK.

### `test_ionq_device_run_submit_job[0]`/`[1]` — mutated module-level fixture

`test_ionq_failed_job` did `GET_JOB_RESPONSE["status"] = "failed"` on the shared module-level dict and never restored it. Under `-n auto --dist worksteal` it can land before `test_ionq_device_run_submit_job` on the same worker, which then reads `status="failed"` and fails its `== JobStatus.COMPLETED` assertion. It now builds its own copy.

Reproduced on `main` by forcing the order:

```
$ pytest tests/runtime/ionq/test_ionq_runtime.py::test_ionq_failed_job \
         tests/runtime/ionq/test_ionq_runtime.py::test_ionq_device_run_submit_job
3 failed, 3 passed
```

After the fix, `6 passed`.

### `TestPasqalProvider::test_init_with_token_provider` — env leaked in

`ci-daily.yml` exports `PASQAL_USERNAME` from a repository secret. When that secret is unset the var still exists as `""`, and `PasqalProvider.__init__` did `username or os.getenv("PASQAL_USERNAME")`, so the test's `assert kwargs["username"] is None` saw `''`.

Fixed on both sides:

- The provider now resolves empty env values to `None`, so an empty variable reads as absent rather than reaching `pasqal_cloud.SDK` as an empty credential. This is the only non-test change here.
- `TestPasqalProvider` clears `PASQAL_*` in an autouse fixture, so no constructor assertion depends on the ambient environment. `test_init_requires_credentials` was already doing this by hand; that loop moves into the fixture.

Reproduced on `main` with `PASQAL_USERNAME="" pytest tests/runtime/pasqal/...::test_init_with_token_provider` → `assert '' is None`. After the fix, the pasqal suite passes with the variable empty, populated, and unset.

## Verification

- `pytest tests/runtime/ionq tests/runtime/pasqal -n auto --dist worksteal` → `103 passed, 7 skipped`
- `tox -e format-check` → clean (pylint 10.00/10)

No changelog entry: the provider change is not behaviour a user could be relying on, and the rest is test-only.

Part of the daily-CI cleanup; see also the sibling PRs for the Python 3.14 dependency failures and the Azure/Pasqal result-parsing bug.
