### PR TITLE
test(runtime): fix two Python 3.14 daily-CI failures from missing deps

### DIFF
--- a/tests/runtime/azure/test_azure_remote.py
+++ b/tests/runtime/azure/test_azure_remote.py
@@ -296,6 +296,7 @@ def test_workspace_from_connection_string():
 
 @pytest.mark.remote
 @pytest.mark.skipif(not cirq_found, reason="cirq not installed")
+@pytest.mark.skipif(not pyquil_found, reason="pyquil not installed, so Rigetti has no ProgramSpec")
 def test_submit_cirq_to_rigetti(provider: AzureQuantumProvider):
     """A Cirq circuit reaches the Rigetti simulator and comes back with counts.
 

--- a/tests/runtime/native/test_qir_simulator_remote.py
+++ b/tests/runtime/native/test_qir_simulator_remote.py
@@ -59,8 +59,10 @@ def bell_qir_module():
     qis.mz(q0, r0)
     qis.mz(q1, r1)
 
+    # Take the result pointer type off a result value: pyqir 0.12 dropped the
+    # `result_type` helper when QIR moved to opaque pointers.
     i8_ptr = pyqir.PointerType(pyqir.IntType(ctx, 8))
-    rt_type = pyqir.FunctionType(pyqir.Type.void(ctx), [pyqir.result_type(ctx), i8_ptr])
+    rt_type = pyqir.FunctionType(pyqir.Type.void(ctx), [r0.type, i8_ptr])
     rt_fn = pyqir.Function(
         rt_type, pyqir.Linkage.EXTERNAL, "__quantum__rt__result_record_output", mod
     )


### PR DESCRIPTION
## Summary of changes

Two more failures from the [daily 3.14 run](https://github.com/qBraid/qBraid/actions/runs/34243880752/job/102120736981), both from dependencies that differ on Python 3.14. Test-only; no SDK behaviour changes.

### `test_qir_simulator_qir_module` — pyqir 0.12 removed `result_type`

```
ERROR at setup of test_qir_simulator_qir_module
  AttributeError: module 'pyqir' has no attribute 'result_type'
```

pyqir arrives transitively via `qbraid-qir`, and CI resolved `pyqir==0.12.5` on 3.14. 0.12 dropped `result_type`, `qubit_type`, `is_result_type` and `result_id` when QIR moved to opaque pointers. Nothing under `qbraid/` uses those symbols — only this fixture did.

The fixture now takes the result pointer type off a result value (`r0.type`) instead of asking for it by name. That works on both versions and emits identical IR; 0.10 still produces `%Result*`, 0.12 produces `ptr`:

```
# pyqir 0.10.9
declare void @__quantum__rt__result_record_output(%Result*, i8*)
# pyqir 0.12.5
declare void @__quantum__rt__result_record_output(ptr, ptr)
```

### `test_submit_cirq_to_rigetti` — needs pyquil, has no guard for it

The visible failure was inside azure-quantum:

```
AttributeError: 'Circuit' object has no attribute 'encode'
  azure/quantum/target/target.py:201 in _encode_input_data
```

The raw `cirq.Circuit` reached Azure untranspiled. The cause is in the run's warnings summary:

```
qbraid/runtime/azure/provider.py:132: RuntimeWarning: The default runtime configuration for
device using input data format 'rigetti.quil.v1' requires package 'pyquil', which is not installed.
```

`requirements-dev.txt` pins `pyquil>=5.0.0rc3; python_version < "3.13"`, so on 3.14 `_get_program_spec(RIGETTI)` warns and returns `None`, leaving the device with no ProgramSpec and no cirq → Quil conversion. The test submits Cirq but still depends on pyquil for the target's ProgramSpec, so it now carries the same `pyquil_found` guard as `test_submit_quil_to_rigetti`.

## Verification

Run in a Python 3.14 env with pyqir 0.12.5 and no pyquil — the same shape as the CI runner.

Before, on `main`:

```
$ pytest tests/runtime/native/test_qir_simulator_remote.py --remote true
1 passed, 1 error   # AttributeError: module 'pyqir' has no attribute 'result_type'
$ pytest tests/runtime/azure/test_azure_remote.py --remote true
2 failed, 2 passed, 4 skipped
```

After:

```
$ pytest tests/runtime/native/test_qir_simulator_remote.py --remote true
2 passed            # QIR module built, submitted to qbraid:qbraid:sim:qir-sv, completed
$ pytest tests/runtime/azure/test_azure_remote.py --remote true
1 failed, 2 passed, 5 skipped
SKIPPED [1] tests/runtime/azure/test_azure_remote.py:297: pyquil not installed, so Rigetti has no ProgramSpec
```

The remaining Azure failure is `test_submit_json_to_ionq` (`Device ionq.simulator not found`), which fails identically on `main` here — the local Azure workspace does not expose that target. It passes in CI.

The QIR fixture was also exercised directly against both pyqir versions; both build a module that passes `mod.verify()` with two `__quantum__rt__result_record_output` calls.

`tox -e format-check` clean.

## Notes

Worth a separate look, not changed here: when `_get_program_spec` returns `None`, `AzureQuantumDevice.run` forwards the program untransformed and the failure surfaces as an `AttributeError` from inside azure-quantum. A clearer error at submit time would have made this a one-line diagnosis.

Part of the daily-CI cleanup; see also #1379 and the Azure/Pasqal result-parsing PR.
