### PR TITLE
ci: declare least-privilege token permissions on every workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -27,6 +27,9 @@ on:
           - patch
         default: 'patch'
 
+permissions:
+  contents: read
+
 jobs:
   bump-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -23,6 +23,9 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,9 @@ on:
     types: [opened, reopened, ready_for_review, synchronize]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -19,6 +19,9 @@ on:
     branches: ['main']
     types: [opened, reopened, ready_for_review, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/pr-compliance.yml
+++ b/.github/workflows/pr-compliance.yml
@@ -19,10 +19,16 @@ on:
     branches: ['main']
     types: [opened, reopened, ready_for_review, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   remind:
     name: Changelog
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write  # the reminder posts a comment on the PR
     if: ${{ github.actor != 'dependabot' && github.actor != 'dependabot[bot]' && github.actor != 'github-actions' && github.actor != 'github-actions[bot]' && github.event.pull_request.draft == false }}
     steps:
     - uses: actions/checkout@v7.0.1

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -17,6 +17,9 @@ name: Pre-release qbraid to PyPi
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   pypi-publish:
     name: Build dist & upload to PyPI

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,9 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   pypi-publish:
     name: Build dist & upload to PyPI

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -18,6 +18,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   update-changelog:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary of changes

Eight workflows had no `permissions:` block, so their `GITHUB_TOKEN` fell back to the repository default instead of to what the workflow actually needs. Each now declares `contents: read` at the top level, with write scopes granted per job only where a job uses them.

Effective permissions after this change:

| workflow | top level | job level |
|---|---|---|
| bump-version | `contents: read` | `contents: write`, `pull-requests: write` |
| update-changelog | `contents: read` | `contents: write`, `pull-requests: write`, `issues: write` |
| pre-release / publish | `contents: read` | `id-token: write`, `contents: read` |
| pr-compliance | `contents: read` | `contents: read`, `pull-requests: write` |
| ci-daily / docs / format | `contents: read` | — |

`bump-version` and `update-changelog` were already scoped at job level; the top-level block only stops the repo default applying to jobs added later. `pre-release` and `publish` keep the `id-token: write` that PyPI trusted publishing needs (#1346).

The one behavioural addition is `pr-compliance`, which had no block at all: its changelog reminder posts a PR comment, so it gets `pull-requests: write` explicitly — the new read-only default would otherwise have taken that away and silently broken the reminder.

## Alerts cleared

14 of the 79 open [code scanning alerts](https://github.com/qBraid/qBraid/security/code-scanning), including every actionable high-severity one:

- 10x Scorecard `TokenPermissionsID` (high)
- 4x CodeQL `actions/missing-workflow-permissions` (medium) — the same finding from the other scanner, on `format`, `docs`, `ci-daily`, `pr-compliance`

The only remaining high-severity alert is Scorecard `CodeReviewID`, which has no file attached — it is a repo-policy metric about the share of commits that went through review, not a code defect.

## Verification

All 12 workflows parse, and I checked the effective permission set of each rather than only the diff:

```
bump-version.yml     top={'contents': 'read'}  jobs={'bump-version': {'contents': 'write', 'pull-requests': 'write'}}
pr-compliance.yml    top={'contents': 'read'}  jobs={'remind': {'contents': 'read', 'pull-requests': 'write'}}
publish.yml          top={'contents': 'read'}  jobs={'pypi-publish': {'id-token': 'write', 'contents': 'read'}}
...
```

The four workflows that already had top-level blocks (`main`, `cross-repo-test`, `gh-pages`, `scorecard`) are untouched.

Worth a reviewer's eye: these grants are read off what each workflow's steps do, so a job that needs a scope I did not spot would fail at runtime rather than at review. `bump-version`, `pre-release` and `publish` are `workflow_dispatch`-only, so they are not exercised by this PR's checks.

## Follow-up

The remaining 61 open alerts are almost all Scorecard `PinnedDependenciesID` — actions referenced by tag rather than commit SHA. Worth doing separately: `.github/dependabot.yml` already tracks `github-actions` weekly, and four actions (`scorecard-action`, `codeql-action`, `upload-artifact`, one `checkout`) are already SHA-pinned, so it is an established pattern here rather than a new policy. Kept out of this PR because 61 mechanical `uses:` rewrites would bury a small security change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflows with explicit, read-only access to repository contents.
  * Preserved the permissions required for automated changelog reminders and updates.
  * Improved consistency and security of automated checks, documentation builds, formatting, publishing, and release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->