### PR TITLE
feat(runtime): add resource estimate client (qbraid.runtime.estimate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Writing an entry:
 ## [Unreleased]
 
 ### Added
+- Added `qbraid.runtime.estimate()` and `QbraidProvider.estimate()` for resource and cost frontiers, with polling, open questions, narration, and optional pandas export through `QbraidEstimate`.
 - Added `QuantumDevice.supported_run_inputs` method, which returns the sorted list of program type aliases that can be passed as `run_input` to the device's `run` method ([#803](https://github.com/qBraid/qBraid/issues/803))
 - Added `QudoraProvider`, `QudoraDevice`, and `QudoraJob` classes implementing the qBraid runtime interface for the [QUDORA Cloud](https://api.qudora.com). Authenticates with a `Bearer` API token and submits OpenQASM directly over REST (no vendor SDK); reuses qBraid's existing `qasm2`/`qasm3` program specs so no converter is required. Device ids are backend `username`s (email addresses), and a program list is submitted as a single batched QUDORA job returning one histogram per program ([#1292](https://github.com/qBraid/qBraid/pull/1292))
 - Added `QbraidJob.compiled_program()`, returning the vendor-compiled program that executed on the QPU as a `Program` (`format` is `"qasm3"` for IQM, `"quil"` for Rigetti). It reveals the physical qubits selected and the logical-to-physical mapping the vendor's compiler chose. Returns `None` when no compiled program exists — a simulator, a job that has not completed, or one submitted before the backend captured them — so absence does not need a `try`/`except`. Requires `qbraid-core>=0.3.9`

--- a/qbraid/runtime/__init__.py
+++ b/qbraid/runtime/__init__.py
@@ -41,6 +41,7 @@ Functions
     load_job
     get_providers
     load_provider
+    estimate
 
 Classes
 --------
@@ -59,6 +60,7 @@ Classes
     AnalogResultData
     AnalogShotResult
     AnnealingResultData
+    QbraidEstimate
 
 Exceptions
 ------------
@@ -153,6 +155,8 @@ __all__ = [
     "AnnealingResultData",
     "ValidationLevel",
     "PROVIDERS",
+    "QbraidEstimate",
+    "estimate",
 ]
 
 _lazy = {
@@ -228,6 +232,8 @@ _lazy = {
         "QbraidProvider",
         "QbraidDevice",
         "QbraidJob",
+        "QbraidEstimate",
+        "estimate",
         "QirRunner",
     ],
     "schemas": [],
@@ -253,10 +259,12 @@ if TYPE_CHECKING:
     from .ionq import IonQSession as IonQSession
     from .native import QbraidClientV1 as QbraidClientV1
     from .native import QbraidDevice as QbraidDevice
+    from .native import QbraidEstimate as QbraidEstimate
     from .native import QbraidJob as QbraidJob
     from .native import QbraidProvider as QbraidProvider
     from .native import QbraidSessionV1 as QbraidSessionV1
     from .native import Session as Session
+    from .native.provider import estimate as estimate
     from .openquantum import OpenQuantumDevice as OpenQuantumDevice
     from .openquantum import OpenQuantumJob as OpenQuantumJob
     from .openquantum import OpenQuantumProvider as OpenQuantumProvider

--- a/qbraid/runtime/native/__init__.py
+++ b/qbraid/runtime/native/__init__.py
@@ -18,6 +18,14 @@ quantum jobs through (native) qBraid APIs.
 
 .. currentmodule:: qbraid.runtime.native
 
+Functions
+---------
+
+.. autosummary::
+   :toctree: ../stubs/
+
+    estimate
+
 Classes
 --------
 
@@ -30,13 +38,15 @@ Classes
     QbraidProvider
     QbraidDevice
     QbraidJob
+    QbraidEstimate
 
 """
 from qbraid_core import QbraidClientV1, QbraidSessionV1, Session
 
 from .device import QbraidDevice
+from .estimate import QbraidEstimate
 from .job import QbraidJob
-from .provider import QbraidProvider
+from .provider import QbraidProvider, estimate
 
 __all__ = [
     "Session",
@@ -45,4 +55,6 @@ __all__ = [
     "QbraidProvider",
     "QbraidDevice",
     "QbraidJob",
+    "QbraidEstimate",
+    "estimate",
 ]

--- a/qbraid/runtime/native/estimate.py
+++ b/qbraid/runtime/native/estimate.py
@@ -1,0 +1,162 @@
+# Copyright 2025 qBraid
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Client wrapper for resource estimates returned by the qBraid runtime API."""
+
+from __future__ import annotations
+
+from time import sleep, time
+from typing import TYPE_CHECKING
+
+from qbraid_core.exceptions import RequestsApiError
+from qbraid_core.services.runtime import QuantumRuntimeClient, QuantumRuntimeServiceRequestError
+from qbraid_core.services.runtime.schemas.estimate import (
+    CircuitFeatures,
+    Estimate,
+    EstimateStatus,
+    FrontierPoint,
+    Infeasible,
+)
+
+from qbraid.runtime.exceptions import QbraidRuntimeError
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+
+class QbraidEstimate:
+    """A resource estimate and the client used to refresh it.
+
+    Args:
+        estimate: The runtime API's estimate model.
+        client: The authenticated runtime client that created the estimate.
+    """
+
+    def __init__(self, estimate: Estimate, client: QuantumRuntimeClient) -> None:
+        self._estimate = estimate
+        self._client = client
+
+    @property
+    def id(self) -> str:
+        """Return the estimate identifier."""
+        return self._estimate.id
+
+    @property
+    def status(self) -> EstimateStatus:
+        """Return the last retrieved status; use :meth:`refresh` to update it."""
+        return self._estimate.status
+
+    def refresh(self) -> QbraidEstimate:
+        """Retrieve the current estimate from the runtime API and return self."""
+        try:
+            response = self._client.session.get(f"/estimates/{self.id}")
+            self._estimate = Estimate.model_validate(response.json()["data"])
+        except RequestsApiError as err:
+            raise QuantumRuntimeServiceRequestError(
+                f"Failed to retrieve estimate '{self.id}': {err}"
+            ) from err
+        return self
+
+    def wait(self, timeout: int = 300, poll: float = 2.0) -> QbraidEstimate:
+        """Poll until the estimate completes and return self.
+
+        Args:
+            timeout: Maximum seconds to wait. Defaults to 300 seconds.
+            poll: Seconds between queries. Defaults to 2 seconds.
+
+        Raises:
+            TimeoutError: If the estimate does not finish before the timeout.
+            QbraidRuntimeError: If estimation fails, including the API's error.
+        """
+        start_time = time()
+        terminal_states = {EstimateStatus.COMPLETED, EstimateStatus.FAILED}
+        while self.status not in terminal_states:
+            self.refresh()
+            if self.status in terminal_states:
+                break
+            if time() - start_time >= timeout:
+                raise TimeoutError(f"Timeout while waiting for estimate {self.id}.")
+            sleep(poll)
+        if self.status == EstimateStatus.FAILED:
+            raise QbraidRuntimeError(f"Estimate {self.id} failed: {self._estimate.error}")
+        return self
+
+    @property
+    def frontier(self) -> list[FrontierPoint]:
+        """Return the feasible cost/quality frontier points with their bases."""
+        return self._estimate.frontier
+
+    @property
+    def infeasible(self) -> list[Infeasible]:
+        """Return excluded devices and their feasibility failure reasons."""
+        return self._estimate.infeasible
+
+    @property
+    def open_questions(self) -> list[str]:
+        """Return questions the estimator could not answer."""
+        return self._estimate.openQuestions
+
+    @property
+    def narrative(self) -> str | None:
+        """Return the generated explanation, if available."""
+        return self._estimate.narrative
+
+    @property
+    def features(self) -> CircuitFeatures | None:
+        """Return circuit features used for estimation, if available."""
+        return self._estimate.features
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """Return one row per frontier point, with scalar values and weakest basis.
+
+        Basis is summarized across shots, minutes, all cost components, and quality.
+        From weakest to strongest: ``unavailable``, ``assumed-default``,
+        ``historical-regression``, ``computed``. Full quantities and intervals
+        remain available through :attr:`frontier`.
+
+        Raises:
+            ImportError: If pandas is not installed.
+        """
+        try:
+            import pandas as pd  # pylint: disable=import-outside-toplevel
+        except ImportError as err:
+            raise ImportError(
+                "QbraidEstimate.to_dataframe() requires pandas. "
+                "Install it with 'pip install pandas'."
+            ) from err
+
+        columns = [
+            "deviceQrn",
+            "shots",
+            "minutes",
+            "cost_exact",
+            "cost_runtime",
+            "cost_total",
+            "quality",
+            "basis",
+        ]
+        basis_order = ["computed", "historical-regression", "assumed-default", "unavailable"]
+        rows = []
+        for point in self.frontier:
+            quantities = [
+                point.shots,
+                point.minutes,
+                point.cost.exact,
+                point.cost.runtimeDependent,
+                point.cost.total,
+                point.quality,
+            ]
+            basis = max((quantity.basis for quantity in quantities), key=basis_order.index)
+            rows.append([point.deviceQrn, *(quantity.value for quantity in quantities), basis])
+        return pd.DataFrame(rows, columns=columns)

--- a/qbraid/runtime/native/provider.py
+++ b/qbraid/runtime/native/provider.py
@@ -23,13 +23,14 @@ import json
 from typing import TYPE_CHECKING, Any, Callable
 
 import pyqasm
-from qbraid_core.exceptions import AuthError
+from qbraid_core.exceptions import AuthError, RequestsApiError
 from qbraid_core.services.runtime import QuantumRuntimeClient, QuantumRuntimeServiceRequestError
 from qbraid_core.services.runtime.schemas import Program, RuntimeDevice
+from qbraid_core.services.runtime.schemas.estimate import Estimate, EstimateRequest, EstimateTarget
 
 from qbraid._caching import cached_method
 from qbraid._logging import logger
-from qbraid.programs import QPROGRAM_REGISTRY, ProgramSpec, load_program
+from qbraid.programs import QPROGRAM_REGISTRY, ProgramSpec, get_program_type_alias, load_program
 from qbraid.programs.typer import Qasm2StringType, Qasm3StringType
 from qbraid.runtime.exceptions import ResourceNotFoundError
 from qbraid.runtime.ionq.provider import IonQProvider
@@ -39,10 +40,13 @@ from qbraid.runtime.provider import QuantumProvider
 from qbraid.transpiler import transpile
 
 from .device import QbraidDevice
+from .estimate import QbraidEstimate
 
 if TYPE_CHECKING:
     import pulser
     import pyqir
+
+    import qbraid.programs
 
 
 def _serialize_program(program) -> Program:
@@ -257,6 +261,64 @@ class QbraidProvider(QuantumProvider):
         profile = self._build_runtime_profile(device_model)
         return QbraidDevice(profile, client=self.client)
 
+    def estimate(  # pylint: disable=too-many-arguments
+        self,
+        program: qbraid.programs.QPROGRAM,
+        targets: list[str] | None = None,
+        shots: int | None = None,
+        target: EstimateTarget | dict[str, Any] | None = None,
+        narrate: bool = True,
+        wait: bool = True,
+    ) -> QbraidEstimate:
+        """Estimate resources and cost across devices without submitting a quantum job.
+
+        Args:
+            program: A single supported quantum program. OpenQASM 2/3 strings pass
+                through unchanged; other programs are transpiled to OpenQASM 3.
+            targets: Device QRNs, or ``None`` for all public direct-access devices.
+            shots: Shot count, or ``None`` to leave it to the estimator.
+            target: Observable kind and tolerance, as an EstimateTarget or dictionary.
+            narrate: Whether to request a narrative explanation. Defaults to True.
+            wait: Whether to wait for completion. Defaults to True.
+
+        Returns:
+            The estimate, completed if ``wait`` is True.
+
+        Raises:
+            ValueError: If a batch is supplied or the request is invalid.
+            TimeoutError: If waiting exceeds 300 seconds.
+            QbraidRuntimeError: If estimation fails while waiting.
+        """
+        if isinstance(program, list):
+            raise ValueError("Estimation requires a single program, not a batch.")
+        alias = get_program_type_alias(program)
+        if alias in {"qasm2", "qasm3"}:
+            # The device serializer reformats QASM; preserve source supplied directly.
+            serialized = Program(format="qasm2" if alias == "qasm2" else "qasm3", data=program)
+        else:
+            program = transpile(program, "qasm3")
+            spec = ProgramSpec(
+                QPROGRAM_REGISTRY["qasm3"], alias="qasm3", serialize=_serialize_program
+            )
+            serialized = spec.serialize(program)
+        if isinstance(target, dict):
+            target = EstimateTarget.model_validate(target)
+        request = EstimateRequest(
+            program=serialized,
+            targets=targets,
+            shots=shots,
+            target=target,
+            narrate=narrate,
+        )
+        client = self.client
+        try:
+            response = client.session.post("/estimates", json=request.model_dump(mode="json"))
+            model = Estimate.model_validate(response.json()["data"])
+        except RequestsApiError as err:
+            raise QuantumRuntimeServiceRequestError(f"Failed to create estimate: {err}") from err
+        result = QbraidEstimate(model, client)
+        return result.wait() if wait else result
+
     def __hash__(self):
         if not hasattr(self, "_hash"):
             user_metadata = self.client._user_metadata
@@ -266,3 +328,29 @@ class QbraidProvider(QuantumProvider):
             )
             object.__setattr__(self, "_hash", hash_value)
         return self._hash  # pylint: disable=no-member
+
+
+def estimate(  # pylint: disable=too-many-arguments
+    program: qbraid.programs.QPROGRAM,
+    targets: list[str] | None = None,
+    shots: int | None = None,
+    target: EstimateTarget | dict[str, Any] | None = None,
+    narrate: bool = True,
+    wait: bool = True,
+) -> QbraidEstimate:
+    """Estimate resources using the default :class:`QbraidProvider` credentials.
+
+    Args:
+        program: A single supported program; non-QASM inputs transpile to OpenQASM 3.
+        targets: Device QRNs, or None for all public direct-access devices.
+        shots: Optional shot count.
+        target: Optional EstimateTarget or dictionary of observable kind and tolerance.
+        narrate: Whether to request a narrative explanation.
+        wait: Whether to wait for completion (up to 300 seconds).
+
+    Returns:
+        A :class:`QbraidEstimate`. See :meth:`QbraidProvider.estimate` for details.
+    """
+    return QbraidProvider().estimate(
+        program, targets=targets, shots=shots, target=target, narrate=narrate, wait=wait
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 rustworkx>=0.15.0
 numpy>=1.17
 openqasm3[parser]>=0.4.0
-qbraid-core>=0.3.9,<1.0
+qbraid-core>=0.6.1,<1.0
 pydantic>2.0.0
 pydantic-core
 typing-extensions>=4.0.0

--- a/tests/runtime/test_estimate.py
+++ b/tests/runtime/test_estimate.py
@@ -1,0 +1,293 @@
+# Copyright 2025 qBraid
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Resource estimator client tests using the public core schemas and a patched session."""
+
+import sys
+from unittest.mock import Mock, call, patch
+
+import pyqasm
+import pytest
+from qbraid_core.exceptions import RequestsApiError
+from qbraid_core.services.runtime import QuantumRuntimeClient, QuantumRuntimeServiceRequestError
+from qbraid_core.services.runtime.schemas.estimate import Estimate, EstimateTarget
+
+from qbraid.runtime import QbraidEstimate, QbraidProvider, estimate
+from qbraid.runtime.exceptions import QbraidRuntimeError
+
+QASM3 = 'OPENQASM 3.0;\ninclude "stdgates.inc";\nqubit[2] q;\nh q[0];\ncx q[0], q[1];\n'
+QASM2 = 'OPENQASM 2.0;\ninclude "qelib1.inc";\nqreg q[2];\nh q[0];\ncx q[0], q[1];\n'
+DEVICE = "qbraid:qbraid:sim:qir-sv"
+COLUMNS = [
+    "deviceQrn",
+    "shots",
+    "minutes",
+    "cost_exact",
+    "cost_runtime",
+    "cost_total",
+    "quality",
+    "basis",
+]
+
+
+@pytest.fixture
+def estimate_data():
+    """A completed estimate matching the shared v1 public contract."""
+    return {
+        "id": "estimate-123",
+        "status": "COMPLETED",
+        "createdAt": "2026-09-02T12:00:00Z",
+        "features": {"numQubits": 2, "gateCount": 2, "twoQubitGateCount": 1, "depth": 2},
+        "frontier": [
+            {
+                "deviceQrn": DEVICE,
+                "shots": {"value": 100, "basis": "computed"},
+                "minutes": {"value": 2, "interval": [1, 3], "basis": "historical-regression"},
+                "cost": {
+                    "exact": {"value": 1, "basis": "computed"},
+                    "runtimeDependent": {"value": 2, "basis": "historical-regression"},
+                    "total": {"value": 3, "basis": "historical-regression"},
+                },
+                "quality": {"value": 1, "basis": "computed"},
+            }
+        ],
+        "infeasible": [{"deviceQrn": "qbraid:ionq:qpu:aria-1", "reason": "device max shots"}],
+        "openQuestions": ["What observable are you measuring?"],
+        "narrative": "Provide a target observable to refine this estimate.",
+    }
+
+
+@pytest.fixture
+def estimate_client(estimate_data):
+    """Patch only the HTTP session, retaining core response validation in the SDK."""
+    client = Mock(spec=QuantumRuntimeClient)
+    client.session.post.return_value.json.return_value = {
+        "data": {**estimate_data, "status": "PENDING"}
+    }
+    client.session.get.return_value.json.return_value = {"data": estimate_data}
+    return client
+
+
+@pytest.mark.parametrize("program,alias", [(QASM2, "qasm2"), (QASM3, "qasm3")])
+def test_estimate_qasm_body(estimate_client, program, alias):
+    """QASM passes through unchanged; absent request fields stay null and wait stays local."""
+    program = "// Preserve comments and whitespace.\n  " + program.replace(";\n", ";  \n")
+    with patch("qbraid.runtime.native.provider.transpile") as convert:
+        result = QbraidProvider(client=estimate_client).estimate(program, wait=False)
+    convert.assert_not_called()
+    estimate_client.session.post.assert_called_once_with(
+        "/estimates",
+        json={
+            "program": {"format": alias, "data": program},
+            "targets": None,
+            "shots": None,
+            "target": None,
+            "narrate": True,
+        },
+    )
+    assert isinstance(result, QbraidEstimate)
+    assert result.id == "estimate-123"
+    assert result.status == "PENDING"
+    estimate_client.session.get.assert_not_called()
+
+
+@pytest.mark.parametrize("kind", ["qiskit", "cirq", "braket"])
+def test_estimate_transpiles_to_qasm3(estimate_client, kind):
+    """Real supported circuits take the SDK conversion graph to serialized OpenQASM 3."""
+    module = pytest.importorskip("braket.circuits" if kind == "braket" else kind)
+    if kind == "qiskit":
+        circuit = module.QuantumCircuit(2)
+        circuit.h(0)
+        circuit.cx(0, 1)
+    elif kind == "cirq":
+        qubits = module.LineQubit.range(2)
+        circuit = module.Circuit(module.H(qubits[0]), module.CNOT(*qubits))
+    else:
+        circuit = module.Circuit().h(0).cnot(0, 1)
+    QbraidProvider(client=estimate_client).estimate(circuit, shots=100, wait=False)
+    body = estimate_client.session.post.call_args.kwargs["json"]
+    assert body == {
+        "program": {"format": "qasm3", "data": body["program"]["data"]},
+        "targets": None,
+        "shots": 100,
+        "target": None,
+        "narrate": True,
+    }
+    assert body["program"]["data"].startswith("OPENQASM 3.0;")
+    parsed = pyqasm.loads(body["program"]["data"])
+    parsed.unroll()
+    assert parsed.num_qubits == 2
+    assert parsed.depth() == 2
+
+
+@pytest.mark.parametrize("as_dict", [True, False])
+def test_estimate_options_and_default_wait(estimate_client, as_dict):
+    """All estimation options reach the API and the default call waits for completion."""
+    target = {"observableKind": "expectation", "tolerance": 0.1}
+    result = QbraidProvider(client=estimate_client).estimate(
+        QASM3,
+        targets=[DEVICE],
+        shots=100,
+        target=target if as_dict else EstimateTarget.model_validate(target),
+        narrate=False,
+    )
+    estimate_client.session.post.assert_called_once_with(
+        "/estimates",
+        json={
+            "program": {"format": "qasm3", "data": QASM3},
+            "targets": [DEVICE],
+            "shots": 100,
+            "target": target,
+            "narrate": False,
+        },
+    )
+    estimate_client.session.get.assert_called_once_with("/estimates/estimate-123")
+    assert result.status == "COMPLETED"
+
+
+def test_estimate_wait_polling(estimate_client, estimate_data):
+    """Pending and running responses are polled on the same authenticated session."""
+    estimate_client.session.get.side_effect = [
+        Mock(json=Mock(return_value={"data": {**estimate_data, "status": status}}))
+        for status in ["PENDING", "RUNNING", "COMPLETED"]
+    ]
+    result = QbraidProvider(client=estimate_client).estimate(QASM3, wait=False)
+    with patch("qbraid.runtime.native.estimate.sleep") as sleep:
+        assert result.wait(poll=0.25) is result
+    assert sleep.call_args_list == [call(0.25), call(0.25)]
+    assert estimate_client.session.get.call_count == 3
+    assert result.wait() is result
+    assert estimate_client.session.get.call_count == 3
+
+
+@pytest.mark.parametrize("initial_failure", [True, False])
+def test_estimate_failed(estimate_client, estimate_data, initial_failure):
+    """An API failure includes its reason whether returned by POST or during polling."""
+    failed = {**estimate_data, "status": "FAILED", "error": "estimator did not return in time"}
+    if initial_failure:
+        estimate_client.session.post.return_value.json.return_value = {"data": failed}
+    else:
+        estimate_client.session.get.return_value.json.return_value = {"data": failed}
+    with pytest.raises(QbraidRuntimeError, match="estimator did not return in time"):
+        QbraidProvider(client=estimate_client).estimate(QASM3)
+
+
+def test_estimate_timeout(estimate_client, estimate_data):
+    """An unfinished estimate raises TimeoutError rather than polling indefinitely."""
+    estimate_client.session.get.return_value.json.return_value = {
+        "data": {**estimate_data, "status": "RUNNING"}
+    }
+    result = QbraidProvider(client=estimate_client).estimate(QASM3, wait=False)
+    with patch("qbraid.runtime.native.estimate.sleep") as sleep:
+        with pytest.raises(TimeoutError, match="estimate-123"):
+            result.wait(timeout=0)
+    sleep.assert_not_called()
+
+
+def test_estimate_refresh_and_properties(estimate_client, estimate_data):
+    """Refreshing replaces the entire snapshot, including open questions and narrative."""
+    result = QbraidProvider(client=estimate_client).estimate(QASM3, wait=False)
+    estimate_data["openQuestions"] = ["How many shots?"]
+    assert result.refresh() is result
+    assert result.open_questions == ["How many shots?"]
+    assert result.narrative == estimate_data["narrative"]
+    assert result.features.numQubits == 2
+    assert result.infeasible[0].reason == "device max shots"
+    assert result.frontier[0].minutes.interval == (1, 3)
+
+
+def test_estimate_dataframe(estimate_client, estimate_data):
+    """Each frontier point becomes a row; unknown values remain missing, not zero."""
+    pd = pytest.importorskip("pandas")
+    point = estimate_data["frontier"][0]
+    estimate_data["frontier"].append(
+        {
+            **point,
+            "deviceQrn": "qbraid:ionq:qpu:forte-1",
+            "quality": {"value": None, "basis": "unavailable"},
+        }
+    )
+    result = QbraidEstimate(Estimate.model_validate(estimate_data), estimate_client)
+    frame = result.to_dataframe()
+    assert list(frame.columns) == COLUMNS
+    assert len(frame) == 2
+    assert frame.iloc[0].tolist() == [DEVICE, 100, 2, 1, 2, 3, 1, "historical-regression"]
+    assert pd.isna(frame.iloc[1]["quality"])
+    assert frame.iloc[1]["basis"] == "unavailable"
+
+
+@pytest.mark.parametrize(
+    "basis", ["computed", "historical-regression", "assumed-default", "unavailable"]
+)
+def test_estimate_dataframe_weakest_basis(estimate_client, estimate_data, basis):
+    """The row basis accounts for every quantity, including a weaker quality basis."""
+    pytest.importorskip("pandas")
+    model = Estimate.model_validate(estimate_data)
+    point = model.frontier[0]
+    point.minutes.basis = "computed"
+    point.cost.runtimeDependent.basis = "computed"
+    point.cost.total.basis = "computed"
+    point.quality.basis = basis
+    assert QbraidEstimate(model, estimate_client).to_dataframe().iloc[0]["basis"] == basis
+
+
+def test_estimate_empty_dataframe(estimate_client, estimate_data):
+    """An empty frontier retains the documented DataFrame columns."""
+    pytest.importorskip("pandas")
+    estimate_data["frontier"] = []
+    frame = QbraidEstimate(Estimate.model_validate(estimate_data), estimate_client).to_dataframe()
+    assert frame.empty
+    assert list(frame.columns) == COLUMNS
+
+
+def test_estimate_without_pandas(estimate_client):
+    """Pandas is needed only for to_dataframe, with an actionable installation hint."""
+    with patch.dict(sys.modules, {"pandas": None}):
+        result = QbraidProvider(client=estimate_client).estimate(QASM3)
+        with pytest.raises(ImportError, match="pip install pandas"):
+            result.to_dataframe()
+
+
+def test_estimate_convenience():
+    """The public convenience function constructs a default provider and forwards options."""
+    with patch("qbraid.runtime.native.provider.QbraidProvider") as provider:
+        result = estimate(QASM3, targets=[DEVICE], shots=100, narrate=False, wait=False)
+    provider.assert_called_once_with()
+    provider.return_value.estimate.assert_called_once_with(
+        QASM3, targets=[DEVICE], shots=100, target=None, narrate=False, wait=False
+    )
+    assert result is provider.return_value.estimate.return_value
+
+
+@pytest.mark.parametrize("options", [{"shots": 0}, {"target": {"tolerance": 1}}])
+def test_estimate_invalid_request(estimate_client, options):
+    """Core validation rejects invalid options before sending a request."""
+    with pytest.raises(ValueError):
+        QbraidProvider(client=estimate_client).estimate(QASM3, **options)
+    estimate_client.session.post.assert_not_called()
+
+
+def test_estimate_rejects_batch(estimate_client):
+    """Estimation never silently submits the first item of a batch."""
+    with pytest.raises(ValueError, match="single program"):
+        QbraidProvider(client=estimate_client).estimate([QASM3])
+    estimate_client.session.post.assert_not_called()
+
+
+@pytest.mark.parametrize("method", ["post", "get"])
+def test_estimate_request_error(estimate_client, method):
+    """HTTP failures use the same runtime-service exception as native job requests."""
+    getattr(estimate_client.session, method).side_effect = RequestsApiError("unavailable")
+    with pytest.raises(QuantumRuntimeServiceRequestError, match="unavailable"):
+        QbraidProvider(client=estimate_client).estimate(QASM3)


### PR DESCRIPTION
## Parent
qBraid/qbraid-simulators#240 — resource/cost estimator v1 (slice 8). Depends on qBraid/qbraid-core#316 (0.6.1) being released — `requirements.txt` pin bumped to `qbraid-core>=0.6.1,<1.0`.

## What
```python
est = qbraid.runtime.estimate(program, targets=None, shots=None, target=None, narrate=True, wait=True)
est.frontier / est.infeasible / est.open_questions / est.narrative / est.features
est.to_dataframe()   # one row per frontier point; cost split exact / runtime / total; weakest `basis` column
est.refresh(); est.wait(timeout=300, poll=2.0)   # raises on FAILED
```
Also `QbraidProvider.estimate(...)` and `QbraidEstimate`. Program conversion reuses the `device.run` path (QASM strings pass through verbatim; other programs transpile to qasm3). pandas imported lazily.

## Verification
`pytest tests -q` 2,245 passed / 654 skipped · pylint, isort, black, ruff, headers pass · mypy: 869 pre-existing baseline errors, zero added.