### PR TITLE
test(runtime): deep-copy the shared device data fixtures

### DIFF
--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -19,6 +19,7 @@ Fixtures imported/defined in this file can be used by any test in this directory
 without needing to import them (pytest will automatically discover them).
 
 """
+import copy
 import random
 import textwrap
 from typing import Optional
@@ -152,13 +153,13 @@ def circuit_meas(request, run_inputs_meas):
 @pytest.fixture
 def device_data_qir():
     """Return a dictionary of device data for the qBraid QIR simulator."""
-    return DEVICE_DATA_QIR
+    return copy.deepcopy(DEVICE_DATA_QIR)
 
 
 @pytest.fixture
 def device_data_aquila():
     """Return a dictionary of device data for the QuEra Aquila QPU."""
-    return DEVICE_DATA_AQUILA
+    return copy.deepcopy(DEVICE_DATA_AQUILA)
 
 
 @pytest.fixture

--- a/tests/runtime/test_device.py
+++ b/tests/runtime/test_device.py
@@ -902,31 +902,38 @@ def test_resolve_noise_model_raises_for_unsupported_model(mock_qbraid_device):
         mock_qbraid_device._resolve_noise_model("depolarizing")
 
 
-def test_provider_get_devices_raises_when_no_direct_access_devices(mock_client):
+def test_device_data_fixture_isolates_shared_resource(device_data_qir):
+    """The fixture hands out a private copy, including nested keys.
+
+    ``MockClient`` reads the module-level resources directly, so a test that writes through a
+    shallow copy poisons every later device built from them in the same session.
+    """
+    assert device_data_qir == DEVICE_DATA_QIR
+    assert device_data_qir["data"] is not DEVICE_DATA_QIR["data"]
+
+    device_data_qir["data"]["directAccess"] = False
+    assert DEVICE_DATA_QIR["data"]["directAccess"] is True
+
+
+def test_provider_get_devices_raises_when_no_direct_access_devices(mock_client, device_data_qir):
     """Test that get_devices raises ResourceNotFoundError when no directAccess devices found."""
     provider = QbraidProvider(client=mock_client)
     # Mock client to return devices without directAccess
-    device_data_no_direct = DEVICE_DATA_QIR.copy()
-    device_data_no_direct["data"]["directAccess"] = False
+    device_data_qir["data"]["directAccess"] = False
     mock_client.list_devices = Mock()
-    mock_client.list_devices.return_value = [
-        RuntimeDevice.model_validate(device_data_no_direct["data"])
-    ]
+    mock_client.list_devices.return_value = [RuntimeDevice.model_validate(device_data_qir["data"])]
 
     with pytest.raises(ResourceNotFoundError, match="No devices found matching given criteria"):
         provider.get_devices()
 
 
-def test_provider_get_device_raises_when_no_direct_access(mock_client):
+def test_provider_get_device_raises_when_no_direct_access(mock_client, device_data_qir):
     """Test that get_device raises ValueError when device doesn't support direct access."""
     provider = QbraidProvider(client=mock_client)
     # Mock client to return device without directAccess
-    device_data_no_direct = DEVICE_DATA_QIR.copy()
-    device_data_no_direct["data"]["directAccess"] = False
+    device_data_qir["data"]["directAccess"] = False
     mock_client.get_device = Mock()
-    mock_client.get_device.return_value = RuntimeDevice.model_validate(
-        device_data_no_direct["data"]
-    )
+    mock_client.get_device.return_value = RuntimeDevice.model_validate(device_data_qir["data"])
 
     with pytest.raises(
         ValueError,


### PR DESCRIPTION
## Summary of changes

Closes #1383.

`tests/runtime/conftest.py` handed out the module-level dicts from `_resources.py` by reference:

```python
@pytest.fixture
def device_data_qir():
    return DEVICE_DATA_QIR      # the live object, not a copy
```

and the two `directAccess` tests in `test_device.py` took a shallow `.copy()`, whose nested `["data"]` is still the same object:

```
shared nested dict: True
module fixture now: False
```

`MockClient.DEVICE_MAP` and `MockClient.list_devices` read those globals directly, so once `directAccess` was written to `False` every later `qbraid:qbraid:sim:qir-sv` device in the session was built without direct access.

Both fixtures now return `copy.deepcopy(...)`, and the two tests take the fixture instead of importing the global — so there is no shared object left for them to reach.

## Why it was hard to see

`test_batch_submit_unsupported_device_raises` *did* raise `ValueError`, just not the one it asserts on:

```
ValueError: qBraid does not currently support direct access to device 'qbraid:qbraid:sim:qir-sv'.
  qbraid/runtime/native/provider.py:253
```

Only its `match="Batch jobs are not supported"` caught the mismatch. A less specific `pytest.raises(ValueError)` anywhere else would have passed against a poisoned fixture, so this adds a guard on the invariant itself rather than relying on the symptom:

```python
def test_device_data_fixture_isolates_shared_resource(device_data_qir):
    assert device_data_qir["data"] is not DEVICE_DATA_QIR["data"]
    device_data_qir["data"]["directAccess"] = False
    assert DEVICE_DATA_QIR["data"]["directAccess"] is True
```

That test fails on the pre-fix conftest (`AssertionError: assert {...} is not {...}`), so it is a real regression test and not decoration.

## The scan the issue asked for

The other two `.copy()` calls on `_resources.py` fixtures are safe — both write only top-level keys, where a shallow copy is sufficient:

- `test_job.py:119` — `JOB_DATA_QIR.copy()`, then writes `["status"]` / `["statusMsg"]`
- `test_quera_aquila_runtime.py:40` — `JOB_DATA_AQUILA.copy()`, returned unmutated

The three `device_data_qir.copy()` call sites in the caching tests (`test_device.py:285/305/326`) only read. Left alone rather than churned.

`device_data_aquila` had the same by-reference hazard as `device_data_qir` with no current victim, so it is deep-copied too.

## Verification

The issue's reproducer, before on `main`:

```
$ pytest tests/runtime/test_device.py \
         tests/runtime/native/test_batch_jobs.py::...::test_batch_submit_unsupported_device_raises
1 failed, 84 passed
```

After:

```
86 passed
```

Full suite offline, `-n auto --dist worksteal`: `1449 passed` here vs `1448 passed` on `main` — the difference is the one added test, no failures either way. (The six `test_loader.py` failures I see locally are stale entry-point metadata in my editable install; they reproduce identically on `main` and pass in CI.)

`tox -e format-check` clean.
